### PR TITLE
(minor) some shell code quality and formatting fixes

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
 # don't do this for clang
-if [ "$CXX" = "g++" ];
-    then export CXX="g++-4.8" CC="gcc-4.8";
+if [ "$CXX" = "g++" ]; then
+    export CXX="g++-4.8" CC="gcc-4.8"
 fi
 # in case anything ignores the environment variables, override through PATH
 mkdir bin
-ln -s $(which gcc-4.8) bin/cc
-ln -s $(which gcc-4.8) bin/gcc
-ln -s $(which c++-4.8) bin/c++
-ln -s $(which g++-4.8) bin/g++
+ln -s "$(which gcc-4.8)" bin/cc
+ln -s "$(which gcc-4.8)" bin/gcc
+ln -s "$(which c++-4.8)" bin/c++
+ln -s "$(which g++-4.8)" bin/g++
+
 export PATH=$PWD/bin:$PATH

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -9,19 +9,19 @@ travis_retry make fetchthirdparty
 if [ "$TARGET" = kobo ]; then
     chmod -R 777 $HOME/.ccache
     docker run -t \
-        -v $HOME/.ccache:${DOCKER_HOME}/.ccache \
+        -v "${HOME}"/.ccache:${DOCKER_HOME}/.ccache \
         -v `pwd`:${DOCKER_HOME}/base ${DOCKER_IMG} \
         /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && make TARGET=kobo all'
 elif [ "$TARGET" = kindle ]; then
     chmod -R 777 $HOME/.ccache
     docker run -t \
-        -v $HOME/.ccache:${DOCKER_HOME}/.ccache \
+        -v "${HOME}"/.ccache:${DOCKER_HOME}/.ccache \
         -v `pwd`:${DOCKER_HOME}/base ${DOCKER_IMG} \
         /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && make TARGET=kindle all'
 elif [ "$TARGET" = pocketbook ]; then
     chmod -R 777 $HOME/.ccache
     docker run -t \
-        -v $HOME/.ccache:${DOCKER_HOME}/.ccache \
+        -v "${HOME}"/.ccache:${DOCKER_HOME}/.ccache \
         -v `pwd`:${DOCKER_HOME}/base ${DOCKER_IMG} \
         /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && make pocketbook-toolchain && make VERBOSE=1 TARGET=pocketbook all"
 else

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,59 +1,62 @@
+#!/usr/bin/env bash
+
 set -e
 set -o pipefail
 
 ANSI_RED="\033[31;1m"
+# shellcheck disable=SC2034
 ANSI_GREEN="\033[32;1m"
 ANSI_RESET="\033[0m"
