### PR TITLE
update sdcv to consider -u params to be already utf8

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CFG_CMD sh -c "${SOURCE_DIR}/configure ${CFG_OPTS}")
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     git://github.com/koreader/sdcv.git
-    4455cf31bb4a424370e29d858dc07cf8d8f5de04
+    fdf7da2cbf52f40724c0146b9bd31de376901708
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Needed by: Dict settings menu: list dictionaries, and allow disabling them https://github.com/koreader/koreader/pull/3144 