### PR TITLE
thidparty: add sqlite target

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -480,6 +480,10 @@ LUA_SPORE_VER=lua-spore-$(SPORE_VER)
 LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks
 LUA_SPORE_ROCK=$(LUAROCKS_DIR)/lua-spore/$(SPORE_VER)/$(LUA_SPORE_VER).rockspec
 
+SQLITE_BUILD_DIR=$(THIRDPARTY_DIR)/sqlite/build/$(MACHINE)
+SQLITE_DIR=$(CURDIR)/$(SQLITE_BUILD_DIR)/sqlite-prefix/src/sqlite-build
+SQLITE_LIB=$(SQLITE_DIR)/lib/libsqlite3.a
+
 # CFLAGS for the Lua/C/C++ modules:
 #
 # setting the rpath to '$ORIGIN' will make the dynamic linker search

--- a/Makefile.third
+++ b/Makefile.third
@@ -495,3 +495,11 @@ $(EVERNOTE_LIB): $(THIRDPARTY_DIR)/evernote-sdk-lua/CMakeLists.txt
 $(LUALONGNUMBER): $(EVERNOTE_LIB) $(THIRDPARTY_DIR)/evernote-sdk-lua/CMakeLists.txt
 	cp $(CURDIR)/$(EVERNOTE_PLUGIN_DIR)/lib/liblualongnumber.so \
 		$(CURDIR)/$(OUTPUT_DIR)/libs
+
+$(SQLITE_LIB): $(THIRDPARTY_DIR)/sqlite/CMakeLists.txt
+	install -d $(SQLITE_BUILD_DIR)
+	cd $(SQLITE_BUILD_DIR) && \
+		$(CMAKE) -DCC="$(CC)" \
+			-DCFLAGS="$(CFLAGS)" \
+		$(CURDIR)/thirdparty/sqlite && \
+		$(MAKE)

--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -1,0 +1,28 @@
+PROJECT(sqlite)
+cmake_minimum_required(VERSION 2.8.3)
+
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
+include("koreader_thirdparty_common")
+
+enable_language(C)
+
+assert_var_defined(CC)
+assert_var_defined(CFLAGS)
+
+ep_get_binary_dir(BINARY_DIR)
+
+set(CFG_CMD sh -c "CC=\"${CC}\" CFLAGS=\"${CFLAGS} -fno-fast-math\" ./configure")
+set(CFG_CMD "${CFG_CMD} --enable-static --disable-shared --enable-threadsafe")
+set(CFG_CMD "${CFG_CMD} --disable-dynamic-extensions --prefix=${BINARY_DIR}")
+
+include(ExternalProject)
+set(SQLITE_VER "3120200")
+ExternalProject_Add(
+    ${PROJECT_NAME}
+    DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
+    URL https://www.sqlite.org/2016/sqlite-autoconf-${SQLITE_VER}.tar.gz
+    URL_HASH SHA1=b43c2e7238e54c50b95fbbd85c48792f4f39af8c
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ${CFG_CMD}
+    BUILD_COMMAND $(MAKE) -j${PARALLEL_JOBS}
+)


### PR DESCRIPTION
Right now, it's not added as a dependency for the main target. If we decided to adopt sqlite in the future, we can just add $(SQLITE_LIB) to all.