### PR TITLE
add _DEFAULT_SOURCE define for czmq for newer glibc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,9 +429,12 @@ $(CZMQ_LIB): $(ZMQ_LIB)
 		sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
 	# patch: ignore limited broadcast address
 	-cd $(CZMQ_DIR) && patch -N -p1 < ../zbeacon.patch
+	# patch: add _DEFAULT_SOURCE define for glibc starting at version 2.20
+	-cd $(CZMQ_DIR) && patch -N -p1 < ../czmq_default_source_define.patch
 	-$(MAKE) -j$(PROCESSORS) -C $(CZMQ_DIR)/build --silent uninstall
 	$(MAKE) -j$(PROCESSORS) -C $(CZMQ_DIR)/build --silent install
 	-cd $(CZMQ_DIR) && patch -R -p1 < ../zbeacon.patch
+	-cd $(CZMQ_DIR) && patch -R -p1 < ../czmq_default_source_define.patch
 	cp -fL $(CZMQ_DIR)/build/$(if $(WIN32),bin,lib)/$(notdir $(CZMQ_LIB)) $@
 
 $(FILEMQ_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(OPENSSL_LIB)

--- a/czmq_default_source_define.patch
+++ b/czmq_default_source_define.patch
@@ -1,0 +1,14 @@
+diff --git a/include/czmq_prelude.h b/include/czmq_prelude.h
+index c77e922..890f743 100644
+--- a/include/czmq_prelude.h
++++ b/include/czmq_prelude.h
+@@ -155,6 +155,9 @@
+ #   ifndef _BSD_SOURCE
+ #   define _BSD_SOURCE                  //  Include stuff from 4.3 BSD Unix
+ #   endif
++#   ifndef _DEFAULT_SOURCE
++#   define _DEFAULT_SOURCE
++#   endif
+ #elif (defined (Mips))
+ #   define __UTYPE_MIPS
+ #   define __UNIX__


### PR DESCRIPTION
This is needed for newer glibc, otherwise a #warning will be issued - and czmq compiles with -Werror, so the compile would break there. _DEFAULT_SOURCE is new for _BSD_SOURCE.
