### PR TITLE
Add util.getsec shortcut to get current time in seconds

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -376,4 +376,10 @@ function util.unichar (value)
     end
 end
 
+-- Returns current time in seconds
+function util.getsec()
+    local now = { util.gettime() }
+    return now[1]
+end
+
 return util


### PR DESCRIPTION
This is part of to add an auto-suspend function for Kobo, which does not have power management function in kernel.
Discussed in #1356 #1565 & #1814.