### PR TITLE
Makefile: add luajit-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,9 @@ dist-clean:
 	-rm -rf build
 	-rm -rf $(THIRDPARTY_DIR)/{$(CMAKE_THIRDPARTY_LIBS)}/build
 
+luajit-clean:
+	-rm -rf $(LUAJIT_BUILD_DIR)
+
 # ===========================================================================
 # start of unit tests section
 


### PR DESCRIPTION
Some automation should probably be added, but this is to aid switching between builds with and without KODEBUG. LuaJIT requires a manual `make clean` if you do.