### PR TITLE
sdcv patch: allow utf8 encoded in -u dictnames (try 2)

### DIFF
--- a/thirdparty/sdcv/sdcv.patch
+++ b/thirdparty/sdcv/sdcv.patch
@@ -1,16 +1,25 @@
 diff --git a/src/sdcv.cpp b/src/sdcv.cpp
-index 0c75eb1..f0dee2b 100644
+index 0c75eb1..da3ff4c 100644
 --- a/src/sdcv.cpp
 +++ b/src/sdcv.cpp
-@@ -62,7 +62,7 @@ using StrArr = ResourceWrapper<gchar *, gchar *, free_str_array>;
- static void list_dicts(const std::list<std::string> &dicts_dir_list, bool use_json);
- 
- int main(int argc, char *argv[]) try {
--    setlocale(LC_ALL, "");
-+    setlocale(LC_ALL, "en_US.UTF-8");
- #if ENABLE_NLS
-     bindtextdomain("sdcv",
-                    //"./locale"//< for testing
+@@ -88,7 +88,7 @@ int main(int argc, char *argv[]) try {
+           _("display version information and exit"), nullptr },
+         { "list-dicts", 'l', 0, G_OPTION_ARG_NONE, &show_list_dicts,
+           _("display list of available dictionaries and exit"), nullptr },
+-        { "use-dict", 'u', 0, G_OPTION_ARG_STRING_ARRAY, get_addr(use_dict_list),
++        { "use-dict", 'u', 0, G_OPTION_ARG_FILENAME_ARRAY, get_addr(use_dict_list),
+           _("for search use only dictionary with this bookname"),
+           _("bookname") },
+         { "non-interactive", 'n', 0, G_OPTION_ARG_NONE, &non_interactive,
+@@ -101,7 +101,7 @@ int main(int argc, char *argv[]) try {
+           _("output must be in utf8"), nullptr },
+         { "utf8-input", '1', 0, G_OPTION_ARG_NONE, &utf8_input,
+           _("input of sdcv in utf8"), nullptr },
+-        { "data-dir", '2', 0, G_OPTION_ARG_STRING, get_addr(opt_data_dir),
++        { "data-dir", '2', 0, G_OPTION_ARG_FILENAME, get_addr(opt_data_dir),
+           _("use this directory as path to stardict data directory"),
+           _("path/to/dir") },
+         { "only-data-dir", 'x', 0, G_OPTION_ARG_NONE, &only_data_dir,
 @@ -182,7 +182,9 @@ int main(int argc, char *argv[]) try {
          // add bookname to list
          gchar **p = get_impl(use_dict_list);


### PR DESCRIPTION
Second attempt at solving this problem. See https://github.com/koreader/koreader/pull/3378#issuecomment-338478405