### PR TITLE
[build] sdcv: change to upstream 0.5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ env:
 addons:
   apt:
     packages:
+      - cmake3
       - g++-4.8
       - libsdl1.2-dev
       - luarocks

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -309,8 +309,8 @@ ifdef EMULATE_READER
 	CXXFLAGS+= $(HOST_ARCH)
 else
 	# CMake is difficult about CC and CXX, especially when it's not just a full path
-	CMAKE_C_COMPILER:=$(shell which $(CC))
-	CMAKE_CXX_COMPILER:=$(shell which $(CXX))
+	CMAKE_C_COMPILER:=$(shell which $(strip $(CC)))
+	CMAKE_CXX_COMPILER:=$(shell which $(strip $(CXX)))
 	CMAKE_C_COMPILER_ARG1:= -static-libstdc++
 	CMAKE_CXX_COMPILER_ARG1:= -static-libstdc++
 	ifdef CCACHE

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -309,8 +309,8 @@ ifdef EMULATE_READER
 	CXXFLAGS+= $(HOST_ARCH)
 else
 	# CMake is difficult about CC and CXX, especially when it's not just a full path
-	CMAKE_C_COMPILER:=$(shell which $(strip $(CC)))
-	CMAKE_CXX_COMPILER:=$(shell which $(strip $(CXX)))
+	CMAKE_C_COMPILER:=$(CC)
+	CMAKE_CXX_COMPILER:=$(CXX)
 	CMAKE_C_COMPILER_ARG1:= -static-libstdc++
 	CMAKE_CXX_COMPILER_ARG1:= -static-libstdc++
 	ifdef CCACHE

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -289,6 +289,14 @@ endif
 # in that case.
 
 ifdef EMULATE_READER
+	# CMake is difficult about CC and CXX, especially when it's not just a full path
+	CMAKE_C_COMPILER:=$(shell which $(strip $(HOSTCC)))
+	CMAKE_CXX_COMPILER:=$(shell which $(strip $(HOSTCXX)))
+	ifdef CCACHE
+		CMAKE_C_COMPILER_LAUNCHER:=$(CCACHE)
+		CMAKE_CXX_COMPILER_LAUNCHER:=$(CCACHE)
+	endif
+	# Regular
 	HOSTCC:=$(strip $(CCACHE) $(HOSTCC))
 	HOSTCXX:=$(strip $(CCACHE) $(HOSTCXX))
 	HOSTAR:=$(strip $(CCACHE) $(HOSTAR))
@@ -300,6 +308,15 @@ ifdef EMULATE_READER
 	CFLAGS+= $(HOST_ARCH)
 	CXXFLAGS+= $(HOST_ARCH)
 else
+	# CMake is difficult about CC and CXX, especially when it's not just a full path
+	CMAKE_C_COMPILER:=$(shell which $(CC))
+	CMAKE_CXX_COMPILER:=$(shell which $(CXX))
+	CMAKE_C_COMPILER_ARG1:= -static-libstdc++
+	CMAKE_CXX_COMPILER_ARG1:= -static-libstdc++
+	ifdef CCACHE
+		CMAKE_C_COMPILER_LAUNCHER:=$(CCACHE)
+		CMAKE_CXX_COMPILER_LAUNCHER:=$(CCACHE)
+	endif
 	# Don't let libtool piss on our parade...
 	# See what was mentioned around STATIC_LIBSTDCPP on ~L#93 for more details
 	# (cf. https://www.gnu.org/software/libtool/manual/html_node/Stripped-link-flags.html#Stripped-link-flags)

