### PR TITLE
Fixes the bug that once true, self.sleepLight remains true

### DIFF
--- a/ffi/kobolight.lua
+++ b/ffi/kobolight.lua
@@ -34,6 +34,8 @@ function kobolight_mt.__index:sleep()
 	if self.isOn then
 		self.sleepLight = true
 		self:toggle()
+	else
+		self.sleepLight = false
 	end
 end
 


### PR DESCRIPTION
The issue occurred by suspending with the light on at least once.
From that moment, every consecutive resume would toggle the light
back on.
