### PR TITLE
cblitbuffer: fix alpha in some bb conversions, and add a few more

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -509,6 +509,7 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                 dstptr->r = srcptr->a;
                 dstptr->g = srcptr->a;
                 dstptr->b = srcptr->a;
+                dstptr->alpha = 0xFF;
                 o_y += 1;
             }
             o_x += 1;
@@ -524,6 +525,7 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                 dstptr->r = srcptr->a;
                 dstptr->g = srcptr->a;
                 dstptr->b = srcptr->a;
+                dstptr->alpha = srcptr->alpha; // if bad result, try: 0xFF - srcptr->alpha
                 o_y += 1;
             }
             o_x += 1;
@@ -539,6 +541,7 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                 dstptr->r = ColorRGB16_GetR(srcptr->v);
                 dstptr->g = ColorRGB16_GetG(srcptr->v);
                 dstptr->b = ColorRGB16_GetB(srcptr->v);
+                dstptr->alpha = 0xFF;
                 o_y += 1;
             }
             o_x += 1;
@@ -554,6 +557,7 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                 dstptr->r = srcptr->r;
                 dstptr->g = srcptr->g;
                 dstptr->b = srcptr->b;
+                dstptr->alpha = 0xFF;
                 o_y += 1;
             }
             o_x += 1;
@@ -771,6 +775,24 @@ void BB_alpha_blit_from(BlitBuffer *dst, BlitBuffer *src,
                 dstptr->r = srcptr->r;
                 dstptr->g = srcptr->g;
                 dstptr->b = srcptr->b;
+                dstptr->alpha = 0xFF;
+                o_y += 1;
+            }
+            o_x += 1;
+        }
+    } else if (dbb_type == TYPE_BBRGB32 && sbb_type == TYPE_BB8) {
+        o_x = offs_x;
+        ColorRGB32 *dstptr;
+        Color8 *srcptr;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB32, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, Color8, o_x, o_y, &srcptr);
+                dstptr->r = srcptr->a;
+                dstptr->g = srcptr->a;
+                dstptr->b = srcptr->a;
+                dstptr->alpha = 0xFF;
                 o_y += 1;
             }
             o_x += 1;

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -797,6 +797,23 @@ void BB_alpha_blit_from(BlitBuffer *dst, BlitBuffer *src,
             }
             o_x += 1;
         }
+    } else if (dbb_type == TYPE_BBRGB32 && sbb_type == TYPE_BB8A) {
+        o_x = offs_x;
+        ColorRGB32 *dstptr;
+        Color8A *srcptr;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB32, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, Color8A, o_x, o_y, &srcptr);
+                dstptr->r = srcptr->a;
+                dstptr->g = srcptr->a;
+                dstptr->b = srcptr->a;
+                dstptr->alpha = srcptr->alpha; // if bad result, try: 0xFF - srcptr->alpha
+                o_y += 1;
+            }
+            o_x += 1;
+        }
     } else {
         fprintf(stderr, "incompatible bb (dst: %d, src: %d) in file %s, line %d!\r\n",
                 dbb_type, sbb_type, __FILE__, __LINE__); exit(1);

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -622,6 +622,10 @@ function mupdf.renderImage(data, size, width, height)
     W.mupdf_drop_buffer(context(), buffer)
     if image == nil then merror("could not load image data") end
     M.fz_keep_image(context(), image)
+    -- Note: mupdf1.12 (unlike mupdf1.8) may incorrectly guess the
+    -- nb of channels of a jpeg image (image.n = 3 instead of 1 for
+    -- some greyscale jpeg), resulting in the following call
+    -- outputing "padding truncated image" and a corrupted image.
     local pixmap = W.mupdf_get_pixmap_from_image(context(),
                     image, nil, nil, nil, nil)
     M.fz_drop_image(context(), image)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -633,12 +633,19 @@ function mupdf.renderImage(data, size, width, height)
     local p_height = M.fz_pixmap_height(context(), pixmap)
     -- mupdf_get_pixmap_from_image() may not scale image to the
     -- width and height provided, so check and scale it if needed
-    if width and height and (p_width ~= width or p_height ~= height) then
-        local scaled_pixmap = M.fz_scale_pixmap(context(), pixmap, 0, 0, width, height, nil)
-        M.fz_drop_pixmap(context(), pixmap)
-        pixmap = scaled_pixmap
-        p_width = M.fz_pixmap_width(context(), pixmap)
-        p_height = M.fz_pixmap_height(context(), pixmap)
+    if width and height then
+        -- MuPDF 1.12 fz_scale_pixmap() may behave strangely (on ARM only!)
+        -- if it is given non-integer width and height, and returns a corrupted
+        -- image with a different ncomp than original pixmap...)
+        width = math.floor(width)
+        height = math.floor(height)
+        if p_width ~= width or p_height ~= height then
+            local scaled_pixmap = M.fz_scale_pixmap(context(), pixmap, 0, 0, width, height, nil)
+            M.fz_drop_pixmap(context(), pixmap)
+            pixmap = scaled_pixmap
+            p_width = M.fz_pixmap_width(context(), pixmap)
+            p_height = M.fz_pixmap_height(context(), pixmap)
+        end
     end
     local bbtype
     local ncomp = M.fz_pixmap_components(context(), pixmap)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -622,10 +622,6 @@ function mupdf.renderImage(data, size, width, height)
     W.mupdf_drop_buffer(context(), buffer)
     if image == nil then merror("could not load image data") end
     M.fz_keep_image(context(), image)
