### PR TITLE
MuPDF document loading from memory, Noto Sans support

### DIFF
--- a/ffi-cdecl/mupdf_decl.c
+++ b/ffi-cdecl/mupdf_decl.c
@@ -86,10 +86,12 @@ cdecl_struct(fz_document_s)
 cdecl_struct(fz_page_s)
 
 cdecl_func(mupdf_open_document)
+cdecl_func(mupdf_open_document_with_stream)
 cdecl_func(fz_needs_password)
 cdecl_func(fz_authenticate_password)
 cdecl_func(fz_drop_document) // NOTE: libk2pdfopt uses old fz_free_document symbol
 cdecl_func(mupdf_count_pages)
+cdecl_func(mupdf_layout_document)
 cdecl_func(fz_lookup_metadata)
 cdecl_func(fz_resolve_link)
 
@@ -106,6 +108,10 @@ cdecl_func(fz_drop_link)
 /* outline */
 cdecl_func(mupdf_load_outline)
 cdecl_func(fz_drop_outline) // NOTE: libk2pdfopt uses old fz_free_outline symbol
+
+/* stream */
+cdecl_func(mupdf_drop_stream)
+cdecl_func(mupdf_open_memory)
 
 /* structured text */
 cdecl_type(fz_stext_char)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -646,7 +646,6 @@ function mupdf.renderImage(data, size, width, height)
     local image = W.mupdf_new_image_from_buffer(context(), buffer)
     W.mupdf_drop_buffer(context(), buffer)
     if image == nil then merror("could not load image data") end
-    M.fz_keep_image(context(), image)
     local pixmap = W.mupdf_get_pixmap_from_image(context(),
                     image, nil, nil, nil, nil)
     M.fz_drop_image(context(), image)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -100,12 +100,10 @@ end
 function mupdf.openDocumentFromText(text, magic)
     M.fz_register_document_handlers(context())
 
