### PR TITLE
[build] Add -fsanitize=undefined to debug flags

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -146,12 +146,17 @@ else
     STATIC_LIBSTDCPP=
 endif
 
+FSANITIZED_UNDEFINED_SUPPORTED := $(shell touch foo.c && gcc -fsanitize=undefined -c foo.c -o foo.o &> /dev/null && echo 1; rm -f foo.c foo.o)
+
 # Base CFLAGS, without arch. We'll need it for luajit, because its
 # Makefiles do some tricky stuff to differentiate HOST/TARGET
 BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 # Use this for debugging:
 ifdef KODEBUG
-    BASE_CFLAGS:=-Og -g -fsanitize=undefined -ffast-math -pipe -fomit-frame-pointer
+    BASE_CFLAGS:=-Og -g -ffast-math -pipe -fomit-frame-pointer
+    ifeq ($(FSANITIZED_UNDEFINED_SUPPORTED),1)
+        BASE_CFLAGS:=$(BASE_CFLAGS) -fsanitize=undefined
+    endif
 endif
 # For ricers.
 #BASE_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer -frename-registers -fweb
@@ -390,6 +395,7 @@ ifdef KODEBUG
     $(info ************ Building for MACHINE: "$(MACHINE)" **********)
     $(info ************ PATH: "$(PATH)" **********)
     $(info ************ CHOST: "$(CHOST)" **********)
+    $(info ************ BASE_CFLAGS: "$(BASE_CFLAGS)" **********)
 endif
 OUTPUT_DIR?=build/$(MACHINE)
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -151,7 +151,7 @@ endif
 BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 # Use this for debugging:
 ifdef KODEBUG
-    BASE_CFLAGS:=-Og -g -ffast-math -pipe -fomit-frame-pointer
+    BASE_CFLAGS:=-Og -g -fsanitize=undefined -ffast-math -pipe -fomit-frame-pointer
 endif
 # For ricers.
 #BASE_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer -frename-registers -fweb


### PR DESCRIPTION
Forgot to push this back in October, see https://github.com/koreader/crengine/pull/90#issuecomment-338333188

<hr>

Some more info here: https://developers.redhat.com/blog/2014/10/16/gcc-undefined-behavior-sanitizer-ubsan/

Btw, there are more sanitize options, some of which are mutually exclusive.

Clang has 'em too. (Based on the same lib?) http://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#ubsan-checks