### PR TITLE
Minor buildsystem fixes

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -90,7 +90,10 @@ HOSTAR:=ar
 HOSTLD:=ld
 HOSTRANLIB:=ranlib
 
-# static libstdc++
+# Static libstdc++, because libtool filters flags at link-time, and drops -static-libstdc++ on GNU/Linux...
+# NOTE: We default to libtool's preferred workaround of putting those extra flags we really want to keep in CC/CXX
+# But to add insult to injury, libtool also links with -nostdlib, which renders -static-lib* useless, so we
+# need this ugly workaround, even on recent (>= 4.5) GCC versions where any sane person would imagine -static-libstdc++ to be enough...
 STATIC_LIBSTDCPP=$(shell $(CC) -print-file-name=libstdc++.a)
 
 # try to find number of CPUs for build machine
@@ -130,7 +133,7 @@ BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 MG2K12_COMPAT_CFLAGS:=-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE -fno-finite-math-only
 MG2K12_COMPAT_CXXFLAGS:=-fno-use-cxa-atexit
 # My legacy TC is based on glibc 2.9, that should be enough :).
-NILUJE_COMPAT_CFLAGS:=-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE
+NILUJE_COMPAT_CFLAGS:=-fno-stack-protector -U_FORTIFY_SOURCE -D_GNU_SOURCE -mno-unaligned-access
 
 # Same deal, but when targeting the K5/Kobo & using Ubuntu's Linaro TCs
 UBUNTU_COMPAT_CFLAGS:=-fno-finite-math-only -fno-stack-protector -U_FORTIFY_SOURCE
@@ -247,8 +250,11 @@ ifdef EMULATE_READER
 	CFLAGS+= $(HOST_ARCH)
 	CXXFLAGS+= $(HOST_ARCH)
 else
-	CC:=$(strip $(CCACHE) $(CC))
-	CXX:=$(strip $(CCACHE) $(CXX))
+	# Don't let libtool piss on our parade...
+	# See what was mentioned around STATIC_LIBSTDCPP on ~L#93 for more details
+	# (cf. https://www.gnu.org/software/libtool/manual/html_node/Stripped-link-flags.html#Stripped-link-flags)
+	CC:=$(strip $(CCACHE) $(CC)) -static-libstdc++
+	CXX:=$(strip $(CCACHE) $(CXX)) -static-libstdc++
 	AR:=$(strip $(CCACHE) $(AR))
 	CFLAGS+= $(ARM_ARCH) $(COMPAT_CFLAGS)
 	CXXFLAGS+= $(ARM_ARCH) $(COMPAT_CXXFLAGS)

--- a/third.Makefile
+++ b/third.Makefile
@@ -383,7 +383,9 @@ $(LUACOMPAT52): $(LUASERIAL_LIB) $(THIRDPARTY_DIR)/lua-serialize/CMakeLists.txt
 $(ZMQ_LIB): $(THIRDPARTY_DIR)/libzmq/CMakeLists.txt
 	install -d $(ZMQ_BUILD_DIR)
 	cd $(ZMQ_BUILD_DIR) && \
-		$(CMAKE) -DCC="$(CC)" -DCFLAGS="$(CFLAGS) $(if $(CLANG),-O0,)" \
+		$(CMAKE) -DCC="$(CC)" -DCXX="$(CXX)" \
+		-DCFLAGS="$(CFLAGS) $(if $(CLANG),-O0,)" \
+		-DCXXFLAGS="$(CXXFLAGS) $(if $(CLANG),-O0,)" \
 		-DLDFLAGS="$(LDFLAGS)" -DSTATIC_LIBSTDCPP="$(STATIC_LIBSTDCPP)" \
 		$(if $(LEGACY),-DLEGACY:BOOL=ON,) -DCHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/libzmq && \

--- a/thirdparty/libzmq/CMakeLists.txt
+++ b/thirdparty/libzmq/CMakeLists.txt
@@ -7,13 +7,17 @@ include("koreader_thirdparty_git")
 
 enable_language(C CXX)
 
+assert_var_defined(CC)
+assert_var_defined(CXX)
+assert_var_defined(CFLAGS)
+assert_var_defined(CXXFLAGS)
 assert_var_defined(LDFLAGS)
 assert_var_defined(STATIC_LIBSTDCPP)
 
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
-set(CFG_ENV_VAR "CC=\"${CC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" LIBS=\"${STATIC_LIBSTDCPP}\" libzmq_have_xmlto=no libzmq_have_asciidoc=no")
+set(CFG_ENV_VAR "CC=\"${CC}\" CXX=\"${CXX}\" CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\"  LDFLAGS=\"${LDFLAGS}\" LIBS=\"${STATIC_LIBSTDCPP}\" libzmq_have_xmlto=no libzmq_have_asciidoc=no")
 
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --disable-static --enable-shared --without-documentation --host=\"${CHOST}\"")
 if(${LEGACY})
@@ -39,7 +43,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     PATCH_COMMAND ./autogen.sh COMMAND ${FORCE_DYNAMLIB_VERSION} COMMAND ${SKIP_TEST} COMMAND ${CLEAR_BUILD_DIR}
-    CONFIGURE_COMMAND sh -c ${CFG_CMD_STR} COMMANd sed -i 's|-lstdc++||g' libtool
+    CONFIGURE_COMMAND sh -c ${CFG_CMD_STR} COMMAND sed -i "s|-lstdc++||g" libtool
     BUILD_COMMAND $(MAKE) -j${PARALLEL_JOBS} --silent
     INSTALL_COMMAND $(MAKE) -j${PARALLEL_JOBS} --silent install
 )

--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/LuaJIT/LuaJIT
-    18f6aa97fd93df8e9964c2d22f20f16e6b71b72b
+    v2.1.0-beta2
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -32,7 +32,7 @@ set(MAKE_CMD_STR "${MAKE_CMD_STR} --silent depend build_crypto build_ssl >/dev/n
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/openssl/openssl.git
-    OpenSSL_1_0_1r
+    OpenSSL_1_0_1s
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Fix zmq to link to libstdc++ statically again
* Bump LuaJIT & OpenSSL (1.0.2 is still a no-go w/ Clang. There's a patch available in ChromeOS, but the current trunk is also OK, so, meh, let's wait for that to hit a release).