--- a/Makefile.third
+++ b/Makefile.third
@@ -290,19 +290,19 @@ $(OUTPUT_DIR)/sdcv: $(if $(ANDROID),$(GLIB_STATIC),$(GLIB)) $(ZLIB_STATIC) $(THI
 	cd $(SDCV_BUILD_DIR) && \
 		$(CMAKE) -DHOST="$(if $(EMULATE_READER),,$(CHOST))" \
 		$(PAGE_SIZE_CFG) -DPKG_CONFIG_PATH="$(GLIB_DIR)/lib/pkgconfig" \
-		-DCXX="$(CXX) $(if $(ANDROID),-D_GETOPT_DEFINED,)" \
-		-DCXXFLAGS="$(CXXFLAGS) -I$(ZLIB_DIR) $(if $(ANDROID), \
-			-I$(LIBICONV_DIR)/include -I$(GETTEXT_DIR)/include,)" \
-		-DLDFLAGS="$(LDFLAGS) -L$(ZLIB_DIR) $(if $(ANDROID), \
-			-L$(LIBICONV_DIR)/lib -L$(GETTEXT_DIR)/lib,)" \
-		-DLIBS="$(if $(ANDROID),$(GLIB_STATIC),) \
-			$(if $(ANDROID),,-lpthread -lrt) \
-			$(ZLIB_STATIC) \
-			$(if $(ANDROID),-static,) \
-			-static-libgcc -static-libstdc++" \
+		-DLDFLAGS="$(LDFLAGS)" \
+		-DCMAKE_CXX_COMPILER="$(CMAKE_CXX_COMPILER)" \
+		-DCMAKE_CXX_COMPILER_LAUNCHER="$(CMAKE_CXX_COMPILER_LAUNCHER)" \
+		-DCMAKE_CXX_COMPILER_ARG1="$(CMAKE_CXX_COMPILER_ARG1)" \
+		-DGLIB="$(if $(ANDROID),$(GLIB_STATIC),$(GLIB))" \
+		-DGLIB_DIR="$(GLIB_DIR)" \
+		-DZLIB="$(ZLIB_STATIC)" \
+		-DZLIB_DIR="$(ZLIB_DIR)" \
+		-DLIBICONV_DIR="$(LIBICONV_DIR)" \
+		-DGETTEXT_DIR="$(GETTEXT_DIR)" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/sdcv && \
 		$(MAKE)
-	cp $(SDCV_DIR)/src/sdcv $(OUTPUT_DIR)/
+	cp $(SDCV_DIR)/sdcv $(OUTPUT_DIR)/
 ifdef ANDROID
 	readelf -d $@ | grep "no dynamic" \
 		|| echo "warning: Android L+ support only PIE binary and can't run this"

--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -22,25 +22,21 @@ assert_var_defined(ZLIB_DIR)
 
 ep_get_source_dir(SOURCE_DIR)
 
-if($ENV{ANDROID})
+if(DEFINED ENV{ANDROID})
     set(CRIPPLED_BY_ANDROID_FILES "${SOURCE_DIR}/src/libwrapper.cpp ${SOURCE_DIR}/src/sdcv.cpp ${SOURCE_DIR}/src/utils.cpp")
     set(PATCH_CMD "${ISED} 's|_(|(|' ${CRIPPLED_BY_ANDROID_FILES}")
     set(PATCH_CMD "${PATCH_CMD} && ${ISED} 's|#include <glib/gi18n.h>||' ${CRIPPLED_BY_ANDROID_FILES}")
     set(PATCH_CMD sh -c "${PATCH_CMD}")
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I$(ZLIB_DIR)")
-if($ENV{ANDROID})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${LIBICONV_DIR}/include -I${GETTEXT_DIR}/include")
-else()
+if(NOT DEFINED ENV{ANDROID})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -lrt")
 endif()
 
 # because cmake needs all kinds of annoying special cmake variables
 set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS} -static-libgcc -static-libstdc++")
-if($ENV{ANDROID})
+if(DEFINED ENV{ANDROID})
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${LIBICONV_DIR}/lib -L${GETTEXT_DIR}/lib")
 endif()
 
 # took me an eternity to find $<SEMICOLON>
@@ -48,25 +44,48 @@ endif()
 set(GLIB2_INCLUDE_DIRS "${GLIB_DIR}/include/glib-2.0")
 set(GLIB2_INCLUDE_DIRS "${GLIB2_INCLUDE_DIRS}$<SEMICOLON>${GLIB_DIR}/lib/glib-2.0/include")
 set(GLIB2_LIBRARIES "${GLIB}")
-# glib2 also needs to link with libiconv and gettext
-# this is the only cleanish hack I've been able to come up with
-# CMAKE_CXX_FLAGS doesn't seem to have much of an effect
-if($ENV{ANDROID})
+
+# `CMAKE_PREFIX_PATH`, `CMAKE_INCLUDE_PATH` and `CMAKE_LIBRARY_PATH` are key
+# It's very hard to tell CMake to use specific directories, but it's easy to
+# tell it to search in specific directories.
+set(CMAKE_PREFIX_PATH "${GLIB2_INCLUDE_DIRS}$<SEMICOLON>${ZLIB_DIR}$<SEMICOLON>${LIBICONV_DIR}$<SEMICOLON>${GETTEXT_DIR}") 
+
+# For some reason this doesn't actually work and CMake keeps finding mostly .so
+# Which is funny, because the .a is in the *same* directory. Just saying.
+# Instead we add semi-hardcoded references to the right libraries in GLIB2_LIBRARIES
+if(DEFINED ENV{ANDROID})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+
+    # glib2 also needs to link with libiconv and gettext
+    # this is a fairly clean hack
+    # CMAKE_CXX_FLAGS with -I and -L doesn't seem to have much of an effect
     set(GLIB2_LIBRARIES "${GLIB2_LIBRARIES}$<SEMICOLON>${LIBICONV_DIR}/lib/libiconv.a$<SEMICOLON>${GETTEXT_DIR}/lib/libintl.a")
 endif()
 
 
 set(ZLIB_INCLUDE_DIR "${ZLIB_DIR}/include")
 set(ZLIB_LIBRARIES "${ZLIB}")