-    stream = W.mupdf_open_memory(context(), ffi.cast("const unsigned char*", text), #text)
-
+    local stream = W.mupdf_open_memory(context(), ffi.cast("const unsigned char*", text), #text)
     local mupdf_doc = {
         doc = W.mupdf_open_document_with_stream(context(), magic, stream),
     }
-
     W.mupdf_drop_stream(context(), stream)
 
     if mupdf_doc.doc == nil then

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -180,10 +180,12 @@ struct fz_page_s {
   int (*overprint)(fz_context *, fz_page *);
 };
 fz_document *mupdf_open_document(fz_context *, const char *);
+fz_document *mupdf_open_document_with_stream(fz_context *, const char *, struct fz_stream_s *);
 int fz_needs_password(fz_context *, fz_document *);
 int fz_authenticate_password(fz_context *, fz_document *, const char *);
 void fz_drop_document(fz_context *, fz_document *);
 int mupdf_count_pages(fz_context *, fz_document *);
+void *mupdf_layout_document(fz_context *, fz_document *, float, float, float);
 int fz_lookup_metadata(fz_context *, fz_document *, const char *, char *, int);
 int fz_resolve_link(fz_context *, fz_document *, const char *, float *, float *);
 fz_page *mupdf_load_page(fz_context *, fz_document *, int);
@@ -200,6 +202,8 @@ fz_link *mupdf_load_links(fz_context *, fz_page *);
 void fz_drop_link(fz_context *, fz_link *);
 fz_outline *mupdf_load_outline(fz_context *, fz_document *);
 void fz_drop_outline(fz_context *, fz_outline *);
+void *mupdf_drop_stream(fz_context *, struct fz_stream_s *);
+struct fz_stream_s *mupdf_open_memory(fz_context *, const unsigned char *, long unsigned int);
 typedef struct fz_stext_char_s fz_stext_char;
 struct fz_stext_char_s {
   int c;

--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -47,7 +47,7 @@ index e197fa1b..8b74c624 100644
  
  fz_font *fz_load_system_font(fz_context *ctx, const char *name, int bold, int italic, int needs_exact_metrics)
 diff --git a/source/fitz/noto.c b/source/fitz/noto.c
-index f6951ba2..40188875 100644
+index f6951ba2..bc338184 100644
 --- a/source/fitz/noto.c
 +++ b/source/fitz/noto.c
 @@ -1,8 +1,12 @@
@@ -63,7 +63,7 @@ index f6951ba2..40188875 100644
  /*
  	Base 14 PDF fonts from URW.
  	Noto fonts from Google.
-@@ -367,3 +371,122 @@ fz_lookup_noto_emoji_font(fz_context *ctx, int *size)
+@@ -367,3 +371,134 @@ fz_lookup_noto_emoji_font(fz_context *ctx, int *size)
  	return *size = 0, NULL;
  #endif
  }
@@ -122,6 +122,18 @@ index f6951ba2..40188875 100644
 +	}
 +	if (!strcmp("Helvetica-BoldOblique", name)) {
 +		return get_font_file("urw/NimbusSanL-BolIta.cff");
++	}
++	if (!strcmp("NotoSans", name)) {
++		return get_font_file("noto/NotoSans-Regular.ttf");
++	}
++	if (!strcmp("NotoSans-Bold", name)) {
++		return get_font_file("noto/NotoSans-Bold.ttf");
++	}
++	if (!strcmp("NotoSans-BoldItalic", name)) {
++		return get_font_file("noto/NotoSans-BoldItalic.ttf");
++	}
++	if (!strcmp("NotoSans-Italic", name)) {
++		return get_font_file("noto/NotoSans-Italic.ttf");
 +	}
 +	if (!strcmp("Times-Roman", name)) {
 +		return get_font_file("urw/NimbusRomNo9L-Reg.cff");
@@ -187,16 +199,26 @@ index f6951ba2..40188875 100644
 +
 +#endif
 diff --git a/source/html/html-font.c b/source/html/html-font.c
-index d319a462..bb59e0d6 100644
+index d319a462..49ac58df 100644
 --- a/source/html/html-font.c
 +++ b/source/html/html-font.c
-@@ -3,6 +3,37 @@
+@@ -3,6 +3,47 @@
  
  #include <string.h>
  
 +char *
-+html_lookup_substitute_font_from_file(fz_context *ctx, int mono, int serif, int bold, int italic)
++html_lookup_substitute_font_from_file(fz_context *ctx, const char *fontname, int mono, int serif, int bold, int italic)
 +{
++	if (strcmp(fontname, "Noto Sans") == 0) {
++		if (bold) {
++			if (italic) return fz_lookup_base14_font_from_file(ctx, "NotoSans-BoldItalic");
++			else return fz_lookup_base14_font_from_file(ctx, "NotoSans-Bold");
++		} else {
++			if (italic) return fz_lookup_base14_font_from_file(ctx, "NotoSans-Italic");
++			else return fz_lookup_base14_font_from_file(ctx, "NotoSans");
++		}
++	}
++
 +	if (mono) {
 +		if (bold) {
 +			if (italic) return fz_lookup_base14_font_from_file(ctx, "Courier-BoldOblique");
@@ -228,7 +250,7 @@ index d319a462..bb59e0d6 100644
  static fz_font *
  fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *family, int is_bold, int is_italic)
  {
-@@ -13,6 +44,7 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
+@@ -13,6 +54,7 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
  	int idx = (is_mono ? 8 : is_sans ? 4 : 0) + is_bold * 2 + is_italic;
  	if (!set->fonts[idx])
  	{
@@ -236,20 +258,30 @@ index d319a462..bb59e0d6 100644
  		const unsigned char *data;
  		int size;
  
-@@ -23,6 +55,13 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
+@@ -23,6 +65,14 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
  			fz_throw(ctx, FZ_ERROR_GENERIC, "cannot load html font: %s", real_family);
  		set->fonts[idx] = fz_new_font_from_memory(ctx, NULL, data, size, 0, 1);
  		fz_font_flags(set->fonts[idx])->is_serif = !is_sans;
 +#else
-+		char * filename = html_lookup_substitute_font_from_file(ctx, is_mono, !is_sans, is_bold, is_italic);
++		char * filename = html_lookup_substitute_font_from_file(ctx, family, is_mono, !is_sans, is_bold, is_italic);
 +		if (!filename)
 +			fz_throw(ctx, FZ_ERROR_GENERIC, "cannot load html font");
 +
 +		set->fonts[idx] = fz_new_font_from_file(ctx, NULL, filename, 0, 1);
++		fz_font_flags(set->fonts[idx])->is_serif = !is_sans;
 +#endif
  	}
  	return set->fonts[idx];
  }
+@@ -73,7 +123,7 @@ fz_load_html_font(fz_context *ctx, fz_html_font_set *set, const char *family, in
+ 		return font;
+ 	}
+ 
+-	if (!strcmp(family, "monospace") || !strcmp(family, "sans-serif") || !strcmp(family, "serif"))
++	if (!strcmp(family, "monospace") || !strcmp(family, "sans-serif") || !strcmp(family, "serif") || !strcmp(family, "Noto Sans"))
+ 		return fz_load_html_default_font(ctx, set, family, is_bold, is_italic);
+ 
+ 	return NULL;
 diff --git a/source/pdf/pdf-font.c b/source/pdf/pdf-font.c
 index be69ce1c..a24b2122 100644
 --- a/source/pdf/pdf-font.c

--- a/wrap-mupdf.h
+++ b/wrap-mupdf.h
@@ -60,9 +60,21 @@ extern char* mupdf_error_message(fz_context *ctx);
 MUPDF_WRAP(mupdf_open_document, fz_document*, NULL,
     ret = fz_open_document(ctx, filename),
     const char* filename)
+MUPDF_WRAP(mupdf_open_document_with_stream, fz_document*, NULL,
+    ret = fz_open_document_with_stream(ctx, magic, stream),
+    const char *magic, fz_stream *stream)
+MUPDF_WRAP(mupdf_open_memory, fz_stream*, NULL,
+    ret = fz_open_memory(ctx, data, len),
+    const unsigned char *data, size_t len)
+MUPDF_WRAP(mupdf_drop_stream, void*, NULL,
+    { fz_drop_stream(ctx, stm); ret = (void*) -1; },
+    fz_stream *stm)
 MUPDF_WRAP(mupdf_count_pages, int, -1,
     ret = fz_count_pages(ctx, doc),
     fz_document *doc)
+MUPDF_WRAP(mupdf_layout_document, void*, NULL,
+    { fz_layout_document(ctx, doc, w, h, em); ret = (void*) -1; },
+    fz_document *doc, float w, float h, float em)
 MUPDF_WRAP(mupdf_load_outline, fz_outline*, NULL,
     ret = fz_load_outline(ctx, doc),
     fz_document *doc)


### PR DESCRIPTION
MuPDF related changes:
* support loading HTML from a string
* layout HTML for a given resolution
* use Noto Sans font when requested

Needed for https://github.com/koreader/koreader/issues/1776