### PR TITLE
Update tesseract to latest release 255c31 and fix android build issue (librt won't be provided in NDK 11c)

### DIFF
--- a/thirdparty/tesseract/CMakeLists.txt
+++ b/thirdparty/tesseract/CMakeLists.txt
@@ -7,7 +7,11 @@ include("koreader_thirdparty_git")
 
 ep_get_source_dir(SOURCE_DIR)
 
-set(PATCH_CMD sh -c "${ISED} \"s|AM_CONFIG_HEADER|AC_CONFIG_HEADERS|g\" configure.ac")
+if ("$ENV{ANDROID}" STREQUAL "1")
+    set(PATCH_CMD sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tesseract-android.patch")
+else()
+    set(PATCH_CMD echo)
+endif()
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/tesseract/tesseract-android.patch
+++ b/thirdparty/tesseract/tesseract-android.patch
@@ -1,0 +1,12 @@
+diff --git a/configure.ac b/configure.ac
+index dce7f75..2fb083e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -111,7 +111,7 @@ case "${host_os}" in
+         ;;
+     *)
+         # default
+-        AM_CONDITIONAL(ADD_RT, true)
++        AM_CONDITIONAL(ADD_RT, false)
+         ;;
+ esac


### PR DESCRIPTION
This change is part of android NDK 11c toolchain migration, which has been discussed in #2043 of koreader (https://goo.gl/8oSJGy)

1. Update tesseract to latest release build 255c31fe31c418fd93cd2dde5941e0f923ab51ca.
For the sample.pdf in our testdata, both version cannot work very well, i.e. the text selection won't be able to select the correct word.
2. Add a patch to disable librt in tesseract, which won't be provided in NDK 11c.