-# f*ck cmake, I just want to be able to -I and -L and have things work
+# I just want to be able to -I and -L and have things work. CMake, CMake...
 set(ZLIB_LIBRARY_RELEASE "${ZLIB}")
 
-# includes and libraries
+### Includes and libraries
+# By overspecifying the heck out of everything we hope to force CMake into the
+# equivalent of a couple of simple -I and -L flags because the proper method
+# with CMAKE_PREFIX_PATH and CMAKE_FIND_LIBRARY_SUFFIXES does. not. work
 set(CFG_OPTS "-DGLIB2_INCLUDE_DIRS='${GLIB2_INCLUDE_DIRS}' -DGLIB2_LIBRARIES='${GLIB2_LIBRARIES}' -DZLIB_INCLUDE_DIR='${ZLIB_INCLUDE_DIR}' -DZLIB_LIBRARIES='${ZLIB_LIBRARIES}' -DZLIB_LIBRARY_RELEASE='${ZLIB_LIBRARY_RELEASE}'")
-# compiler and linker flags
+# These are the directories where we tell CMake to search for libs and includes
+set(CFG_OPTS "${CFG_OPTS} -DCMAKE_PREFIX_PATH='${CMAKE_PREFIX_PATH}'")
+if(DEFINED ENV{ANDROID})
+    # the default `;` causes escape issues
+    # we could escape it but on Android we only want .a and otherwise the default
+    set(CFG_OPTS "${CFG_OPTS} -DCMAKE_FIND_LIBRARY_SUFFIXES='${CMAKE_FIND_LIBRARY_SUFFIXES}'")
+endif()
+### Compiler and linker flags
 set(CFG_OPTS "${CFG_OPTS} -DCMAKE_CXX_COMPILER='${CMAKE_CXX_COMPILER}' -DCMAKE_CXX_COMPILER_LAUNCHER='${CMAKE_CXX_COMPILER_LAUNCHER}' -DCMAKE_CXX_COMPILER_ARG1='${CMAKE_CXX_COMPILER_ARG1}' -DCMAKE_CXX_FLAGS='${CMAKE_CXX_FLAGS}' -DCMAKE_EXE_LINKER_FLAGS='${CMAKE_EXE_LINKER_FLAGS}'")
-# disable some stuff we don't need
+### Disable some sdcv stuff we don't need
 set(CFG_OPTS "${CFG_OPTS} -DENABLE_NLS:BOOL=False -DWITH_READLINE:BOOL=False")
