### PR TITLE
fix: only build popen for kindle & bump lj-wpaclient for bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,12 +71,14 @@ libs: \
 	$(OUTPUT_DIR)/libs/libkoreader-cre.so \
 	$(OUTPUT_DIR)/libs/libwrap-mupdf.so
 
-$(OUTPUT_DIR)/libs/libkoreader-input.so: input/*.c input/*.h $(POPEN_NOSHELL_LIB)
+$(OUTPUT_DIR)/libs/libkoreader-input.so: input/*.c input/*.h $(if $(KINDLE),$(POPEN_NOSHELL_LIB),)
 	@echo "Building koreader input module..."
 	$(CC) $(DYNLIB_CFLAGS) -I$(POPEN_NOSHELL_DIR) -I./input \
 		$(if $(KOBO),-DKOBO,) $(if $(KINDLE),-DKINDLE,) $(if $(POCKETBOOK),-DPOCKETBOOK,) \
 		-o $@ \
-		input/input.c $(POPEN_NOSHELL_LIB) $(if $(POCKETBOOK),-linkview,)
+		input/input.c \
+		$(if $(KINDLE),$(POPEN_NOSHELL_LIB),) \
+		$(if $(POCKETBOOK),-linkview,)
 
 $(OUTPUT_DIR)/libs/libkoreader-lfs.so: \
 			$(if $(or $(ANDROID),$(WIN32)),$(LUAJIT_LIB),) \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -526,9 +526,10 @@ SQLITE_DIR=$(CURDIR)/$(SQLITE_BUILD_DIR)/sqlite-prefix/src/sqlite-build
 SQLITE_LIB=$(SQLITE_DIR)/lib/libsqlite3.a
 
 # pure LuaJIT module, so no need to separate build dir by MACHINE
+LJ_WPACLIENT_FILES=wpaclient.lua socket_h.lua consts_h.lua socket.lua wpa_ctrl.lua
 LJ_WPACLIENT_BUILD_DIR=$(THIRDPARTY_DIR)/lj-wpaclient/build
 LJ_WPACLIENT_DIR=$(CURDIR)/$(LJ_WPACLIENT_BUILD_DIR)/lj-wpaclient-prefix/src/lj-wpaclient
-LJ_WPACLIENT=$(OUTPUT_DIR)/common/lj-wpaclient/wpaclient.lua
+LJ_WPACLIENT=$(addprefix $(OUTPUT_DIR)/common/lj-wpaclient/, $(LJ_WPACLIENT_FILES))
 
 # CFLAGS for the Lua/C/C++ modules:
 #

--- a/Makefile.third
+++ b/Makefile.third
@@ -527,11 +527,15 @@ $(SQLITE_LIB): $(THIRDPARTY_DIR)/sqlite/CMakeLists.txt
 		$(CURDIR)/thirdparty/sqlite && \
 		$(MAKE)
 
+comma:=,
+empty:=
+space:=$(empty) $(empty)
 $(LJ_WPACLIENT): $(THIRDPARTY_DIR)/lj-wpaclient/CMakeLists.txt
+	echo 'yoo' $(LJ_WPACLIENT)
 	install -d $(LJ_WPACLIENT_BUILD_DIR)
 	cd $(LJ_WPACLIENT_BUILD_DIR) && \
 		$(CMAKE) $(CURDIR)/thirdparty/lj-wpaclient && \
 		$(MAKE)
 	install -d $(OUTPUT_DIR)/common/lj-wpaclient
-	cp $(LJ_WPACLIENT_DIR)/{wpaclient,wpa_ctrl,socket_h,socket}.lua \
+	cp $(LJ_WPACLIENT_DIR)/{$(subst $(space),$(comma),$(LJ_WPACLIENT_FILES))} \
 		$(OUTPUT_DIR)/common/lj-wpaclient/

--- a/thirdparty/lj-wpaclient/CMakeLists.txt
+++ b/thirdparty/lj-wpaclient/CMakeLists.txt
@@ -10,7 +10,7 @@ ep_get_source_dir(SOURCE_DIR)
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/lj-wpaclient.git
-    4f69339f9cbd320259c29e451aaba75d8dd9b818
+    d1ad33b2af9585313f803a27d62726d952655acc
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
A bug in lj-wpaclient causing it to identify the wrong network as the currently connected one.