### PR TITLE
validate coordinates for single-pixel writes

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -74,6 +74,8 @@ set a color value for a certain pixel
 @param value color value (currently 0-15 for 4bpp BlitBuffers)
 --]]
 function BB_mt.__index:setPixel(x, y, value)
+	-- do nothing if not in our range:
+	if x < 0 or x >= self.w or y < 0 or y >= self.h then return end
 	local pos = y * self.pitch + rshift(x, 1)
 	if x % 2 == 1 then
 		self.data[pos] = bor(band(self.data[pos], 0xF0), value)


### PR DESCRIPTION
in the long run, we need to check our painting directives since this is quite expensive

This fixes the recent segfault which turns out to happen in paintRoundedCorner(), rather than the blitbuffer rotation. We should probably check parameters in that function then, but it is a bit over my head at the moment, so we can use this rather general fix in the meantime.
