### PR TITLE
fix compile errors under Fedora due to -Werror

### DIFF
--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -17,6 +17,9 @@ assert_var_defined(CHOST)
 
 ep_get_source_dir(SOURCE_DIR)
 
+# fix build error due to -Werror under Fedora 26 (and potentially other systems)
+set(CFLAGS "${CFLAGS} -Wno-error")
+
 set(CFG_ENV_VAR "CC=\"${CC}\" CXX=\"${CXX}\" CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\" LIBS=\"${LIBS}\"")
 set(CFG_OPTS "-q --disable-desktopfiles --disable-static --enable-shared --disable-xmltools --disable-largefile --without-jpeg --without-tiff -host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -26,7 +26,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    # patch turbo to specify path of libssl and libcrypto
+    # patch turbo to specify path of libssl and libcrypto and to remove -Werror flag from turbo/deps/http_parser/Makefile
     PATCH_COMMAND patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/turbo.patch
     # skip configure
     CONFIGURE_COMMAND ""

--- a/thirdparty/turbo/turbo.patch
+++ b/thirdparty/turbo/turbo.patch
@@ -71,3 +71,17 @@ index 85cadc1..7f92575 100644
              -- Still not OK...
              error("Could not load " .. name .. " \
              Please run makefile and ensure that installation is done correct.")
+diff --git a/deps/http-parser/Makefile b/deps/http-parser/Makefile
+index c8e7b8c..68f5eda 100644
+--- a/deps/http-parser/Makefile
++++ b/deps/http-parser/Makefile
+@@ -37,7 +37,7 @@ CPPFLAGS_DEBUG += $(CPPFLAGS_DEBUG_EXTRA)
+ CPPFLAGS_FAST = $(MYCPPFLAGS) -DHTTP_PARSER_STRICT=0
+ CPPFLAGS_FAST += $(CPPFLAGS_FAST_EXTRA)
+ 
+-MYCFLAGS = -Wall -Wextra -Werror
++MYCFLAGS = -Wall -Wextra
+ CFLAGS_DEBUG = $(MYCFLAGS) -O0 -g $(CFLAGS_DEBUG_EXTRA)
+ CFLAGS_FAST = $(MYCFLAGS) -O3 $(CFLAGS_FAST_EXTRA)
+ CFLAGS = -O3 $(CFLAGS_FAST_EXTRA)
+


### PR DESCRIPTION
fixes compilation errors reported in https://github.com/koreader/koreader/issues/3069
does not fix runtime errors under fedora (due to lua5.3 vs lua 5.1), though