### PR TITLE
sdcv patch: allow utf8 encoded or not-found -u dictnames

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -87,6 +87,8 @@ set(CFG_OPTS "${CFG_OPTS} -DENABLE_NLS:BOOL=False -DWITH_READLINE:BOOL=False")
 ### Disable the silly build tree RPATH
 set(CFG_OPTS "${CFG_OPTS} -DCMAKE_SKIP_BUILD_RPATH:BOOL=True")
 set(CFG_CMD sh -c "${CMAKE_COMMAND} ${CFG_OPTS}")
+# Force utf8 command line parsing, and accept not-found -u dictnames
+set(PATCH_CMD2 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/sdcv.patch || true")
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
@@ -100,7 +102,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND ${PATCH_CMD}
+    PATCH_COMMAND COMMAND ${PATCH_CMD} COMMAND ${PATCH_CMD2}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND $(MAKE) -j${PARALLEL_JOBS}
     # skip install

--- a/thirdparty/sdcv/sdcv.patch
+++ b/thirdparty/sdcv/sdcv.patch
@@ -1,0 +1,24 @@
+diff --git a/src/sdcv.cpp b/src/sdcv.cpp
+index 0c75eb1..f0dee2b 100644
+--- a/src/sdcv.cpp
++++ b/src/sdcv.cpp
+@@ -62,7 +62,7 @@ using StrArr = ResourceWrapper<gchar *, gchar *, free_str_array>;
+ static void list_dicts(const std::list<std::string> &dicts_dir_list, bool use_json);
+ 
+ int main(int argc, char *argv[]) try {
+-    setlocale(LC_ALL, "");
++    setlocale(LC_ALL, "en_US.UTF-8");
+ #if ENABLE_NLS
+     bindtextdomain("sdcv",
+                    //"./locale"//< for testing
+@@ -182,7 +182,9 @@ int main(int argc, char *argv[]) try {
+         // add bookname to list
+         gchar **p = get_impl(use_dict_list);
+         while (*p) {
+-            order_list.push_back(bookname_to_ifo.at(*p));
++            if (bookname_to_ifo.count(*p) > 0) {
++                order_list.push_back(bookname_to_ifo.at(*p));
++            }
+             ++p;
+         }
+     } else {


### PR DESCRIPTION
(temporary) patch to have Enabling/Disabling dictionaries working with sdcv 0.5.2.
See https://github.com/koreader/koreader/pull/3378