### PR TITLE
cre: make loadDocument() return success or failure

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -424,7 +424,10 @@ static int loadDocument(lua_State *L) {
 	doc->text_view->LoadDocument(file_name);
 	doc->dom_doc = doc->text_view->getDocument();
 
-	return 0;
+	bool loaded = false;
+	if (doc->dom_doc) { loaded = true ;}
+	lua_pushboolean(L, loaded);
+	return 1;
 }
 
 static int renderDocument(lua_State *L) {


### PR DESCRIPTION
koreader would have crengine segfault when opening an unrecognized format document (for example: a .epub in which `/mimetype` file is absent), because loadDocument would return false, but Koreader would continue to call methods on it (render()). This will allow us to return an error in init so we can display _No reader engine for this file or invalid file_ instead of crashing.