### PR TITLE
bump libk2pdfopt - fix android build with NDK 11c

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
     # recent versions of busted may cause some weird segmentation faults
     # - git clone https://github.com/Olivine-Labs/busted/
     # - cd busted && git checkout v1.10.0 && luarocks --local make busted-1.10.0-0.rockspec && cd ..
-    - travis_retry luarocks --local install busted 2.0.rc11-0
+    - travis_retry luarocks --local install busted 2.0.rc12-1
     # for verbose_print module
     - travis_retry luarocks --local install ansicolors
     - eval $(luarocks path --bin)

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     git://github.com/koreader/libk2pdfopt.git
-    d9ddb6e7c5a334cb8b68ac95b1707cb7bf2c5b9c
+    e26e2c3e98ad8a956ad0336d7b59bfe9787bec98
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
This change is part of Android NDK 11c build fixup. This issue has been discussed in #2043 of koreader. The change to add a define for android build has been merged into libk2pdfopt, so bump koreader-base to fix this issue.