### PR TITLE
Add an os.execute-like function for calling execl

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -36,6 +36,17 @@ function util.realpath(path)
 	return path
 end
 
+function util.execute(...)
+	local pid = ffi.C.fork()
+	if pid == 0 then
+		local args = {...}
+		ffi.C.execl(args[1], unpack(args, 1, #args+1))
+	end
+	local status = ffi.new('int[1]')
+	ffi.C.waitpid(pid, status, 0)
+	return status[0]
+end
+
 function util.utf8charcode(charstring)
 	local ptr = ffi.cast("uint8_t *", charstring)
 	local len = #charstring


### PR DESCRIPTION
It is safer than using os.execute when passing filenames as arguments
