### PR TITLE
BB:colorblitFrom: add missing bounds check when use_cblitbuffer

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -766,12 +766,11 @@ BB_mt.__index.blitFullFrom = BB_mt.__index.blitFrom
 
 -- blitting with a per-blit alpha value
 function BB_mt.__index:addblitFrom(source, dest_x, dest_y, offs_x, offs_y, width, height, intensity)
-    width, height = width or source:getWidth(), height or source:getHeight()
-    width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
-    height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
-    if width <= 0 or height <= 0 then return end
-
     if use_cblitbuffer then
+        width, height = width or source:getWidth(), height or source:getHeight()
+        width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
+        height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
+        if width <= 0 or height <= 0 then return end
         cblitbuffer.BB_add_blit_from(ffi.cast("struct BlitBuffer *", self),
             ffi.cast("struct BlitBuffer *", source),
             dest_x, dest_y, offs_x, offs_y, width, height, intt(intensity*0xFF))
@@ -782,12 +781,11 @@ end
 
 -- alpha-pane aware blitting
 function BB_mt.__index:alphablitFrom(source, dest_x, dest_y, offs_x, offs_y, width, height)
-    width, height = width or source:getWidth(), height or source:getHeight()
-    width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
-    height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
-    if width <= 0 or height <= 0 then return end
-
     if use_cblitbuffer then
+        width, height = width or source:getWidth(), height or source:getHeight()
+        width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
+        height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
+        if width <= 0 or height <= 0 then return end
         cblitbuffer.BB_alpha_blit_from(ffi.cast("struct BlitBuffer *", self),
             ffi.cast("struct BlitBuffer *", source),
             dest_x, dest_y, offs_x, offs_y, width, height)
@@ -798,17 +796,16 @@ end
 
 -- invert blitting
 function BB_mt.__index:invertblitFrom(source, dest_x, dest_y, offs_x, offs_y, width, height)
-    width, height = width or source:getWidth(), height or source:getHeight()
-    width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
-    height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
-    if width <= 0 or height <= 0 then return end
-
     if use_cblitbuffer then
+        width, height = width or source:getWidth(), height or source:getHeight()
+        width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
+        height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
+        if width <= 0 or height <= 0 then return end
         cblitbuffer.BB_invert_blit_from(ffi.cast("struct BlitBuffer *", self),
             ffi.cast("struct BlitBuffer *", source),
             dest_x, dest_y, offs_x, offs_y, width, height)
     else
-        self:blitFrom(self, dest_x, dest_y, offs_x, offs_y, width, height, self.setPixelInverted)
+        self:blitFrom(source, dest_x, dest_y, offs_x, offs_y, width, height, self.setPixelInverted)
     end
 end
 
@@ -817,6 +814,10 @@ function BB_mt.__index:colorblitFrom(source, dest_x, dest_y, offs_x, offs_y, wid
     -- we need color with alpha later:
     color = color:getColorRGB32()
     if use_cblitbuffer then
+        width, height = width or source:getWidth(), height or source:getHeight()
+        width, dest_x, offs_x = BB.checkBounds(width, dest_x or 0, offs_x or 0, self:getWidth(), source:getWidth())
+        height, dest_y, offs_y = BB.checkBounds(height, dest_y or 0, offs_y or 0, self:getHeight(), source:getHeight())
+        if width <= 0 or height <= 0 then return end
         cblitbuffer.BB_color_blit_from(ffi.cast("struct BlitBuffer *", self),
             ffi.cast("struct BlitBuffer *", source),
             dest_x, dest_y, offs_x, offs_y, width, height, color:getColorRGB32())


### PR DESCRIPTION
I've been toying with making a MovebableContainer so we can move some widgets on screen, and got segfaults (in libc6.so or libcrengine.so!) when moving some widgets past the top left corner. Did not happen if I removed libblitbuffer.so.
I guess the missing BB.checkBounds were making cblibuffer draw/poke outside the malloc'ed buffer, so in some other code data (guess that's what is called a _buffer overflow_ :)
Shouldn't have had any impact, as current code is hardly drawing outside screen (dunno if that could be responsbile for some crashes on Android with nightmode when some viewport/fullscreen are involved).

I also moved the existing checkBounds _et al._ inside the `if use_cblitbuffer` sections, as the `else` all call `self:blitFrom` (line 750), where checkBounds are done anyway - so we avoid doing 2 times the same checks.

Fixed typo BB_mt.__index:invertblitFrom in its `else` : `self:blitFrom(self` should be `self:blitFrom(source` as all the others - but no impact as invertblitFrom is not use in the main code, only in the SDL and Android framebuffer implementations that uses cblitbuffer anyway.
