### PR TITLE
Reintroduce base git-rev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ all: check-luajit-clean $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(or $(DARWIN),$(WIN32)), ,$(ZMQ_LIB) $(CZMQ_LIB) $(FILEMQ_LIB) $(ZYRE_LIB)) \
 		$(SQLITE_LIB) \
 		$(LUA_LJ_SQLITE) $(OUTPUT_DIR)/common/xsys.lua
+	echo $(VERSION_BASE) >git-rev
 ifndef EMULATE_READER
 	STRIP_FILES="\
 		$(if $(WIN32),,$(OUTPUT_DIR)/sdcv) \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,5 +1,8 @@
 SHELL:=/bin/bash
 
+# Used to decide whether to generate new CircleCI cache in frontend
+VERSION_BASE=$(shell git describe HEAD)
+
 # Use ccache in build system by default. Define USE_NO_CCACHE=1 to force disable it.
 ifeq ($(USE_NO_CCACHE), 1)
     CCACHE:=


### PR DESCRIPTION
git-rev was moved to the frontend in 4e99f99f8b88e88cfcb544239971b46c3ed9abc1
because it's used as a versioning tool for the entirety of KOReader. However,
there are uses for keeping an easy to reference base git-rev as well.

It looks like the easiest way to ensure CircleCI cache is updated is to use a key.

https://circleci.com/docs/2.0/configuration-reference/#save_cache

In our case we can use `{{ checksum "filename" }}` to decide whether base has
changed and whether we should save a new base cache.

Presently the cache from early September is always reused and hence base will
always be compiled in the frontend CircleCI build.