### PR TITLE
[chore] Add ANDROID_ARCH environment variable

### DIFF
--- a/.ci/android_install.sh
+++ b/.ci/android_install.sh
@@ -5,11 +5,7 @@ sudo dpkg --add-architecture i386
 sudo apt-get update
 sudo apt-get install zlib1g:i386 libc6-dev-i386 linux-libc-dev:i386
 
-if [ "$NDKREV" = "r9c" ]; then
-    curl -L "http://dl.google.com/android/ndk/android-ndk-${NDKREV}-linux-x86_64.tar.bz2" -O
-    echo "extracting android ndk"
-    bzip2 -dc "android-ndk-${NDKREV}-linux-x86_64.tar.bz2" | tar xf -
-elif [ "$NDKREV" = "r11c" ]; then
+if [ "$NDKREV" = "r11c" ]; then
     curl -L "http://dl.google.com/android/repository/android-ndk-${NDKREV}-linux-x86_64.zip" -O
     echo "extracting android ndk"
     unzip -q "android-ndk-${NDKREV}-linux-x86_64.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,13 @@ env:
     - TARGET=kindle DOCKER_IMG=houqp/kokindle:0.0.2
     - TARGET=kobo DOCKER_IMG=houqp/kokobo:0.0.2
     - TARGET=pocketbook DOCKER_IMG=houqp/kopb:0.0.1
-    - TARGET=android NDKREV=r9c
     - TARGET=android NDKREV=r11c
+    - TARGET=android NDKREV=r11c ANDROID_ARCH=x86
     - TARGET=android NDKREV=r12b
+    - TARGET=android NDKREV=r12b ANDROID_ARCH=x86
     # API level 14 is the minimum target for NDK 15
     - TARGET=android NDKREV=r15c NDKABI=14
+    - TARGET=android NDKREV=r15c NDKABI=14 ANDROID_ARCH=x86
     - SHELLCHECKS=1
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,9 @@ env:
     - TARGET=kindle DOCKER_IMG=houqp/kokindle:0.0.2
     - TARGET=kobo DOCKER_IMG=houqp/kokobo:0.0.2
     - TARGET=pocketbook DOCKER_IMG=houqp/kopb:0.0.1
+    # ANDROID_ARCH=x86 is currently broken on these older NDKs (at least on Travis), so no point in testing it
     - TARGET=android NDKREV=r11c
-    - TARGET=android NDKREV=r11c ANDROID_ARCH=x86
     - TARGET=android NDKREV=r12b
-    - TARGET=android NDKREV=r12b ANDROID_ARCH=x86
     # API level 14 is the minimum target for NDK 15
     - TARGET=android NDKREV=r15c NDKABI=14
     - TARGET=android NDKREV=r15c NDKABI=14 ANDROID_ARCH=x86

--- a/Makefile
+++ b/Makefile
@@ -152,9 +152,9 @@ ifeq ($(wildcard $(NDK)/build/tools/make_standalone_toolchain.py),)
 		--install-dir=$(ANDROID_TOOLCHAIN)
 else
 	$(NDK)/build/tools/make_standalone_toolchain.py --force --install-dir=$(ANDROID_TOOLCHAIN) \
-		--arch arm --api $(NDKABI) --deprecated-headers || \
+		--arch $(ANDROID_ARCH) --api $(NDKABI) --deprecated-headers || \
 	$(NDK)/build/tools/make_standalone_toolchain.py --force --install-dir=$(ANDROID_TOOLCHAIN) \
-		--arch arm --api $(NDKABI)
+		--arch $(ANDROID_ARCH) --api $(NDKABI)
 endif
 endif
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,7 +13,8 @@ UNAME:=$(shell uname -s)
 MAKEFILE_DIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN_DIR=$(MAKEFILE_DIR)toolchain
 POCKETBOOK_TOOLCHAIN=$(TOOLCHAIN_DIR)/pocketbook-toolchain
-ANDROID_TOOLCHAIN=$(TOOLCHAIN_DIR)/android-toolchain
+ANDROID_ARCH?=armeabi-v7a
+ANDROID_TOOLCHAIN=$(TOOLCHAIN_DIR)/android-toolchain-$(ANDROID_ARCH)
 NDK?=$(TOOLCHAIN_DIR)/android-ndk-r15c
 NDKABI?=9
 
@@ -51,8 +52,12 @@ else ifeq ($(TARGET), ubuntu-touch)
 else ifeq ($(TARGET), android)
     export ANDROID=1
     export PATH:=$(ANDROID_TOOLCHAIN)/bin:$(PATH)
-    export SYSROOT=$(NDK)/platforms/android-$(NDKABI)/arch-arm
-    CHOST?=arm-linux-androideabi
+    export SYSROOT=$(NDK)/platforms/android-$(NDKABI)/arch-$(ANDROID_ARCH)
+    ifeq ($(ANDROID_ARCH), x86)
+        CHOST?=i686-linux-android
+    else
+        CHOST?=arm-linux-androideabi
+    endif
 else ifeq ($(TARGET), win32)
     CHOST?=i686-w64-mingw32
     export WIN32=1
@@ -176,11 +181,14 @@ ARMV7_A8_ARCH:=-march=armv7-a -mtune=cortex-a8 -mfpu=neon -mthumb
 # Cortex A9 (Kindle PW2)
 ARMV7_A9_ARCH:=-march=armv7-a -mtune=cortex-a9 -mfpu=neon -mthumb
 # Android.
