### PR TITLE
mupdf, cre: allow for optional colored rendering

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1287,7 +1287,7 @@ static int drawCurrentPage(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	BlitBuffer *bb = (BlitBuffer*) lua_topointer(L, 2);
 	bool color = false;
-	if (lua_isboolean(L,3)) {
+	if (lua_isboolean(L, 3)) {
 		color = lua_toboolean(L, 3);
 	}
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -1286,15 +1286,28 @@ static int clearSelection(lua_State *L) {
 static int drawCurrentPage(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	BlitBuffer *bb = (BlitBuffer*) lua_topointer(L, 2);
+	bool color = false;
+	if (lua_isboolean(L,3)) {
+		color = lua_toboolean(L, 3);
+	}
 
 	int w = bb->w,
 		h = bb->h;
-	/* Set DrawBuf to 8bpp */
-	LVGrayDrawBuf drawBuf(w, h, 8, bb->data);
 
 	doc->text_view->Resize(w, h);
 	doc->text_view->Render();
-	doc->text_view->Draw(drawBuf, false);
+	if (color) {
+		/* Use Color buffer - caller should have provided us with a
+                 * Blitbuffer.TYPE_BBRGB16, see CreDocument:drawCurrentView
+                 * for why not TYPE_BBRGB32) */
+		LVColorDrawBuf drawBuf(w, h, bb->data, 16);
+		doc->text_view->Draw(drawBuf, false);
+	}
+	else {
+		/* Set DrawBuf to 8bpp */
+		LVGrayDrawBuf drawBuf(w, h, 8, bb->data);
+		doc->text_view->Draw(drawBuf, false);
+	}
 
 	return 0;
 }

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -557,7 +557,7 @@ function page_mt.__index:draw_new(draw_context, width, height, offset_x, offset_
     bbox[0].x1 = offset_x + width
     bbox[0].y1 = offset_y + height
 
-    local bb = BlitBuffer.new(width, height, mupdf.color and BlitBuffer.TYPE_RGB32 or BlitBuffer.TYPE_BB8A)
+    local bb = BlitBuffer.new(width, height, mupdf.color and BlitBuffer.TYPE_BBRGB32 or BlitBuffer.TYPE_BB8A)
 
     local colorspace = mupdf.color and M.fz_device_rgb(context())
         or M.fz_device_gray(context())


### PR DESCRIPTION
Support for colored rendering is already there for all engines/formats. It just needs a few fixes, and enabling it. This is the stuff needed in base.