### PR TITLE
Transform output libs into order-only prerequisites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ $(ZLIB):
 # ===========================================================================
 # console version of StarDict(sdcv)
 
-$(OUTPUT_DIR)/sdcv: $(GLIB) $(ZLIB)
+$(OUTPUT_DIR)/sdcv: | $(GLIB) $(ZLIB)
 ifeq ("$(shell $(CC) -dumpmachine | sed s/-.*//)","x86_64")
 	# quick fix for x86_64 (zeus)
 	cd $(SDCV_DIR) && sed -i 's|guint32 page_size|guint64 page_size|' src/lib/lib.cpp
@@ -344,7 +344,7 @@ $(ZMQ_LIB):
 	-$(MAKE) -j$(PROCESSORS) -C $(ZMQ_DIR)/build install
 	cp -fL $(ZMQ_DIR)/build/lib/$(notdir $(ZMQ_LIB)) $@
 
-$(CZMQ_LIB): $(ZMQ_LIB)
+$(CZMQ_LIB): | $(ZMQ_LIB)
 	mkdir -p $(CZMQ_DIR)/build
 	cd $(CZMQ_DIR) && sh autogen.sh
 	cd $(CZMQ_DIR)/build && \
@@ -366,7 +366,7 @@ $(CZMQ_LIB): $(ZMQ_LIB)
 	-$(MAKE) -j$(PROCESSORS) -C $(CZMQ_DIR)/build install
 	cp -fL $(CZMQ_DIR)/build/lib/$(notdir $(CZMQ_LIB)) $@
 
-$(FILEMQ_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(OPENSSL_LIB)
+$(FILEMQ_LIB): | $(ZMQ_LIB) $(CZMQ_LIB) $(OPENSSL_LIB)
 	mkdir -p $(FILEMQ_DIR)/build
 	cd $(FILEMQ_DIR) && sh autogen.sh
 	cd $(FILEMQ_DIR)/build && \
@@ -386,7 +386,7 @@ $(FILEMQ_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(OPENSSL_LIB)
 	-$(MAKE) -j$(PROCESSORS) -C $(FILEMQ_DIR)/build install
 	cp -fL $(FILEMQ_DIR)/build/lib/$(notdir $(FILEMQ_LIB)) $@
 
-$(ZYRE_LIB): $(ZMQ_LIB) $(CZMQ_LIB)
+$(ZYRE_LIB): | $(ZMQ_LIB) $(CZMQ_LIB)
 	mkdir -p $(ZYRE_DIR)/build
 	cd $(ZYRE_DIR) && sh autogen.sh
 	cd $(ZYRE_DIR)/build && \


### PR DESCRIPTION
When strip is called from the Makefile, it is run over the files in alphabetic order. This is currently causing libzcmq to fail build on Kindle (and probably also Kobo) targets because the build system will try to build it (and thus patch its source code) again after verifying libzmq (on which it depends) has a more recent date.

Nothing would happen if `make -C $(KOR_BASE)` was not done in two different places in koreader's Makefile (luajit and `all` targets), but the build system should anyway be somewhat resilient to be called multiple times.

Perhaps the simpler way to solve this is by using [order-only prerequisites](https://www.gnu.org/software/make/manual/html_node/Prerequisite-Types.html) like in the present patch. 
