### PR TITLE
Fix Android CFLAGS

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -90,7 +90,7 @@ ARMV7_A9_ARCH:=-march=armv7-a -mtune=cortex-a9 -mfpu=neon -mthumb
 # Mirror the NDK's armeabi-v7a APP_ABI (cf. #201)
 ANDROID_ARCH:=--sysroot $(SYSROOT)
 ANDROID_ARCH+=-march=armv7-a -mfpu=vfpv3-d16
-ANDROID_ARCH+=-mthumb -DNDEBUG
+ANDROID_ARCH+=-mthumb
 ANDROID_ARCH+=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
 
 # Use target-specific CFLAGS


### PR DESCRIPTION
Kill the NDEBUG define, which is something we're not doing for other targets anyway.
zmq & co default to building w/ -Wall + -Werror, and, without ifdefing the whole thing around NDEBUG, declare & use some variables strictly in assert() calls, so leaving it defined leads to stupid build failures.