+# shellcheck disable=SC2034
 ANSI_CLEAR="\033[0K"
 
 travis_retry() {
-  local result=0
-  local count=1
-  set +e
+    local result=0
+    local count=1
+    set +e
 
-  while [ $count -le 3 ]; do
-    [ $result -ne 0 ] && {
-      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+    while [ $count -le 3 ]; do
+        [ $result -ne 0 ] && {
+            echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of 3.${ANSI_RESET}\n" >&2
+        }
+        "$@"
+        result=$?
+        [ $result -eq 0 ] && break
+        count=$((count + 1))
+        sleep 1
+    done
+
+    [ $count -gt 3 ] && {
+        echo -e "\n${ANSI_RED}The command \"$*\" failed 3 times.${ANSI_RESET}\n" >&2
     }
-    "$@"
-    result=$?
-    [ $result -eq 0 ] && break
-    count=$(($count + 1))
-    sleep 1
-  done
 
-  [ $count -gt 3 ] && {
-    echo -e "\n${ANSI_RED}The command \"$@\" failed 3 times.${ANSI_RESET}\n" >&2
-  }
-
-  set -e
-  return $result
+    set -e
+    return $result
 }
 
 retry_cmd() {
-  local result=0
-  local count=1
-  set +e
+    local result=0
+    local count=1
+    set +e
 
-  retry_cnt=$1
-  shift 1
+    retry_cnt=$1
+    shift 1
 
-  while [ $count -le ${retry_cnt} ]; do
-    [ $result -ne 0 ] && {
-      echo -e "\n${ANSI_RED}The command \"$@\" failed. Retrying, $count of ${retry_cnt}${ANSI_RESET}\n" >&2
+    while [ $count -le "${retry_cnt}" ]; do
+        [ $result -ne 0 ] && {
+            echo -e "\n${ANSI_RED}The command \"$*\" failed. Retrying, $count of ${retry_cnt}${ANSI_RESET}\n" >&2
+        }
+        "$@"
+        result=$?
+        [ $result -eq 0 ] && break
+        count=$((count + 1))
+        sleep 1
+    done
+
+    [ $count -gt "${retry_cnt}" ] && {
+        echo -e "\n${ANSI_RED}The command \"$*\" failed ${retry_cnt} times.${ANSI_RESET}\n" >&2
     }
-    "$@"
-    result=$?
-    [ $result -eq 0 ] && break
-    count=$(($count + 1))
-    sleep 1
-  done
 
-  [ $count -gt ${retry_cnt} ] && {
-    echo -e "\n${ANSI_RED}The command \"$@\" failed ${retry_cnt} times.${ANSI_RESET}\n" >&2
-  }
-
-  set -e
-  return $result
+    set -e
+    return $result
 }
-

--- a/utils/pdfattach
+++ b/utils/pdfattach
@@ -8,34 +8,32 @@
 # Written by Tigran Aivazian <tigran@bibles.org.uk>
 #
 
-progname=$(basename $0)
+progname=$(basename "$0")
 
-function escape_tex_specialchars()
-{
-	local txt=$1
-	local res=$(echo "$txt" | sed -e "s%_%\\\_%g" -e "s%&%\\\&%g")
-	echo "$res"
+function escape_tex_specialchars() {
+    local txt=$1
+    local res=$(echo "$txt" | sed -e "s%_%\\\_%g" -e "s%&%\\\&%g")
+    echo "$res"
 }
 
-function usage()
-{
-	echo "Usage: $progname -o file.pdf [-a author] file1.djvu [file2.mp3] ..."
-	exit 1
+function usage() {
+    echo "Usage: $progname -o file.pdf [-a author] file1.djvu [file2.mp3] ..."
+    exit 1
 }
 
 if (! getopts ":o:" opt); then
-	echo "$progname: Missing options." >&2
-	usage
+    echo "$progname: Missing options." >&2
+    usage
 fi
 
-if ! type pdflatex > /dev/null 2>&1 ; then
-	echo "$progname: pdfLaTeX program is required." >&2
-	exit 1
+if ! type pdflatex >/dev/null 2>&1; then
+    echo "$progname: pdfLaTeX program is required." >&2
+    exit 1
 fi
 
-if ! kpsewhich attachfile.sty > /dev/null 2>&1 ; then
-	echo "$progname: attachfile.sty package is required." >&2
-	exit 1
+if ! kpsewhich attachfile.sty >/dev/null 2>&1; then
+    echo "$progname: attachfile.sty package is required." >&2
+    exit 1
 fi
 
 declare outfile=""
@@ -46,80 +44,77 @@ declare -i infcount=0 outfcount=0 totalsize=0
 declare author=""
 
 while getopts ":o:a:" opt; do
-	case $opt in
-	a)
-		author="$OPTARG"
-		;;
-	o)
-		outfile=$(readlink -f "$OPTARG")
-		((outfcount++))
-		;;
-	\?)
-		echo "$progname: Invalid option: -$OPTARG" >&2
-		usage
-		;;
-	:)
-		echo "$progname: Option -$OPTARG requires an argument." >&2
-		usage
-		;;
-	esac
+    case $opt in
+        a)
+            author="$OPTARG"
+            ;;
+        o)
+            outfile=$(readlink -f "$OPTARG")
+            ((outfcount++))
+            ;;
+        \?)
+            echo "$progname: Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+        :)
+            echo "$progname: Option -$OPTARG requires an argument." >&2
+            usage
+            ;;
+    esac
 done
 
-shift $((OPTIND-1))
+shift $((OPTIND - 1))
 
 numargs=$#
-for ((i=1 ; i <= $numargs ; i++))
-do
-	fullname=$(readlink -f "$1")
-	if [ ! -r "$fullname" ] ; then
-		echo "$progname: cannot access the file \"$fullname\"" >&2
-		usage
-	fi
-	infiles[$infcount]="$fullname"
-	infiles_texclean[$infcount]=$(escape_tex_specialchars $(basename "${infiles[$infcount]}"))
-	infilesize[$infcount]=$(stat --print="%s" "$fullname")
-	((totalsize=totalsize+${infilesize[$infcount]}))
-	((infcount++))
-	shift
+for ((i = 1; i <= numargs; i++)); do
+    fullname=$(readlink -f "$1")
+    if [ ! -r "$fullname" ]; then
+        echo "$progname: cannot access the file \"$fullname\"" >&2
+        usage
+    fi
+    infiles[$infcount]="$fullname"
+    infiles_texclean[$infcount]=$(escape_tex_specialchars $(basename "${infiles[$infcount]}"))
+    infilesize[$infcount]=$(stat --print="%s" "$fullname")
+    ((totalsize = totalsize + ${infilesize[$infcount]}))
+    ((infcount++))
+    shift
 done
 
-if ((infcount == 0)) ; then
-	echo "$progname: No input file(s) specified." >&2
-	usage
+if ((infcount == 0)); then
+    echo "$progname: No input file(s) specified." >&2
+    usage
 fi
 
