### PR TITLE
Fix build break of gettext library with android NDK 11c

### DIFF
--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -13,6 +13,9 @@ ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
 set(CFG_ENV_VAR "CC=\"${CC}\"")
+if(${IS_ANDROID})
+    set(CFG_ENV_VAR "${CFG_ENV_VAR} && LDFLAGS=-lc")
+endif()
 set(CFG_OPTS "--with-threads=none --prefix=${BINARY_DIR} --with-libiconv-prefix=${LIBICONV_PREFIX} --enable-shared=false --enable-static=true ${CHOST_OPTS}")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 # remove HAVE_PWD_H for android build

--- a/thirdparty/tesseract/CMakeLists.txt
+++ b/thirdparty/tesseract/CMakeLists.txt
@@ -8,9 +8,9 @@ include("koreader_thirdparty_git")
 ep_get_source_dir(SOURCE_DIR)
 
 if ("$ENV{ANDROID}" STREQUAL "1")
-    set(PATCH_CMD sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tesseract-android.patch")
+    set(PATCH_CMD COMMAND sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/tesseract-android.patch")
 else()
-    set(PATCH_CMD echo)
+    set(PATCH_CMD "")
 endif()
 
 ko_write_gitclone_script(
@@ -24,7 +24,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND COMMAND ${PATCH_CMD}
+    PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ""
     # skip build and install, libk2pdfopt will build it
     BUILD_COMMAND ""


### PR DESCRIPTION
This issue has been discussed at koreader issue 2043 https://github.com/koreader/koreader/issues/2043

This change adds libc in gettext ld flags.