### PR TITLE
[fix] ffi/framebuffer_android: landscape mode was broken

### DIFF
--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -42,17 +42,11 @@ function framebuffer:refreshFullImp()
     if bb then
         local ext_bb = self.full_bb or self.bb
 
-        -- on Android we just do the whole screen
-        local x = 0
-        local y = 0
-        local w = buffer[0].width
-        local h = buffer[0].height
-
         bb:setInverse(ext_bb:getInverse())
         -- adapt to possible rotation changes
         bb:setRotation(ext_bb:getRotation())
 
-        bb:blitFrom(ext_bb, x, y, x, y, w, h)
+        bb:blitFrom(ext_bb)
     end
 
     android.lib.ANativeWindow_unlockAndPost(android.app.window);


### PR DESCRIPTION
@poire-z Turns out I significantly overcomplicated things due to my earlier debugging-related activities while I was trying to figure out what went wrong.

The landscape problem was rudimentary: when you rotate the screen, so do "width" and "height", which I had matched up with the "physical" dimensions.

When you don't pass any other parameters to `blitFrom` it automatically does the equivalent of

```lua
bb:blitFrom(ext_bb, 0, 0, 0, 0, ext_bb:getWidth(), ext_bb:getHeight())
```

The only part of my earlier fix that was actually properly relevant was adding in `self.full_bb`, which doesn't yet exist the very first time it's called.