### PR TITLE
SDL: handle quit event

### DIFF
--- a/ffi/SDL1_2.lua
+++ b/ffi/SDL1_2.lua
@@ -1,4 +1,4 @@
---[[
+--[[--
 Module for interfacing SDL video/input facilities
 
 This module is intended to provide input/output facilities on a
@@ -117,7 +117,9 @@ function S.waitForEvent(usecs)
 			genEmuEvent(ffi.C.EV_ABS, ffi.C.ABS_MT_POSITION_Y, event.button.y)
 			genEmuEvent(ffi.C.EV_SYN, ffi.C.SYN_REPORT, 0)
 		elseif event.type == SDL.SDL_QUIT then
-			error("application forced to quit")
+			-- send Alt + F4
+			genEmuEvent(ffi.C.EV_KEY, 226, 1)
+			genEmuEvent(ffi.C.EV_KEY, 61, 1)
 		end
 	end
 end

--- a/ffi/SDL1_2.lua
+++ b/ffi/SDL1_2.lua
@@ -1,4 +1,4 @@
---[[--
+--[[
 Module for interfacing SDL video/input facilities
 
 This module is intended to provide input/output facilities on a
@@ -117,9 +117,7 @@ function S.waitForEvent(usecs)
 			genEmuEvent(ffi.C.EV_ABS, ffi.C.ABS_MT_POSITION_Y, event.button.y)
 			genEmuEvent(ffi.C.EV_SYN, ffi.C.SYN_REPORT, 0)
 		elseif event.type == SDL.SDL_QUIT then
-			-- send Alt + F4
-			genEmuEvent(ffi.C.EV_KEY, 226, 1)
-			genEmuEvent(ffi.C.EV_KEY, 61, 1)
+			error("application forced to quit")
 		end
 	end
 end

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -1,4 +1,4 @@
---[[
+--[[--
 Module for interfacing SDL 2.0 video/input facilities
 
 This module is intended to provide input/output facilities on a
@@ -160,7 +160,9 @@ function S.waitForEvent(usecs)
 		elseif event.type == SDL.SDL_MULTIGESTURE then
 			-- TODO: multi-touch support
 		elseif event.type == SDL.SDL_QUIT then
-			error("application forced to quit")
+			-- send Alt + F4
+			genEmuEvent(ffi.C.EV_KEY, 226, 1)
+			genEmuEvent(ffi.C.EV_KEY, 61, 1)
 		end
 	end
 end

--- a/ffi/input.lua
+++ b/ffi/input.lua
@@ -1,14 +1,13 @@
 local util = require("ffi/util")
 
 if util.isSDL() then
-	if util.haveSDL2() then
-		return require("ffi/input_SDL2_0")
-	else
-		return require("ffi/input_SDL1_2")
-	end
+    if util.haveSDL2() then
+        return require("ffi/input_SDL2_0")
+    else
+        return require("ffi/input_SDL1_2")
+    end
 elseif util.isAndroid() then
-	return require("ffi/input_android")
+    return require("ffi/input_android")
 else
-	return require("libs/libkoreader-input")
+    return require("libs/libkoreader-input")
 end
-

--- a/ffi/input_SDL2_0.lua
+++ b/ffi/input_SDL2_0.lua
@@ -2,10 +2,10 @@
 local SDL = require("ffi/SDL2_0")
 
 return {
-	open = SDL.open,
-	waitForEvent = SDL.waitForEvent,
-	-- NOP:
-	fakeTapInput = function() end,
-	-- NOP:
-	closeAll = function() end
+    open = SDL.open,
+    waitForEvent = SDL.waitForEvent,
+    -- NOP:
+    fakeTapInput = function() end,
+    -- NOP:
+    closeAll = function() end
 }


### PR DESCRIPTION
This will send Alt + F4 on any SQL quit event, whether from Alt + F4 or
another interaction with the window manager. The frontend can subsequently
mount an appropriate response by obliterating itself.