### PR TITLE
test: disable auto-insulate in busted

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ $(OUTPUT_DIR)/spec/base:
 test: $(OUTPUT_DIR)/spec $(OUTPUT_DIR)/.busted
 	cd $(OUTPUT_DIR) && \
 		./luajit $(shell which busted) \
-		--exclude-tags=notest -o ./spec/base/unit/verbose_print ./spec/base/unit
+		--exclude-tags=notest \
+		--no-auto-insulate \
+		-o ./spec/base/unit/verbose_print ./spec/base/unit
 
 .PHONY: test


### PR DESCRIPTION
This should hopefully fix the random segfault we have with busted+LuaJIT FFI