### PR TITLE
Fix memory leak with BB.fromstring()

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1296,7 +1296,9 @@ end
 function BB.fromstring(width, height, buffertype, str, pitch)
     local dataptr = ffi.C.malloc(#str)
     ffi.copy(dataptr, str, #str)
-    return BB.new(width, height, buffertype, dataptr, pitch)
+    local bb = BB.new(width, height, buffertype, dataptr, pitch)
+    bb:setAllocated(1)
+    return bb
 end
 
 function BB.tostring(bb)


### PR DESCRIPTION
Not used much by koreader, except when loading a cached TileCacheItem and in one unit test.
(But I witnessed huge memory leaks when playing with cached cover images and some thumbnails view - not sure i'll end up making something of that, but this bug should be fixed).
This setAllocated(1) is what will make the calls to free() actually do some freeing, it's what used in this file in all other places after a ffi.C.malloc() is made.