### PR TITLE
Add missing dash

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -166,7 +166,7 @@ UBUNTU_COMPAT_CFLAGS:=-fno-finite-math-only -fno-stack-protector -U_FORTIFY_SOUR
 # ARM 1136JF-S (Legacy Kidle devices [K2/K3/DX/DXG])
 ARMV6_1136_ARCH:=-march=armv6j -mtune=arm1136jf-s -mfpu=vfp -marm
 # Generic armv6
-ARMV6_GENERIC_ARCH:=march=armv6 -mtune=generic-armv6 -marm
+ARMV6_GENERIC_ARCH:=-march=armv6 -mtune=generic-armv6 -marm
 # Cortex A8 (K4, Kindle Touch, PW1, Kobos since the Touch)
 ARMV7_A8_ARCH:=-march=armv7-a -mtune=cortex-a8 -mfpu=neon -mthumb
 # Cortex A9 (Kindle PW2)


### PR DESCRIPTION
In Makefile.defs, a dash is missing in the ARMV6_GENERIC_ARCH variable, making the build process stop working.