### PR TITLE
MuPDF: fix possible memory leaks

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -587,8 +587,8 @@ function page_mt.__index:draw_new(draw_context, width, height, offset_x, offset_
         M.fz_gamma_pixmap(context(), pix, draw_context.gamma)
     end
 
-    -- FIXME: undefined pixmap
-    M.fz_drop_pixmap(context(), pixmap) -- luacheck: ignore 113
+    M.fz_drop_pixmap(context(), pix)
+    M.fz_drop_colorspace(context(), colorspace)
 
     return bb
 end
@@ -756,6 +756,7 @@ function mupdf.scaleBlitBuffer(bb, width, height)
     local p = M.fz_pixmap_samples(context(), scaled_pixmap)
     bb = BlitBuffer.new(p_width, p_height, bbtype, p):copy()
     M.fz_drop_pixmap(context(), scaled_pixmap) -- free our scaled pixmap
+    M.fz_drop_colorspace(context(), colorspace)
     if converted_bb then converted_bb:free() end -- free our home made bb
     return bb
 end
@@ -840,6 +841,7 @@ local function render_for_kopt(bmp, page, scale, bounds)
     bmpmupdf_pixmap_to_bmp(bmp, pix)
 
     M.fz_drop_pixmap(context(), pix)
+    M.fz_drop_colorspace(context(), colorspace)
 end
 
 function page_mt.__index:reflow(kopt_context)

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -271,6 +271,7 @@ int fz_pixmap_components(fz_context *, fz_pixmap *);
 unsigned char *fz_pixmap_samples(fz_context *, fz_pixmap *);
 fz_colorspace *fz_device_gray(fz_context *);
 fz_colorspace *fz_device_rgb(fz_context *);
+void fz_drop_colorspace(fz_context *, fz_colorspace *);
 struct fz_device_s *mupdf_new_draw_device(fz_context *, const fz_matrix *, fz_pixmap *);
 struct fz_device_s *mupdf_new_text_device(fz_context *, fz_stext_page *, const fz_stext_options *);
 struct fz_device_s *mupdf_new_bbox_device(fz_context *, fz_rect *);


### PR DESCRIPTION
Not really sure the `fz_drop_colorspace()` are really needed (or they are small datastructures that we don't see growing), but it seems logical, and they don't seem to hurt.
But the `FIXME: undefined pixmap`, whick feels like a typo, looks like there were `pix` there never freed - but if that was the case, we should have seen big memory leaks (at least people who read pdf, which I rarely do).

I've been trying to understand and hunt possible memory leaks with the html dictionary, where I see a huge grow in mem use when used - but may be it's not unlimited. On the emulator, with mupdf.lua `debug_memory = true`, it seems it grows quickly to +30Mb, but then try to stays at around 30/35.
I didn't find any such 30/32/35/256<<17 in MuPDF sources, so I don't know where that is made out and ensured...
On my Kobo, memory seems to grow quickly from 30Mb to 70/100MB, and then may grow less quickly,
So, it may be the same thing as observed on the emulaor - lua objects stacked up at the end of memory, make it grows slowly, and the big mupdf cache(?) is not released, which should be ok.
