### PR TITLE
fix no openssl libversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,7 +380,7 @@ $(OPENSSL_LIB):
 		$(if $(WIN32),mingw,linux-generic32)) \
 		$(if $(WIN32),no-,)shared no-asm no-idea no-mdc2 no-rc5 \
 		&& $(MAKE) CC="$(CC) $(CFLAGS)" \
-		LD=$(LD) RANLIB=$(RANLIB) LIBVERSION="" \
+		LD=$(LD) RANLIB=$(RANLIB) \
 		--silent build_crypto build_ssl
 ifdef ANDROID
 	cp -fL $(OPENSSL_DIR)/$(notdir $(SSL_LIB)) $(SSL_LIB)


### PR DESCRIPTION
We need to install openssl libraries because the blank LIBVERSION
variable is not reliable to get rid of the major and minor versions
in the soname of libssl and libcrypto. To make this consistent on all
platforms it's choosen to add the version info in the soname. It should
work on Android (libraries installed in the apk) and Kindle
(libssl.so.1.0.0 is in /usr/lib). If it fails on Kobo (as it always
would be) we probably need to ship with openssl libraries for all platform.
