### PR TITLE
fix GLIBC_2.7 symbols in PocketBook build of sdcv cannot run on 4.x firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,14 +227,14 @@ $(LUAJIT_JIT): $(if $(ANDROID),$(LUAJIT_LIB),$(LUAJIT))
 
 # popen-noshell, fetched via SVN
 $(POPEN_NOSHELL_LIB):
-ifdef KINDLE_LEGACY
+ifdef LEGACY
 	# Revert 8d7a98d on legacy devices, pipe2 was introduced in Linux 2.6.27 & glibc 2.9
 	sed -e 's/if (pipe2(pipefd, O_CLOEXEC) != 0) return NULL;/if (pipe(pipefd) != 0) return NULL;/' -i $(POPEN_NOSHELL_DIR)/popen_noshell.c
 endif
 	$(MAKE) -j$(PROCESSORS) -C $(POPEN_NOSHELL_DIR) \
 		CC="$(CC)" AR="$(AR)" \
 		CFLAGS="$(CFLAGS) $(if $(ANDROID),--sysroot=$(SYSROOT),)"
-ifdef KINDLE_LEGACY
+ifdef LEGACY
 	# Re-apply 8d7a98d if need be
 	sed -e 's/if (pipe(pipefd) != 0) return NULL;/if (pipe2(pipefd, O_CLOEXEC) != 0) return NULL;/' -i $(POPEN_NOSHELL_DIR)/popen_noshell.c
 endif
@@ -327,7 +327,10 @@ $(LIBGETTEXT): $(LIBICONV)
 	-cd $(GETTEXT_DIR) && $(MAKE) -j$(PROCESSORS) install
 
 $(GLIB):
+	# in order to support legacy PocketBook 4.x firmware we should get rid of
+	# eventfd@GLIBC_2.7 and pipe2@GLIB_2.9
 	echo -e "glib_cv_stack_grows=no\nglib_cv_uscore=no\n \
+		glib_cv_eventfd=no\n ac_cv_func_pipe2=no\n \
 		ac_cv_func_posix_getpwuid_r=no\nac_cv_func_posix_getgrgid_r=no\n" > \
 		$(GLIB_DIR)/arm_cache.conf
 	cd $(GLIB_DIR) && NOCONFIGURE=1 ./autogen.sh && CC="$(CC) -std=gnu89" ./configure \
@@ -400,9 +403,9 @@ $(OUTPUT_DIR)/tar:
 	-cd $(TAR_DIR) && patch -N -p1 < ../tar-0001-fix-build-failure.patch
 	cd $(TAR_DIR) && ./configure -q LIBS=$(if $(WIN32),,-lrt) \
 		$(if $(EMULATE_READER),,--host=$(CHOST)) \
-		$(if $(KINDLE_LEGACY),--disable-largefile,)
+		$(if $(LEGACY),--disable-largefile,)
 	# Forcibly disable FORTIFY on legacy devices...
-ifdef KINDLE_LEGACY
+ifdef LEGACY
 	sed -e 's/# define _FORTIFY_SOURCE 2/#undef _FORTIFY_SOURCE/' -i $(TAR_DIR)/config.h
 endif
 	cd $(TAR_DIR) && $(MAKE) -j$(PROCESSORS) --silent
@@ -494,8 +497,7 @@ $(ZMQ_LIB):
 		LIBS="$(STATIC_LIBSTDCPP)" \
 		libzmq_have_xmlto=no libzmq_have_asciidoc=no \
 			../configure -q --prefix=$(CURDIR)/$(ZMQ_DIR)/build \
-				$(if $(POCKETBOOK),--disable-eventfd,) \
-				$(if $(KINDLE_LEGACY),--disable-eventfd,) \
+				$(if $(LEGACY),--disable-eventfd,) \
 				--disable-static --enable-shared \
 				--host=$(CHOST)
 	cd $(ZMQ_DIR)/build && sed -i 's|-lstdc++||g' libtool

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -330,7 +330,8 @@ ZLIB_DIR=$(MUPDF_DIR)/thirdparty/zlib
 
 LIBICONV=$(LIBICONV_DIR)/lib/libiconv.a
 LIBGETTEXT=$(GETTEXT_DIR)/lib/libintl.a
-GLIB=$(GLIB_DIR)/lib/libglib-2.0.a
+GLIB=$(GLIB_DIR)/lib/libglib-2.0.so.0
+GLIB_STATIC=$(GLIB_DIR)/lib/libglib-2.0.a
 ZLIB=$(OUTPUT_DIR)/libs/$(if $(WIN32),zlib1.dll,libz.so.1)
 ZLIB_STATIC=$(ZLIB_DIR)/libz.a
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -31,7 +31,7 @@ else ifeq ($(TARGET), kindlepw2)
 	CHOST?=arm-kindlepw2-linux-gnueabi
 else ifeq ($(TARGET), kindle-legacy)
 	CHOST?=arm-kindle-linux-gnueabi
-	export KINDLE_LEGACY=1
+	export LEGACY=1
 else ifeq ($(TARGET), kobo)
 	CHOST?=arm-linux-gnueabihf
 else ifeq ($(TARGET), android)
@@ -44,6 +44,7 @@ else ifeq ($(TARGET), win32)
     export WIN32=1
 else ifeq ($(TARGET), pocketbook)
     CHOST?=arm-obreey-linux-gnueabi
+    export LEGACY=1
     export POCKETBOOK=1
     export PATH:=$(CURDIR)/$(POCKETBOOK_TOOLCHAIN)/bin:$(PATH)
     export SYSROOT=$(CURDIR)/$(POCKETBOOK_TOOLCHAIN)/arm-obreey-linux-gnueabi/sysroot


### PR DESCRIPTION
Now only Android build of sdcv uses static libglib, all other platforms use shared library.