### PR TITLE
More accurate word detection and text selection

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1078,10 +1078,25 @@ static int getWordBoxesFromPositions(lua_State *L) {
 			return 0;
 		r.sort();
 
+	        // Old saved highlights may have included punctuation at
+	        // edges (they were not displayed in boxes because of
+	        // lvtinydom.cpp's ldomWordsCollector catching only letters)
+	        // and punctuation was considered part of the word
+	        // (a space was the sole word separator), so
+	        // r.getStart().isVisibleWordStart() and r.getEnd().isVisibleWordEnd()
+	        // were always true.
+	        // With our changes to word detection, this is no more true,
+	        // and the next tests would gather the previous or following
+	        // words, which were not part of the saved highlight !
+	        // But we can change the method to indeed get the word just
+	        // after or before the punctuation and actually get
+	        // exactly the included words without punctuation
 		if (!r.getStart().isVisibleWordStart())
-			r.getStart().prevVisibleWordStart();
+			// r.getStart().prevVisibleWordStart();
+			r.getStart().nextVisibleWordStart();
 		if (!r.getEnd().isVisibleWordEnd())
-			r.getEnd().nextVisibleWordEnd();
+			// r.getEnd().nextVisibleWordEnd();
+			r.getEnd().prevVisibleWordEnd();
 		if (r.isNull())
 			return 0;
 


### PR DESCRIPTION
See https://github.com/koreader/crengine/pull/69 for details.
Bumped crengine.
Added fix for a correct display of old (before this crengine mod) saved highlights that included punctuation at edges.

Well, I didn't use highlights at all, so I'd be happy if one of you who do, and have such epubs near the emulator, could test on the emulator that everything feels right (old highlights display the same, new hightlights are fine, text selection is indeed better). Thanks !