### PR TITLE
czmq: Add -Wnoerror to CFLAGS

### DIFF
--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -16,7 +16,8 @@ assert_var_defined(HOST)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
-set(CFG_ENV_VAR "CC=\"${CC}\" LDFLAGS=\"${LDFLAGS}\" CFLAGS=\"${CFLAGS}\" czmq_have_xmlto=no czmq_have_asciidoc=no")
+#-Wno-error so we can build on glibc 2.24 in spite of readdir_r
+set(CFG_ENV_VAR "CC=\"${CC}\" LDFLAGS=\"${LDFLAGS}\" CFLAGS=\"-Wno-error ${CFLAGS}\" czmq_have_xmlto=no czmq_have_asciidoc=no")
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --with-gnu-ld --with-libzmq=${ZMQ_DIR} --disable-static --enable-shared --host=${HOST}")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 


### PR DESCRIPTION
This works around the readdir_r being depracated error in glibc 2.24. References #471.