+ANDROID_COMPAT_CFLAGS:=--sysroot $(SYSROOT)
+ANDROID_COMPAT_CXXFLAGS:=--sysroot $(SYSROOT)
 # Mirror the NDK's armeabi-v7a APP_ABI (cf. #201)
-ANDROID_ARCH:=--sysroot $(SYSROOT)
-ANDROID_ARCH+=-march=armv7-a -mfpu=vfpv3-d16
-ANDROID_ARCH+=-mthumb
-ANDROID_ARCH+=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
+ifeq ($(ANDROID_ARCH), armeabi-v7a)
+    ANDROID_ARM_ARCH:=-march=armv7-a -mfpu=vfpv3-d16
+    ANDROID_ARM_ARCH+=-mthumb
+    ANDROID_ARM_ARCH+=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
+endif
 
 # Use target-specific CFLAGS
 ifeq ($(TARGET), kobo)
@@ -223,9 +231,13 @@ else ifeq ($(TARGET), kindle-legacy)
 	export ac_cv_func_utimensat=no
 	export ac_cv_func_futimens=no
 else ifeq ($(TARGET), android)
-	ARM_ARCH:=$(ANDROID_ARCH)
-	ARM_ARCH+=-mfloat-abi=softfp
-	export ac_cv_type_in_port_t=yes
+	COMPAT_CFLAGS:=$(ANDROID_COMPAT_CFLAGS)
+	COMPAT_CXXFLAGS:=$(ANDROID_COMPAT_CXXFLAGS)
+	ifeq ($(ANDROID_ARCH), armeabi-v7a)
+		ARM_ARCH:=$(ANDROID_ARM_ARCH)
+		ARM_ARCH+=-mfloat-abi=softfp
+		export ac_cv_type_in_port_t=yes
+	endif
 else ifeq ($(TARGET), arm-generic)
 	# Defaults to generic crap
 	ARM_ARCH:=$(ARMV6_GENERIC_ARCH)
@@ -254,7 +266,7 @@ endif
 
 # NOTE: Follow the NDK's lead
 ifeq ($(TARGET), android)
-	LDFLAGS+=-march=armv7-a -no-canonical-prefixes -Wl,--fix-cortex-a8
+	LDFLAGS+=-no-canonical-prefixes -Wl,--fix-cortex-a8
 endif
 
 ifeq ($(TARGET), win32)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -13,7 +13,7 @@ UNAME:=$(shell uname -s)
 MAKEFILE_DIR=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 TOOLCHAIN_DIR=$(MAKEFILE_DIR)toolchain
 POCKETBOOK_TOOLCHAIN=$(TOOLCHAIN_DIR)/pocketbook-toolchain
-ANDROID_ARCH?=armeabi-v7a
+ANDROID_ARCH?=arm
 ANDROID_TOOLCHAIN=$(TOOLCHAIN_DIR)/android-toolchain-$(ANDROID_ARCH)
 NDK?=$(TOOLCHAIN_DIR)/android-ndk-r15c
 NDKABI?=9
@@ -184,7 +184,7 @@ ARMV7_A9_ARCH:=-march=armv7-a -mtune=cortex-a9 -mfpu=neon -mthumb
 ANDROID_COMPAT_CFLAGS:=--sysroot $(SYSROOT)
 ANDROID_COMPAT_CXXFLAGS:=--sysroot $(SYSROOT)
 # Mirror the NDK's armeabi-v7a APP_ABI (cf. #201)
-ifeq ($(ANDROID_ARCH), armeabi-v7a)
+ifeq ($(ANDROID_ARCH), arm)
     ANDROID_ARM_ARCH:=-march=armv7-a -mfpu=vfpv3-d16
     ANDROID_ARM_ARCH+=-mthumb
     ANDROID_ARM_ARCH+=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
@@ -233,7 +233,7 @@ else ifeq ($(TARGET), kindle-legacy)
 else ifeq ($(TARGET), android)
 	COMPAT_CFLAGS:=$(ANDROID_COMPAT_CFLAGS)
 	COMPAT_CXXFLAGS:=$(ANDROID_COMPAT_CXXFLAGS)
-	ifeq ($(ANDROID_ARCH), armeabi-v7a)
+	ifeq ($(ANDROID_ARCH), arm)
 		ARM_ARCH:=$(ANDROID_ARM_ARCH)
 		ARM_ARCH+=-mfloat-abi=softfp
 		export ac_cv_type_in_port_t=yes
@@ -267,6 +267,9 @@ endif
 # NOTE: Follow the NDK's lead
 ifeq ($(TARGET), android)
 	LDFLAGS+=-no-canonical-prefixes -Wl,--fix-cortex-a8
+	ifeq ($(ANDROID_ARCH), arm)
+		LDFLAGS+=-march=armv7-a
+	endif
 endif
 
 ifeq ($(TARGET), win32)

--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -27,12 +27,12 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} \"s|#define HAVE_PWD_H 1||\" gettext-tools/config.h")
 endif()
 
-set(GETTEXT_VER "0.19")
+set(GETTEXT_VER "0.19.8.1")
 include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     URL http://ftp.gnu.org/pub/gnu/gettext/gettext-${GETTEXT_VER}.tar.gz
-    URL_MD5 eae24a623e02b33e3e1024adff9a5a08
+    URL_MD5 97e034cf8ce5ba73a28ff6c3c0638092
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND $(MAKE) -j${PARALLEL_JOBS} --silent


### PR DESCRIPTION
This makes the build less stuck to its current ARM paradigm.

Use `ANDROID_ARCH=x86` to build for x86.

References koreader/koreader#1815