### PR TITLE
Statically link libstdc++ for all shared libraries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ env:
     - EMULATE_READER=1 USE_NO_CCACHE=1
 
 before_install:
-    - sudo apt-get update
+    - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq g++-4.8
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.8 50
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 50
 
 install:
     # nasm for building libpng, xutils-dev for building openssl with clang

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -82,6 +82,9 @@ HOSTAR:=ar
 HOSTLD:=ld
 HOSTRANLIB:=ranlib
 
+# static libstdc++
+STATIC_LIBSTDCPP=$(shell $(CC) -print-file-name=libstdc++.a)
+
 # try to find number of CPUs for build machine
 PROCESSORS:=$(shell grep processor /proc/cpuinfo|wc -l)
 # incase we build on system that has no /proc/cpuinfo file
@@ -187,7 +190,7 @@ HOSTCFLAGS:=$(HOST_ARCH) $(BASE_CFLAGS) $(QFLAGS)
 
 CFLAGS:=$(BASE_CFLAGS) $(QFLAGS)
 CXXFLAGS:=$(BASE_CFLAGS) $(QFLAGS)
-LDFLAGS:=-Wl,-O1 -Wl,--as-needed
+LDFLAGS:=-Wl,-O1 -Wl,--as-needed -static-libstdc++
 
 # NOTE: Follow the NDK's lead
 ifeq ($(TARGET), android)
@@ -195,7 +198,7 @@ ifeq ($(TARGET), android)
 endif
 
 ifeq ($(TARGET), win32)
-    LDFLAGS+=-Wl,--allow-multiple-definition -static-libstdc++ -static-libgcc
+    LDFLAGS+=-Wl,--allow-multiple-definition -static-libgcc
 endif
 
 # in case the libstdc++ is to be linked statically, the location of the static


### PR DESCRIPTION
Since libtool does not respect LDFLAGS we just hack it to remove the -lstdc++ dependency and feed the linker with the file `$(CC) -print-file-name=libstdc++.a`.