### PR TITLE
[fix] ffi/framebuffer: memory use explosion in unit tests

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -48,6 +48,8 @@ fb.ORIENTATION_LANDSCAPE = 1
 fb.ORIENTATION_PORTRAIT_ROTATED = 2
 fb.ORIENTATION_LANDSCAPE_ROTATED = 3
 
+local EMULATE_READER_DPI = tonumber(os.getenv("EMULATE_READER_DPI"))
+
 function fb:extend(o)
     o = o or {}
     setmetatable(o, self)
@@ -223,7 +225,7 @@ end
 
 function fb:getDPI()
     if self.dpi == nil then
-        self.dpi = tonumber(os.getenv("EMULATE_READER_DPI")) or G_reader_settings:readSetting("screen_dpi")
+        self.dpi = EMULATE_READER_DPI or G_reader_settings:readSetting("screen_dpi")
     end
     if self.dpi == nil and self.device then
         self.dpi = self.device.display_dpi
@@ -249,7 +251,7 @@ function fb:scaleBySize(px)
     -- if users custom screen dpi, also scale by dpi
     local dpi_scale = size_scale
 
-    local custom_dpi = tonumber(os.getenv("EMULATE_READER_DPI")) or G_reader_settings:readSetting("screen_dpi")
+    local custom_dpi = EMULATE_READER_DPI or G_reader_settings:readSetting("screen_dpi")
     if custom_dpi and self.device and self.device.display_dpi ~= self.dpi then
         dpi_scale = self.dpi / 167
     end


### PR DESCRIPTION
During the unit tests fb:getDPI() is hit multiple times and self.dpi has to be filled from scratch.
This results in multiple calls to `os.getenv("EMULATE_READER_DPI")`. No biggie you would think, but
for some reason this causes memory use to quickly balloon out of proportion and exceed the 2 GB limit.