### PR TITLE
fix position independent executables (PIE) error on Android L

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -297,10 +297,15 @@ $(OUTPUT_DIR)/sdcv: $(if $(ANDROID),$(GLIB_STATIC),$(GLIB)) $(ZLIB_STATIC) $(THI
 		-DLIBS="$(if $(ANDROID),$(GLIB_STATIC),) \
 			$(if $(ANDROID),,-lpthread -lrt) \
 			$(ZLIB_STATIC) \
+			$(if $(ANDROID),-static,) \
 			-static-libgcc -static-libstdc++" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/sdcv && \
 		$(MAKE)
 	cp $(SDCV_DIR)/src/sdcv $(OUTPUT_DIR)/
+ifdef ANDROID
+	readelf -d $@ | grep "no dynamic" \
+		|| echo "warning: Android L+ support only PIE binary and can't run this"
+endif
 
 # ===========================================================================
 # tar: tar package for zsync
@@ -308,12 +313,17 @@ $(OUTPUT_DIR)/sdcv: $(if $(ANDROID),$(GLIB_STATIC),$(GLIB)) $(ZLIB_STATIC) $(THI
 $(OUTPUT_DIR)/tar: $(THIRDPARTY_DIR)/tar/CMakeLists.txt
 	install -d $(TAR_BUILD_DIR)
 	cd $(TAR_BUILD_DIR) && \
-		$(CMAKE) -DCC="$(CC)" -DLIBS="$(if $(or $(ANDROID),$(WIN32)),,-lrt)" \
+		$(CMAKE) -DCC="$(CC)" \
+		-DLIBS="$(if $(or $(ANDROID),$(WIN32)),,-lrt) $(if $(ANDROID),-static,)" \
 		$(if $(LEGACY),-DDISABLE_LARGEFILE:BOOL=ON -DDISABLE_FORTIFY:BOOL=ON,) \
 		-DCHOST="$(if $(EMULATE_READER),,$(CHOST))" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/tar && \
 		$(MAKE)
 	cp $(TAR_DIR)/src/tar $(OUTPUT_DIR)/
+ifdef ANDROID
+	readelf -d $@ | grep "no dynamic" \
+		|| echo "warning: Android L+ support only PIE binary and can't run this"
+endif
 
 # ===========================================================================
 # zsync: rsync over HTTP
@@ -322,9 +332,14 @@ $(OUTPUT_DIR)/zsync: $(THIRDPARTY_DIR)/zsync/CMakeLists.txt
 	install -d $(ZSYNC_BUILD_DIR)
 	cd $(ZSYNC_BUILD_DIR) && \
 		$(CMAKE) -DHOST="$(if $(EMULATE_READER),,$(CHOST))" -DCC="$(CC)" \
+		-DLIBS="$(if $(ANDROID),-static,)" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/zsync && \
 		$(MAKE)
 	cp $(ZSYNC_DIR)/zsync $(OUTPUT_DIR)/
+ifdef ANDROID
+	readelf -d $@ | grep "no dynamic" \
+		|| echo "warning: Android L+ support only PIE binary and can't run this"
+endif
 
 # ===========================================================================
 # common lua library for networking

--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -11,7 +11,7 @@ ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
 set(CFG_ENV_VAR "CC=\"${CC} -DHAVE_MKFIFO=1\"")
-set(CFG_OPTS "-q LIBS=${LIBS} --host=\"${CHOST}\"")
+set(CFG_OPTS "-q LIBS=\"${LIBS}\" --host=\"${CHOST}\"")
 
 if(${DISABLE_LARGEFILE})
     set(CFG_OPTS "${CFG_OPTS} --disable-largefile")

--- a/thirdparty/zsync/CMakeLists.txt
+++ b/thirdparty/zsync/CMakeLists.txt
@@ -9,13 +9,14 @@ enable_language(C)
 
 assert_var_defined(CC)
 assert_var_defined(HOST)
+assert_var_defined(LIBS)
 
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
 set(RECONF_CMD sh -c "cd c && autoreconf -fi")
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --host=\"${HOST}\"")
-set(CFG_CMD sh -c "CC=\"${CC}\" CFLAGS=\"$(CFLAGS) -I${SOURCE_DIR}/c\" ${SOURCE_DIR}/c/configure ${CFG_OPTS}")
+set(CFG_CMD sh -c "CC=\"${CC}\" CFLAGS=\"$(CFLAGS) -I${SOURCE_DIR}/c\" LIBS=\"${LIBS}\" ${SOURCE_DIR}/c/configure ${CFG_OPTS}")
 # don't check missing definition of in_port_t in NDK <netinet/in.h>
 set(PATCH_CMD1 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync.patch || true")
 # fix "rename: Invalid cross-device link" error for Android


### PR DESCRIPTION
Running a non-PIE binary on Android L will cause an error:
```
Error: only position independent executables (PIE) are supported
```
But if we link the binary with `-static` option it will have no dynamic section thus being PIE. Tested on MX4 Android 5.1.