### PR TITLE
MuPDF patch: don't fail rendering some PNG images that includes icc profile

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -63,6 +63,8 @@ set(PATCH_CMD3 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libjpeg_shared.
 set(PATCH_CMD4 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/vec_dot.patch || true")
 # needed for Android
 set(PATCH_CMD5 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/size_max.patch || true")
+# needed to not fail reading some PNG with icc with our -DNO_ICC
+set(PATCH_CMD6 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/no_icc_fixes.patch || true")
 
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
@@ -79,7 +81,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/no_icc_fixes.patch
+++ b/thirdparty/mupdf/no_icc_fixes.patch
@@ -1,0 +1,13 @@
+diff --git a/source/fitz/load-png.c b/source/fitz/load-png.c
+index daa0814a..636447d4 100644
+--- a/source/fitz/load-png.c
++++ b/source/fitz/load-png.c
+@@ -358,7 +358,7 @@ png_read_icc(fz_context *ctx, struct info *info, const unsigned char *p, unsigne
+ 	fz_always(ctx)
+ 		fz_drop_stream(ctx, stm);
+ 	fz_catch(ctx)
+-		fz_rethrow(ctx);
++		fz_warn(ctx, "could not load ICC profile in PNG image");
+ 
+ 	/* drop old one in case we have multiple ICC profiles */
+ 	fz_drop_colorspace(ctx, info->cs);


### PR DESCRIPTION
MuPDF 1.12 outputs a warning for [JPEG](https://github.com/ArtifexSoftware/mupdf/blob/a292539cc9e5e91843d48e691038d9c1b529422c/source/fitz/load-jpeg.c#L149) or [TIFF](https://github.com/ArtifexSoftware/mupdf/blob/a292539cc9e5e91843d48e691038d9c1b529422c/source/fitz/load-tiff.c#L1149) images that include some ICC info/profile and that we can't use with our -DNO_ICC build. But for [PNG](https://github.com/ArtifexSoftware/mupdf/blob/a292539cc9e5e91843d48e691038d9c1b529422c/source/fitz/load-png.c#L361), there is no warning but an exception is thrown. This patch just change this throw to a warning.
So, when meeting such a PNG that embeds some ICC info, it would just output:
```
error: ICC Profiles not supported in NO_ICC build
warning: could not load ICC profile in PNG image
```
and show the image ([example](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Lac_sevan_armenie.png/290px-Lac_sevan_armenie.png)) correctly.
