### PR TITLE
Better error handling on execl

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -40,7 +40,7 @@ function util.execute(...)
 	local pid = ffi.C.fork()
 	if pid == 0 then
 		local args = {...}
-		ffi.C.execl(args[1], unpack(args, 1, #args+1))
+		os.exit(ffi.C.execl(args[1], unpack(args, 1, #args+1)))
 	end
 	local status = ffi.new('int[1]')
 	ffi.C.waitpid(pid, status, 0)


### PR DESCRIPTION
Sorry, just figured out strange things might happen e.g. if the provided command doesn't exist (util.execute would return and continue executing whatever the child process was doing). So call os.exit to avoid that.
