### PR TITLE
Implement event-injection for PocketBook to control auto-suspension 

### DIFF
--- a/input/input-pocketbook.h
+++ b/input/input-pocketbook.h
@@ -123,7 +123,7 @@ void enable_suspend(void) {
 
 static external_suspend_control = 0;
 void fallback_enable_suspend(void) {
-	if (external_suspend_control)
+	if (external_suspend_control == 0)
 		enable_suspend();
 }
 

--- a/input/input-pocketbook.h
+++ b/input/input-pocketbook.h
@@ -121,7 +121,7 @@ void enable_suspend(void) {
 	iv_sleepmode(1);
 }
 
-static external_suspend_control = 0;
+static int external_suspend_control = 0;
 void fallback_enable_suspend(void) {
 	if (external_suspend_control == 0)
 		enable_suspend();

--- a/input/input-pocketbook.h
+++ b/input/input-pocketbook.h
@@ -122,6 +122,7 @@ void enable_suspend(void) {
 }
 
 static int external_suspend_control = 0;
+
 void fallback_enable_suspend(void) {
 	if (external_suspend_control == 0)
 		enable_suspend();
@@ -131,8 +132,8 @@ static int send_to_event_handler(int type, int par1, int par2) {
 	SendEventTo(GetCurrentTask(), type, par1, par2);
 }
 
+
 static int setSuspendState(lua_State *L) {
-	external_suspend_control = 1;
 	send_to_event_handler(
 			PB_SPECIAL_SUSPEND, 
 			luaL_checkint(L, 1), 
@@ -146,6 +147,7 @@ static int pb_event_handler(int type, int par1, int par2) {
     // fflush(stdout);
     int i;
     iv_mtinfo *mti;
+
     // general settings in only possible in forked process
     if (type == EVT_INIT) {
         SetPanelType(PANEL_DISABLED);
@@ -203,6 +205,7 @@ static int pb_event_handler(int type, int par1, int par2) {
         }
         touch_pointers = 0;
     } else if (type == PB_SPECIAL_SUSPEND) {
+	external_suspend_control = 1;
 	if (par1 == 0)
 		SetHardTimer("disable_suspend", disable_suspend, par2);
 	else

--- a/input/input-pocketbook.h
+++ b/input/input-pocketbook.h
@@ -127,6 +127,19 @@ void fallback_enable_suspend(void) {
 		enable_suspend();
 }
 
+static int send_to_event_handler(int type, int par1, int par2) {
+	SendEventTo(GetCurrentTask(), type, par1, par2);
+}
+
+static int setSuspendState(lua_State *L) {
+	external_suspend_control = 1;
+	send_to_event_handler(
+			PB_SPECIAL_SUSPEND, 
+			luaL_checkint(L, 1), 
+			luaL_checkint(L,2)
+			);
+}
+
 int touch_pointers = 0;
 static int pb_event_handler(int type, int par1, int par2) {
     // printf("ev:%d %d %d\n", type, par1, par2);
@@ -198,15 +211,6 @@ static int pb_event_handler(int type, int par1, int par2) {
         genEmuEvent(inputfds[0], type, par1, par2);
     }
     return 0;
-}
-
-static int send_to_event_handler(int type, int par1, int par2) {
-	SendEventTo(GetCurrentTask(), type, par1, par2);
-}
-
-static int setSuspendState(lua_State *L) {
-	external_suspend_control = 1;
-	send_to_event_handler(PB_SPECIAL_SUSPEND, luaL_checkint(L, 1), luaL_checkint(L,2));
 }
 
 static int forkInkViewMain(lua_State *L, const char *inputdevice) {

--- a/input/input.c
+++ b/input/input.c
@@ -261,6 +261,9 @@ static const struct luaL_Reg input_func[] = {
     {"closeAll", closeInputDevices},
     {"waitForEvent", waitForInput},
     {"fakeTapInput", fakeTapInput},
+#ifdef POCKETBOOK
+    {"setSuspendState", setSuspendState},
+#endif
     {NULL, NULL}
 };
 


### PR DESCRIPTION
This PR implements event-injection to control the automatic system-suspension on PB-devices.  See long comment in `input/input-pocketbook.h` for a more detailed description.

Fixes https://github.com/koreader/koreader/issues/3419 in a  way, as suspending is deactivated on start and re-enabled after 60 seconds which should be enough for the initial loading of plugins and book.

In the future this will be controlled from a koreader-plugin which re-enables suspension on onReaderReady() and may disable it while menus are open to smoothen the overall user-experience.