-if ((outfcount != 1)) ; then
-	echo "$progname: One (and only one) output file must be specified." >&2
-	usage
+if ((outfcount != 1)); then
+    echo "$progname: One (and only one) output file must be specified." >&2
+    usage
 fi
 
 workdir=$(mktemp --tmpdir -d pdfattach.XXXXXX)
-cd $workdir
-> tmp.tex
+cd "${workdir}" || exit
+>tmp.tex
 # emit TeX preamble
-echo -E "\documentclass{book}" >> tmp.tex
-echo -E "\usepackage[margin={1mm},papersize={9cm,12cm}]{geometry}" >> tmp.tex
-echo -E "\usepackage{hyperref,attachfile}" >> tmp.tex
-if [ ! -z "$author" ] ; then
-	echo -E "\AtBeginDocument{\hypersetup{pdfauthor={$author}}}" >> tmp.tex
+echo -E "\documentclass{book}" >>tmp.tex
+echo -E "\usepackage[margin={1mm},papersize={9cm,12cm}]{geometry}" >>tmp.tex
+echo -E "\usepackage{hyperref,attachfile}" >>tmp.tex
+if [ ! -z "$author" ]; then
+    echo -E "\AtBeginDocument{\hypersetup{pdfauthor={$author}}}" >>tmp.tex
 fi
-echo -E "\begin{document}" >> tmp.tex
-echo -E "\tolerance=10000\pagestyle{empty}\fontsize{7}{13}\selectfont" >> tmp.tex
+echo -E "\begin{document}" >>tmp.tex
+echo -E "\tolerance=10000\pagestyle{empty}\fontsize{7}{13}\selectfont" >>tmp.tex
 
 # emit the list of all files
-for ((i = 0 ; i < ${#infiles[*]} ; i++));
-do
-	echo -E "\noindent \hyperlink{L$i}{$((i+1))/${infcount}} \texttt{${infiles_texclean[$i]}} (${infilesize[$i]} bytes)" >> tmp.tex
-	echo >> tmp.tex
+for ((i = 0; i < ${#infiles[*]}; i++)); do
+    echo -E "\noindent \hyperlink{L$i}{$((i + 1))/${infcount}} \texttt{${infiles_texclean[$i]}} (${infilesize[$i]} bytes)" >>tmp.tex
+    echo >>tmp.tex
 done
-echo -E "\noindent Total size $totalsize bytes\newpage" >> tmp.tex
+echo -E "\noindent Total size $totalsize bytes\newpage" >>tmp.tex
 
 # now emit all the attachments, one per page
-for ((i = 0 ; i < ${#infiles[*]} ; i++));
-do
-	echo -E "\noindent\hypertarget{L$i}$((i+1))/${infcount}\\\\\texttt{${infiles_texclean[$i]}} (\textattachfile[color={0 0 0}]{${infiles[$i]}}{${infilesize[$i]} bytes})\newpage" >> tmp.tex
+for ((i = 0; i < ${#infiles[*]}; i++)); do
+    echo -E "\noindent\hypertarget{L$i}$((i + 1))/${infcount}\\\\\texttt{${infiles_texclean[$i]}} (\textattachfile[color={0 0 0}]{${infiles[$i]}}{${infilesize[$i]} bytes})\newpage" >>tmp.tex
 done
-echo -E "\end{document}" >> tmp.tex
-pdflatex -halt-on-error tmp.tex > /dev/null && mv tmp.pdf "$outfile"
-cd - > /dev/null
-rm -rf $workdir
+echo -E "\end{document}" >>tmp.tex
+pdflatex -halt-on-error tmp.tex >/dev/null && mv tmp.pdf "$outfile"
+cd - >/dev/null
+rm -rf "${workdir}"


### PR DESCRIPTION
Build array of files with:

```bash
mapfile -t shellscript_locations < <({ git grep -lE '^#!(/usr)?/bin/(env )?(bash|sh)' && git ls-files ./*.sh; } | sort | uniq)
```

Check with:

```bash
for shellscript in "${shellscript_locations[@]}"; do
    echo -e "${ANSI_GREEN}Running shellcheck on ${shellscript}"
    shellcheck "${shellscript}" || SHELLSCRIPT_ERROR=1
    echo -e "${ANSI_GREEN}Running shfmt on ${shellscript}"
    if [ "$(cat "${shellscript}")" != "$(shfmt -i 4 "${shellscript}")" ]; then
        echo -e "${ANSI_RED}Warning: ${shellscript} does not abide by coding style"
        shfmt -i 4 "${shellscript}" | diff "${shellscript}" - || SHELLSCRIPT_ERROR=1
    fi
done
```

See https://github.com/koreader/koreader/blob/6f037cec30673a41492b727648988cc598d40432/.ci/helper_shellchecks.sh