+### Disable the silly build tree RPATH
+set(CFG_OPTS "${CFG_OPTS} -DCMAKE_SKIP_BUILD_RPATH:BOOL=True")
 set(CFG_CMD sh -c "${CMAKE_COMMAND} ${CFG_OPTS}")
 
 ko_write_gitclone_script(

--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -8,24 +8,71 @@ include("koreader_thirdparty_git")
 enable_language(C CXX)
 
 assert_var_defined(PKG_CONFIG_PATH)
-assert_var_defined(CXX)
-assert_var_defined(CXXFLAGS)
+assert_var_defined(CMAKE_CXX_COMPILER)
+assert_var_defined(CMAKE_CXX_COMPILER_LAUNCHER)
+assert_var_defined(CMAKE_CXX_COMPILER_ARG1)
 assert_var_defined(LDFLAGS)
-assert_var_defined(LIBS)
 assert_var_defined(HOST)
+assert_var_defined(GETTEXT_DIR)
+assert_var_defined(LIBICONV_DIR)
+assert_var_defined(GLIB)
+assert_var_defined(GLIB_DIR)
+assert_var_defined(ZLIB)
+assert_var_defined(ZLIB_DIR)
 
 ep_get_source_dir(SOURCE_DIR)
 
-set(PATCH_CMD "${ISED} 's|-lz||' configure.ac && ${ISED} 's|-lz||' configure")
-set(PATCH_CMD sh -c "${PATCH_CMD}")
+if($ENV{ANDROID})
+    set(CRIPPLED_BY_ANDROID_FILES "${SOURCE_DIR}/src/libwrapper.cpp ${SOURCE_DIR}/src/sdcv.cpp ${SOURCE_DIR}/src/utils.cpp")
+    set(PATCH_CMD "${ISED} 's|_(|(|' ${CRIPPLED_BY_ANDROID_FILES}")
+    set(PATCH_CMD "${PATCH_CMD} && ${ISED} 's|#include <glib/gi18n.h>||' ${CRIPPLED_BY_ANDROID_FILES}")
+    set(PATCH_CMD sh -c "${PATCH_CMD}")
+endif()
 
-set(CFG_OPTS "--host=\"${HOST}\" PKG_CONFIG_PATH=\"${PKG_CONFIG_PATH}\" CXX=\"${CXX}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\" LIBS=\"${LIBS}\"")
-set(CFG_CMD sh -c "${SOURCE_DIR}/configure ${CFG_OPTS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I$(ZLIB_DIR)")
+if($ENV{ANDROID})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${LIBICONV_DIR}/include -I${GETTEXT_DIR}/include")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lpthread -lrt")
+endif()
+
+# because cmake needs all kinds of annoying special cmake variables
+set(CMAKE_EXE_LINKER_FLAGS "${LDFLAGS} -static-libgcc -static-libstdc++")
+if($ENV{ANDROID})
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${LIBICONV_DIR}/lib -L${GETTEXT_DIR}/lib")
+endif()
+
+# took me an eternity to find $<SEMICOLON>
+# important docs here https://cmake.org/cmake/help/v2.8.11/cmake.html#command:add_custom_command
+set(GLIB2_INCLUDE_DIRS "${GLIB_DIR}/include/glib-2.0")
+set(GLIB2_INCLUDE_DIRS "${GLIB2_INCLUDE_DIRS}$<SEMICOLON>${GLIB_DIR}/lib/glib-2.0/include")
+set(GLIB2_LIBRARIES "${GLIB}")
+# glib2 also needs to link with libiconv and gettext
+# this is the only cleanish hack I've been able to come up with
+# CMAKE_CXX_FLAGS doesn't seem to have much of an effect
+if($ENV{ANDROID})
+    set(GLIB2_LIBRARIES "${GLIB2_LIBRARIES}$<SEMICOLON>${LIBICONV_DIR}/lib/libiconv.a$<SEMICOLON>${GETTEXT_DIR}/lib/libintl.a")
+endif()
+
+
+set(ZLIB_INCLUDE_DIR "${ZLIB_DIR}/include")
+set(ZLIB_LIBRARIES "${ZLIB}")
+# f*ck cmake, I just want to be able to -I and -L and have things work
+set(ZLIB_LIBRARY_RELEASE "${ZLIB}")
+
+# includes and libraries
+set(CFG_OPTS "-DGLIB2_INCLUDE_DIRS='${GLIB2_INCLUDE_DIRS}' -DGLIB2_LIBRARIES='${GLIB2_LIBRARIES}' -DZLIB_INCLUDE_DIR='${ZLIB_INCLUDE_DIR}' -DZLIB_LIBRARIES='${ZLIB_LIBRARIES}' -DZLIB_LIBRARY_RELEASE='${ZLIB_LIBRARY_RELEASE}'")
+# compiler and linker flags
+set(CFG_OPTS "${CFG_OPTS} -DCMAKE_CXX_COMPILER='${CMAKE_CXX_COMPILER}' -DCMAKE_CXX_COMPILER_LAUNCHER='${CMAKE_CXX_COMPILER_LAUNCHER}' -DCMAKE_CXX_COMPILER_ARG1='${CMAKE_CXX_COMPILER_ARG1}' -DCMAKE_CXX_FLAGS='${CMAKE_CXX_FLAGS}' -DCMAKE_EXE_LINKER_FLAGS='${CMAKE_EXE_LINKER_FLAGS}'")
+# disable some stuff we don't need
+set(CFG_OPTS "${CFG_OPTS} -DENABLE_NLS:BOOL=False -DWITH_READLINE:BOOL=False")
+set(CFG_CMD sh -c "${CMAKE_COMMAND} ${CFG_OPTS}")
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
-    git://github.com/koreader/sdcv.git
-    fdf7da2cbf52f40724c0146b9bd31de376901708
+    https://github.com/Dushistov/sdcv.git
+    v0.5.2
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Deprecates our fork because we've got all improvements included upstream now.

<hr>

Tagged WIP because there are a couple of things remaining that need to be fixed, probably only for Android.