### PR TITLE
Added util.getNonBlockingReadSize(luafile)

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -75,3 +75,5 @@ cdecl_func(printf)
 cdecl_func(sprintf)
 cdecl_func(fprintf)
 cdecl_func(fputc)
+
+cdecl_func(fileno)

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -75,4 +75,6 @@ int printf(const char *, ...);
 int sprintf(char *, const char *, ...) __attribute__((nothrow));
 int fprintf(struct _IO_FILE *restrict, const char *restrict, ...);
 int fputc(int, struct _IO_FILE *);
+static const int FIONREAD = 21531;
+int fileno(struct FILE *stream);
 ]]

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -214,6 +214,23 @@ function util.execute(...)
     end
 end
 
+--- Returns the length of data that can be read immediately without blocking
+function util.getNonBlockingReadSize(luafile)
+    -- returns 0 if not readable yet, otherwise len of available data
+    -- returns nil when unsupported: caller may read (with possible blocking)
+    if util.isAndroid() then
+        return
+    end
+    local fileno = ffi.C.fileno(luafile)
+    local available = ffi.new('int[1]')
+    local ok = ffi.C.ioctl(fileno, ffi.C.FIONREAD, available)
+    if ok ~= 0 then -- ioctl failed, not supported
+        return
+    end
+    available = tonumber(available[0])
+    return available
+end
+
 --- Gets UTF-8 charcode.
 function util.utf8charcode(charstring)
     local ptr = ffi.cast("uint8_t *", charstring)


### PR DESCRIPTION
Needed to implement cancelable dict lookup.
Checking if `static const int FIONREAD = 21531; ` does not fail here...