### PR TITLE
Apply only changed properties instead of reapplying them all.

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -363,7 +363,7 @@ static int setIntProperty(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *propName = luaL_checkstring(L, 2);
     int value = luaL_checkint(L, 3);
-    CRPropRef props = doc->text_view->propsGetCurrent();
+    CRPropRef props = LVCreatePropsContainer();
     props->setInt(propName, value);
     doc->text_view->propsApply(props);
     return 0;
@@ -373,7 +373,7 @@ static int setStringProperty(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *propName = luaL_checkstring(L, 2);
     const char *value = luaL_checkstring(L, 3);
-    CRPropRef props = doc->text_view->propsGetCurrent();
+    CRPropRef props = LVCreatePropsContainer();
     props->setString(propName, value);
     doc->text_view->propsApply(props);
     return 0;


### PR DESCRIPTION
Each call to `cre.setIntProperty()` and `cre.setStringProperty()` currently leads to reapplying  all properties, even those unchanged. Judging from the code in https://github.com/koreader/crengine/blob/b994e572f07f7aa8e1c42bf1230e723041368324/crengine/src/lvdocview.cpp#L5670, this is not really necessary and we can apply only changed properties. This could save as a few CPU cycles and potentionally prevent issues like koreader/koreader#569 or koreader/koreader#1177.
