### PR TITLE
build(fix): update zlib download link

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -6,7 +6,7 @@ source "${CI_DIR}/common.sh"
 
 cp build/*/luajit "${HOME}/.luarocks/bin"
 # install tesseract trained language data for testing OCR functionality
-travis_retry wget http://pkgs.fedoraproject.org/repo/pkgs/tesseract/tesseract-ocr-3.02.eng.tar.gz/3562250fe6f4e76229a329166b8ae853/tesseract-ocr-3.02.eng.tar.gz
+travis_retry wget https://src.fedoraproject.org/repo/pkgs/tesseract/tesseract-ocr-3.02.eng.tar.gz/3562250fe6f4e76229a329166b8ae853/tesseract-ocr-3.02.eng.tar.gz
 tar zxf tesseract-ocr-3.02.eng.tar.gz
 export TESSDATA_PREFIX
 cd build/* && TESSDATA_PREFIX=$(pwd)/data && mkdir -p data/tessdata

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -34,7 +34,7 @@ set(ZLIB_MD5 "44d667c142d7cda120332623eab69f40")
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
-    URL http://pkgs.fedoraproject.org/repo/pkgs/mingw-zlib/zlib-${ZLIB_VER}.tar.gz/${ZLIB_MD5}/zlib-${ZLIB_VER}.tar.gz
+    URL http://zlib.net/fossils/zlib-${ZLIB_VER}.tar.gz
     URL_MD5 ${ZLIB_MD5}
     BUILD_IN_SOURCE 1
     ${optional_cfg_cmd}


### PR DESCRIPTION
Get zlib download link back to http://zlib.net/ , where `All released versions of zlib` links to http://zlib.net/fossils (previously changed in #469)
