### PR TITLE
util.runInSubProcess(): give child its own process group

### DIFF
--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -39,6 +39,7 @@ long int read(int, void *, long unsigned int);
 int kill(int, int) __attribute__((__nothrow__, __leaf__));
 int waitpid(int, int *, int);
 int getpid();
+int setpgid(int, int);
 struct pollfd {
   int fd;
   short int events;


### PR DESCRIPTION
`util.runInSubProcess()`: give child its own process group and use `kill(-pid)` in `terminateSubProcess `to kill child and its children.
Should allow us to safely run `os.execute()` in sub-process.
(No current project in which I would need that, I just had a try with `os.execute("sleep 60")` and it has a few side effects that this solves.)