### PR TITLE
link pthread to wrap-mupdf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,8 +251,10 @@ $(OUTPUT_DIR)/libs/libkoreader-cre.so: cre.cpp \
 
 $(OUTPUT_DIR)/libs/libwrap-mupdf.so: wrap-mupdf.c \
 			$(MUPDF_LIB)
+	# Bionic's C library comes with its own pthread implementation
+	# So we need not to load pthread library for Android build
 	$(CC) -I$(MUPDF_DIR)/include $(DYNLIB_CFLAGS) \
-		-o $@ $^
+		-o $@ $^ $(if $(ANDROID),,-lpthread)
 
 # ===========================================================================
 # the attachment extraction tool:


### PR DESCRIPTION
so that luajit can resolve pthread symbols in the namespace of mupdf.
