### PR TITLE
[fix] Ignore deprecated SSLv2 and SSLv3 encryptions

### DIFF
--- a/thirdparty/luasec/CMakeLists.txt
+++ b/thirdparty/luasec/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/brunoos/luasec
-    dd9688cf12479afc21178638b0b41d640d9274c2
+    luasec-0.7alpha
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
-set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
+set(BUILD_CMD "$(MAKE) depend && $(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
 set(BUILD_CMD sh -c "${BUILD_CMD} --silent depend build_crypto build_ssl >/dev/null 2>&1")
 
 ko_write_gitclone_script(

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -32,7 +32,7 @@ set(BUILD_CMD sh -c "${BUILD_CMD} --silent depend build_crypto build_ssl >/dev/n
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/openssl/openssl.git
-    OpenSSL_1_0_2l
+    OpenSSL_1_0_1u
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -23,7 +23,7 @@ else()
     set(CFG_ENV_VAR "")
     set(CFG_OPTS "shared")
 endif()
-set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 enable-ssl2")
+set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
 set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
@@ -32,7 +32,7 @@ set(BUILD_CMD sh -c "${BUILD_CMD} --silent depend build_crypto build_ssl >/dev/n
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/openssl/openssl.git
-    OpenSSL_1_0_1t
+    OpenSSL_1_0_2l
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Bumping luasec takes care of proper TLS encryption.

* Bump OpenSSL to the latest 1.0.2l and disable insecure deprecated SSLv2 and SSLv3.