### PR TITLE
Bump crengine

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -949,6 +949,10 @@ static int getLinkFromPosition(lua_State *L) {
 	ldomXPointer p = doc->text_view->getNodeByPoint(pt, true);
 	lString16 href = p.getHRef();
 	lua_pushstring(L, UnicodeToLocal(href).c_str());
+	if (!p.isNull()) {// return position's xpointer too
+		lua_pushstring(L, UnicodeToLocal(p.toString()).c_str());
+		return 2;
+	}
 	return 1;
 }
 
@@ -1228,6 +1232,13 @@ static int getPageLinks(lua_State *L) {
 			lua_settable(L, -3);
 			lua_pushstring(L, "end_y");
 			lua_pushinteger(L, end_pt.y - y_offset);
+			lua_settable(L, -3);
+
+			lua_pushstring(L, "start_xpointer");
+			lua_pushstring(L, UnicodeToLocal(currSel.getStart().toString()).c_str());
+			lua_settable(L, -3);
+			lua_pushstring(L, "end_xpointer");
+			lua_pushstring(L, UnicodeToLocal(currSel.getEnd().toString()).c_str());
 			lua_settable(L, -3);
 
 			const char * link_to = link8.c_str();


### PR DESCRIPTION
Bump crengine for https://github.com/koreader/crengine/pull/95

Also have getLinkFromPosition() and getPageLinks() additionaly return xpointers from position/source of link (so we can have a more precise "previous location" in location_stack).
Should have no impact on current code that does not use it.
I just want it in a nightly so I can test on my kobo for some time a followup to https://github.com/koreader/koreader/pull/3202 (_I would also have liked to have that when back from link, to again see where we were before jumping to link, but that's more complicated_)