### PR TITLE
[build] Add -debug suffix to KODEBUG build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.defs
 
 # main target
-all: check-luajit-clean $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
+all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(USE_LUAJIT_LIB),$(LUAJIT_LIB),) \
 		$(LUAJIT_JIT) \
 		libs $(K2PDFOPT_LIB) \
@@ -180,16 +180,6 @@ dist-clean:
 
 luajit-clean:
 	$(MAKE) -C $(LUAJIT_DIR) clean
-
-.PHONY: check-luajit-clean
-
-KODEBUG_OLD=`cat kodebug-$(TARGET) 2>/dev/null`
-check-luajit-clean:
-	if ! test "$(KODEBUG)" = "$(KODEBUG_OLD)" ; then \
-		echo "KODEBUG variable changed; calling luajit-clean"; \
-		$(MAKE) luajit-clean; \
-	fi; \
-	echo "$(KODEBUG)" >kodebug-$(TARGET)
 
 # ===========================================================================
 # start of unit tests section

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -18,6 +18,15 @@ ANDROID_TOOLCHAIN=$(TOOLCHAIN_DIR)/android-toolchain-$(ANDROID_ARCH)
 NDK?=$(TOOLCHAIN_DIR)/android-ndk-r15c
 NDKABI?=9
 
+# set debug-related variables to cascade down
+ifdef KODEBUG
+	DEBUG:=$(KODEBUG)
+	export DEBUG
+	# will have to be passed as -DCMAKE_BUILD_TYPE to $(CMAKE) invocations
+	CMAKE_BUILD_TYPE:=Debug
+	export CMAKE_BUILD_TYPE
+endif
+
 # CMAKE=cmake --no-warn-unused-cli
 CMAKE=cmake
 
@@ -376,7 +385,8 @@ endif
 
 # this will create a path named build/arm-none-linux-gnueabi or similar
 MACHINE?=$(shell PATH='$(PATH)' $(CC) -dumpmachine 2>/dev/null)
-ifdef DEBUG
+ifdef KODEBUG
+    MACHINE:=$(MACHINE)-debug
     $(info ************ Building for MACHINE: "$(MACHINE)" **********)
     $(info ************ PATH: "$(PATH)" **********)
     $(info ************ CHOST: "$(CHOST)" **********)


### PR DESCRIPTION
Cleaning and rebuilding to get a build with and
without debugging symbols is freaking annoying.