-    -- Note: mupdf1.12 (unlike mupdf1.8) may incorrectly guess the
-    -- nb of channels of a jpeg image (image.n = 3 instead of 1 for
-    -- some greyscale jpeg), resulting in the following call
-    -- outputing "padding truncated image" and a corrupted image.
     local pixmap = W.mupdf_get_pixmap_from_image(context(),
                     image, nil, nil, nil, nil)
     M.fz_drop_image(context(), image)


### PR DESCRIPTION
This is about the cblitbuffer code used on the emulator (and android, although for some reason, I didn't notice the following problems on my android phone with the latest nightly...) and the new bbtypes we may get from the new mupdf 1.12.

Mupdf 1.8 used to always return BB8A or RGB32 from renderImage code.
Mupdf 1.12 now can return BB8 (from a greyscale jpeg) and RGB24 (from a color jpeg).
When viewing images from epub with ImageViewer, they would be fine when not scaled. But when scaled, they need to be blitted to a RGB32, and the cblitbuffer code would blit these BB8 or RGB24 with a full transparency, making the image full white. This sets a correct alpha of 0xFF so that no transparency is added (as BB8 and RGB24 do not carry any alpha info).
@chrox : do these additions look ok to you? (I'm not really at ease with all this alpha stuff - and I guess there may be other places that need this kind of alpha fixes - but these were the only ones I could somehow test).

Also added support for alpha_blitting from BB8 (greyscale jpeg) to RGB32, as this can happen when viewing greyscale jpeg cover images, and it would otherwise cause a crash.

Also added a note in mupdf.lua about a regression in Mupdf1.12 with some jpeg images:
https://upload.wikimedia.org/wikipedia/commons/0/0e/Death_of_Darius_by_Andre_Castaigne_cropped.jpg would display fine, but the resized (by wikipedia servers) version https://upload.wikimedia.org/wikipedia/commons/thumb/0/0e/Death_of_Darius_by_Andre_Castaigne_cropped.jpg/440px-Death_of_Darius_by_Andre_Castaigne_cropped.jpg is displayed as:
![bad](https://user-images.githubusercontent.com/24273478/34445858-e0f95c62-ecd6-11e7-9abc-2bead0fde1f1.png)
Tested that this happens too with the mupdf 1.12 windows applet, while the 1.8 windows applet displays it fine (so, it's not some libjpeg mismatch on our side).

