### PR TITLE
do not handle Android app events/commands in timing critical section

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -117,20 +117,7 @@ function input.waitForEvent(usecs)
                 if source[0].id == ffi.C.LOOPER_ID_MAIN then
                     local cmd = ffi.C.android_app_read_cmd(android.app)
                     ffi.C.android_app_pre_exec_cmd(android.app, cmd)
-                    android.LOGI("got command: " .. tonumber(cmd))
                     commandHandler(cmd, 1)
-                    if cmd == ffi.C.APP_CMD_INIT_WINDOW then
-                        if self.device and self.device.screen then
-                            self.device.screen:refreshFull()
-                        end
-                    elseif cmd == ffi.C.APP_CMD_TERM_WINDOW then
-                        -- do nothing for now
-                    elseif cmd == ffi.C.APP_CMD_LOST_FOCUS then
-                        -- do we need this here?
-                        if self.device and self.device.screen then
-                            self.device.screen:refreshFull()
-                        end
-                    end
                     ffi.C.android_app_post_exec_cmd(android.app, cmd)
                 elseif source[0].id == ffi.C.LOOPER_ID_INPUT then
                     local event = ffi.new("AInputEvent*[1]")


### PR DESCRIPTION
we handled some events directly in the looper parsing section. This
led to funky behaviour: code was only executed in some parts (weird,
very, very weird behaviour). But we don't need to handle those events
there, since we pass the event on anyway. So it is some other part of
the application that is now in charge to handle the events.

The timing critical part (or what seems to be it, as the NDK documentation
does not say any special things about this code area) now only enqueues
the event for later processing.

Part of the fix for the not-updating screen on application startup.
