### PR TITLE
fix no "-shared" flag when building libcrypto.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ $(LUASOCKET):
 $(OPENSSL_LIB):
 	cd $(OPENSSL_DIR) && \
 		$(if $(EMULATE_READER),./config,./Configure linux-generic32) \
-		shared no-asm && $(MAKE) -j$(PROCESSORS) CC="$(CC) $(CFLAGS)" \
+		shared no-asm && $(MAKE) -j$(PROCESSORS) CC="$(CC) -shared $(CFLAGS)" \
 		LD=$(LD) RANLIB=$(RANLIB) LIBVERSION="" \
 		build_crypto build_ssl
 


### PR DESCRIPTION
which may cause building errors like:

```
ld: error in libcrypto.a(cryptlib.o)(.eh_frame); no .eh_frame_hdr table
will be created
```
