### PR TITLE
Add proper scaling to mupdf.renderImage()

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -640,6 +640,15 @@ function mupdf.renderImage(data, size, width, height)
 
     local p_width = M.fz_pixmap_width(context(), pixmap)
     local p_height = M.fz_pixmap_height(context(), pixmap)
+    -- mupdf_new_pixmap_from_image() may not scale image to the
+    -- width and height provided, so check and scale it if needed
+    if width and height and (p_width ~= width or p_height ~= height) then
+        local scaled_pixmap = M.fz_scale_pixmap(context(), pixmap, 0, 0, width, height, nil)
+        M.fz_drop_pixmap(context(), pixmap)
+        pixmap = scaled_pixmap
+        p_width = M.fz_pixmap_width(context(), pixmap)
+        p_height = M.fz_pixmap_height(context(), pixmap)
+    end
     local bbtype
     local ncomp = M.fz_pixmap_components(context(), pixmap)
     if ncomp == 2 then bbtype = BlitBuffer.TYPE_BB8A

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -290,6 +290,7 @@ fz_pixmap *fz_new_pixmap(fz_context *, fz_colorspace *, int, int);
 fz_pixmap *mupdf_new_pixmap_with_bbox(fz_context *, fz_colorspace *, const fz_irect *);
 fz_pixmap *mupdf_new_pixmap_with_data(fz_context *, fz_colorspace *, int, int, unsigned char *);
 fz_pixmap *mupdf_new_pixmap_with_bbox_and_data(fz_context *, fz_colorspace *, const fz_irect *, unsigned char *);
+fz_pixmap *fz_scale_pixmap(fz_context *, fz_pixmap *, float, float, float, float, fz_irect *);
 void fz_convert_pixmap(fz_context *, fz_pixmap *, fz_pixmap *);
 fz_pixmap *fz_keep_pixmap(fz_context *, fz_pixmap *);
 void fz_drop_pixmap(fz_context *, fz_pixmap *);


### PR DESCRIPTION
mupdf.renderImage() may not scale the image to the width & height provided, see https://github.com/koreader/koreader/pull/3253#issuecomment-331702912.
I haven't tested that much for side effects, but it seems to work for menu images (they look more blury, less pixelized, dunno if it's actually better and good).
If you can test the rendering results on various sizes/dpi, upscale/downscale, I'm not that much able to appreciate that.
The code in mupdf for the scaling is in mupdf/source/fitz/draw-scale-simple.c fz_scale_pixmap_cached, and I don't even know what algorithm it used :|