### PR TITLE
fix FC in Android 2.3 when calling util.realpath

### DIFF
--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -52,6 +52,7 @@ static const int PROT_READ = 1;
 static const int PROT_WRITE = 2;
 static const int MAP_SHARED = 1;
 static const int MAP_FAILED = -1;
+static const int PATH_MAX = 4096;
 void *mmap(void *, long unsigned int, int, int, int, long int) __attribute__((__nothrow__, __leaf__));
 int ioctl(int, long unsigned int, ...) __attribute__((__nothrow__, __leaf__));
 unsigned int sleep(unsigned int);

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -27,13 +27,9 @@ function util.df(path)
 end
 
 function util.realpath(path)
-	local path_ptr = ffi.C.realpath(path, nil)
-	if path_ptr == nil then
-		return nil
-	end
-	path = ffi.string(path_ptr)
-	ffi.C.free(path_ptr)
-	return path
+	local path_ptr = ffi.C.realpath(path, ffi.new("char[?]", ffi.C.PATH_MAX))
+	if path_ptr == nil then return nil end
+	return ffi.string(path_ptr)
 end
 
 function util.execute(...)


### PR DESCRIPTION
the bionic implementation of realpath in Android 2.3 will
directly copy to resolved ptr without checking the nullity
