### PR TITLE
Relax the compat CFLAGS

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -76,16 +76,18 @@ BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 # fixup (echo 2 > /proc/cpu/alignment) in the launch script,
 # but that's terribly ugly, and might severly nerf performance...
 # That said, MG 2012.03 is still using GCC 4.6.3, so we're good ;).
-# FIXME: If we cared, we'd probably need to do something to convince libzmq not to enable support for eventfd [@GLIBC_2.7]
-MG2K12_COMPAT_CFLAGS:=-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE -fno-finite-math-only
-MG2K12_COMPAT_CXXFLAGS:=-fno-use-cxa-atexit
-
-# Same deal, but when targeting the K5/Kobo & using Ubuntu's Linaro TCs
+#
 # For ref:
 ## no-ssp & killing FORTIFY_SOURCE are for the *_chk private GLIBC symbols [@GLIBC_2.11 & @GLIBC_2.15]
 ## no-finite-maths-only is for the *_finite LM symbols (byproduct of using ffast-maths) [@GLIBC_2.15]
 ## GNU_SOURCE is a very heavy-handed way of getting rid of the __isoc99_sscanf stuff [@GLIBC_2.7]
 ## no-use-cxa-atexit is to get rid of cxa_atexit
+#
+# FIXME: If we cared, we'd probably need to do something to convince libzmq not to enable support for eventfd [@GLIBC_2.7]
+MG2K12_COMPAT_CFLAGS:=-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE -fno-finite-math-only
+MG2K12_COMPAT_CXXFLAGS:=-fno-use-cxa-atexit
+
+# Same deal, but when targeting the K5/Kobo & using Ubuntu's Linaro TCs
 UBUNTU_COMPAT_CFLAGS:=-fno-finite-math-only -fno-stack-protector -U_FORTIFY_SOURCE
 
 # ARM 1136JF-S (Legacy Kidle devices [K2/K3/DX/DXG])


### PR DESCRIPTION
Checked with the Linaro TC from Ubuntu.

We only need to take care of the finite maths stuff, and one SSP related _chk thingy.
We're okay on the CXX front, and we don't need the ugly GNU_SOURCE workaround, since we're targeting something far newer than glibc 2.7.

In doubt, I applied those on Kobo devices too, but if they're running on >= glibc 2.15, that's not needed.
