### PR TITLE
Clearup the leptonica fmemopen compat symbol mess.

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -317,18 +317,22 @@ endif
 # In the same vein, see base#421 for how to deal with an updated glibc symbol
 # for a function which did NOT change its signature, and where we don't have
 # access to a public definition of the old implementation, only a compat
-# versioned symbol. With the added quirk that in this specific instance
-# (fmemopen), the compat symbol has a different version than the old default
-# symbol, so we can only apply this patch when linking against glibc >= 2.22...
+# versioned symbol.
+# With the added confusing quirk that the compat symbol (here, fmemopen) is
+# pinned to a different GLIBC version on arm than on x86... (cf. #2188).
 ifndef DARWIN
 ifndef ANDROID
 ifndef WIN32
     # We're a glibc system... Find the actual libc used by our TC, and check if it's >= 2.22...
-    GLIBC_FILE=$(basename $(notdir $(realpath $(shell $(CC) -print-file-name=libc.so.6))))
-    GLIBC_VER=$(shell echo $(GLIBC_FILE) | cut -f2 -d'-')
-    GLIBC_2_22_SORT=$(shell echo -e "$(GLIBC_VER)\n2.22" | sort -V | head -n1)
-    ifeq ($(GLIBC_2_22_SORT), 2.22)
-        GLIBC_GTE_2_22=1
+    # We only care about that on non-emulated builds (i.e., arm), because compat symbols may be pinned
+    # to different versions on different arches, and we only account for arm in our patches.
+    ifndef EMULATE_READER
+        GLIBC_FILE=$(basename $(notdir $(realpath $(shell $(CC) -print-file-name=libc.so.6))))
+        GLIBC_VER=$(shell echo $(GLIBC_FILE) | cut -f2 -d'-')
+        GLIBC_2_22_SORT=$(shell echo -e "$(GLIBC_VER)\n2.22" | sort -V | head -n1)
+        ifeq ($(GLIBC_2_22_SORT), 2.22)
+            ARM_GLIBC_GTE_2_22=1
+        endif
     endif
 endif
 endif

--- a/Makefile.third
+++ b/Makefile.third
@@ -170,7 +170,7 @@ $(LEPTONICA_DIR): $(THIRDPARTY_DIR)/leptonica/CMakeLists.txt
 	rm -rf $(LEPTONICA_DIR)
 	cd $(LEPTONICA_BUILD_DIR) && \
 		$(CMAKE) \
-		$(if $(GLIBC_GTE_2_22),-DGLIBC_GTE_2_22=on,) \
+		$(if $(ARM_GLIBC_GTE_2_22),-DARM_GLIBC_GTE_2_22=on,) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/leptonica && \
 		$(MAKE)
 

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -14,17 +14,18 @@ ko_write_gitclone_script(
     ${SOURCE_DIR}
 )
 
-# Make sure we use the old fmemopen symbol on Linux when building against
-# glibc >= 2.22 (c.f. base#421)
+# Make sure we use the old fmemopen symbol on ARM Linux when building against
+# glibc >= 2.22 (c.f. base#421 & #2188).
+#
+# NOTE: Technically, provided we're targeting ARM, we could probably apply the patch unilaterally,
+# and not only when glibc >= 2.22, but since we now have the code to make the check, keep it,
+# that ensures a vanilla build with sane TCs ;).
 #
 # NOTE: The patch will be much simpler w/ the upcoming leptonica version,
 # there's a 1.74 version of the patch already in our tree for when that time
-# comes ;)
-#
-# NOTE: Because everything is awesome, this can only be applied safely when
-# building against glibc >= 2.22 ...
-if(${GLIBC_GTE_2_22})
-    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.72-fmemopen-compat-symbol.patch)
+# comes ;).
+if(${ARM_GLIBC_GTE_2_22})
+    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.72-fmemopen-arm-compat-symbol.patch)
 else()
     set(PATCH_CMD "")
 endif()

--- a/thirdparty/leptonica/leptonica-1.72-fmemopen-arm-compat-symbol.patch
+++ b/thirdparty/leptonica/leptonica-1.72-fmemopen-arm-compat-symbol.patch
@@ -1,60 +1,60 @@
 diff --git a/src/bmpio.c b/src/bmpio.c
-index e775dd2..68dc56c 100644
+index e775dd2..0331246 100644
 --- a/src/bmpio.c
 +++ b/src/bmpio.c
 @@ -554,6 +554,7 @@ RGBA_QUAD  *pquad;
  #endif  /* HAVE_CONFIG_H */
  
  #if HAVE_FMEMOPEN
