### PR TITLE
replace viewport check by clamping

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1116,6 +1116,8 @@ Note that the caller has to make sure that the underlying memory
 words, a viewport does not create a new buffer with memory.
 --]]
 function BB_mt.__index:viewport(x, y, w, h)
+    w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
+    h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
     x, y, w, h = self:getPhysicalRect(x, y, w, h)
     local viewport = BB.new(w, h, self:getType(), self:getPixelP(x, y), self.pitch)
     viewport:setRotation(self:getRotation())

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -119,13 +119,6 @@ end
 set a rectangle that represents the area of the screen we are working on
 --]]
 function fb:setViewport(viewport)
-    if viewport.x < 0 or viewport.x >= self.screen_size.w
-    or viewport.y < 0 or viewport.y >= self.screen_size.h
-    or viewport.w < 0 or viewport.x+viewport.w >= self.screen_size.w
-    or viewport.h < 0 or viewport.y+viewport.h >= self.screen_size.h
-    then
-        error("bad viewport")
-    end
     self.bb = self.bb:viewport(
         self.viewport.x, self.viewport.y,
         self.viewport.w, self.viewport.h)


### PR DESCRIPTION
The viewport dimension check was buggy (wrong upper limits).
We don't need it there anyway, rather, we clamp the coordinates
in the viewport() implementation in the Blitbuffer API.