-+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++__asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
  extern FILE *open_memstream(char **data, size_t *size);
  extern FILE *fmemopen(void *data, size_t size, const char *mode);
  #endif  /* HAVE_FMEMOPEN */
 diff --git a/src/jp2kio.c b/src/jp2kio.c
-index 9eb88d1..105b160 100644
+index 9eb88d1..97425d0 100644
 --- a/src/jp2kio.c
 +++ b/src/jp2kio.c
 @@ -743,6 +743,7 @@ opj_image_cmptparm_t  cmptparm[4];
   *                         Read/write to memory                        *
   *---------------------------------------------------------------------*/
  #if HAVE_FMEMOPEN
-+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++__asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
  extern FILE *open_memstream(char **data, size_t *size);
  extern FILE *fmemopen(void *data, size_t size, const char *mode);
  #endif  /* HAVE_FMEMOPEN */
 diff --git a/src/jpegio.c b/src/jpegio.c
-index 06185da..ddc4a3c 100644
+index 06185da..7799142 100644
 --- a/src/jpegio.c
 +++ b/src/jpegio.c
 @@ -939,6 +939,7 @@ jmp_buf                      jmpbuf;  /* must be local to the function */
   *                         Read/write to memory                        *
   *---------------------------------------------------------------------*/
  #if HAVE_FMEMOPEN
-+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++__asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
  extern FILE *open_memstream(char **data, size_t *size);
  extern FILE *fmemopen(void *data, size_t size, const char *mode);
  #endif  /* HAVE_FMEMOPEN */
 diff --git a/src/pngio.c b/src/pngio.c
-index 19f6c55..79b7ed3 100644
+index 19f6c55..0db5e86 100644
 --- a/src/pngio.c
 +++ b/src/pngio.c
 @@ -1252,6 +1252,7 @@ l_pngSetReadStrip16To8(l_int32  flag)
   *                         Read/write to memory                        *
   *---------------------------------------------------------------------*/
  #if HAVE_FMEMOPEN
-+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++__asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
  extern FILE *open_memstream(char **data, size_t *size);
  extern FILE *fmemopen(void *data, size_t size, const char *mode);
  #endif  /* HAVE_FMEMOPEN */
 diff --git a/src/pnmio.c b/src/pnmio.c
-index 3b4b931..00b4e47 100644
+index 3b4b931..b5e00ef 100644
 --- a/src/pnmio.c
 +++ b/src/pnmio.c
 @@ -601,6 +601,7 @@ PIX       *pixs;
  #endif  /* HAVE_CONFIG_H */
  
  #if HAVE_FMEMOPEN
-+__asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++__asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
  extern FILE *open_memstream(char **data, size_t *size);
  extern FILE *fmemopen(void *data, size_t size, const char *mode);
  #endif  /* HAVE_FMEMOPEN */

--- a/thirdparty/leptonica/leptonica-1.74-fmemopen-arm-compat-symbol.patch
+++ b/thirdparty/leptonica/leptonica-1.74-fmemopen-arm-compat-symbol.patch
@@ -1,12 +1,12 @@
 diff --git a/src/utils.c b/src/utils.c
-index 76e7d43..9da46b0 100644
+index bb3507c..9caf08f 100644
 --- a/src/utils.c
 +++ b/src/utils.c
-@@ -1912,6 +1912,7 @@ FILE  *fp;
+@@ -1903,6 +1903,7 @@ FILE  *fp;
          return (FILE *)ERROR_PTR("data not defined", procName, NULL);
  
  #if HAVE_FMEMOPEN
-+    __asm__(".symver fmemopen,fmemopen@GLIBC_2.2.5");
++    __asm__(".symver fmemopen,fmemopen@GLIBC_2.4");
      if ((fp = fmemopen((void *)data, size, "rb")) == NULL)
          return (FILE *)ERROR_PTR("stream not opened", procName, NULL);
  #else  /* write to tmp file */


### PR DESCRIPTION
Turns out the compat symbol is pinned to a different version on arm than
on x86, which explains the discrepancies we were seeing (2.2.5 on x86
vs. 2.4 on ARM).

Since we now have the code to check the TC glibc version, keep using that
check, but only when doing non-emulator builds (i.e., targeting arm).
Make that clear in the variable name and the comments.

And, most importantly, fix the patches so we're actually using the
compat symbol for arm, not x86, since this is where we care about it ;).

This fixes arm builds with current Ubuntu TCs, for instance.

Fix #2188 (thanks for the feedback, @tigran123 ;)).