### PR TITLE
[feat] SDL2: resize framebuffer implementation

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -66,8 +66,8 @@ function S.open()
 end
 
 function S.createTexture(w, h)
-    local w = w or S.w
-    local h = h or S.h
+    w = w or S.w
+    h = h or S.h
 
     return SDL.SDL_CreateTexture(
         S.renderer,

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -62,11 +62,22 @@ function S.open()
     )
 
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
-    S.texture = SDL.SDL_CreateTexture(
-                    S.renderer,
-                    SDL.SDL_PIXELFORMAT_ABGR8888,
-                    SDL.SDL_TEXTUREACCESS_STREAMING,
-                    S.w, S.h)
+    S.texture = S.createTexture()
+end
+
+function S.createTexture(w, h)
+    local w = w or S.w
+    local h = h or S.h
+
+    return SDL.SDL_CreateTexture(
+        S.renderer,
+        SDL.SDL_PIXELFORMAT_ABGR8888,
+        SDL.SDL_TEXTUREACCESS_STREAMING,
+        w, h)
+end
+
+function S.destroyTexture(texture)
+    SDL.SDL_DestroyTexture(texture)
 end
 
 -- one SDL event can generate more than one event for koreader,
@@ -170,6 +181,19 @@ function S.waitForEvent(usecs)
             genEmuEvent(ffi.C.EV_SYN, ffi.C.SYN_REPORT, 0)
         elseif event.type == SDL.SDL_MULTIGESTURE then -- luacheck: ignore 542
             -- TODO: multi-touch support
+        elseif event.type == SDL.SDL_WINDOWEVENT
+            and (event.window.event == SDL.SDL_WINDOWEVENT_RESIZED
+                 or event.window.event == SDL.SDL_WINDOWEVENT_SIZE_CHANGED) then
+            local x = 0
+            local y = 1
+            local new_size_x = event.window.data1
+            local new_size_y = event.window.data2
+
+            if new_size_x and new_size_y then
+                genEmuEvent(ffi.C.EV_MSC, SDL.SDL_WINDOWEVENT_RESIZED, 0)
+                genEmuEvent(ffi.C.EV_MSC, x, new_size_x)
+                genEmuEvent(ffi.C.EV_MSC, y, new_size_y)
+            end
         elseif event.type == SDL.SDL_QUIT then
             -- send Alt + F4
             genEmuEvent(ffi.C.EV_KEY, 226, 1)

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -184,15 +184,15 @@ function S.waitForEvent(usecs)
         elseif event.type == SDL.SDL_WINDOWEVENT
             and (event.window.event == SDL.SDL_WINDOWEVENT_RESIZED
                  or event.window.event == SDL.SDL_WINDOWEVENT_SIZE_CHANGED) then
-            local x = 0
-            local y = 1
-            local new_size_x = event.window.data1
-            local new_size_y = event.window.data2
+            local w = 0
+            local h = 1
+            local new_size_w = event.window.data1
+            local new_size_h = event.window.data2
 
-            if new_size_x and new_size_y then
+            if new_size_w and new_size_h then
+                genEmuEvent(ffi.C.EV_MSC, w, new_size_w)
+                genEmuEvent(ffi.C.EV_MSC, h, new_size_h)
                 genEmuEvent(ffi.C.EV_MSC, SDL.SDL_WINDOWEVENT_RESIZED, 0)
-                genEmuEvent(ffi.C.EV_MSC, x, new_size_x)
-                genEmuEvent(ffi.C.EV_MSC, y, new_size_y)
             end
         elseif event.type == SDL.SDL_QUIT then
             -- send Alt + F4

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -314,6 +314,36 @@ struct SDL_WindowEvent {
   int data1;
   int data2;
 };
+
+/**
+ *  \brief Event subtype for window events
+ */
+typedef enum
+{
+    SDL_WINDOWEVENT_NONE,           /**< Never used */
+    SDL_WINDOWEVENT_SHOWN,          /**< Window has been shown */
+    SDL_WINDOWEVENT_HIDDEN,         /**< Window has been hidden */
+    SDL_WINDOWEVENT_EXPOSED,        /**< Window has been exposed and should be
+                                         redrawn */
+    SDL_WINDOWEVENT_MOVED,          /**< Window has been moved to data1, data2
+                                     */
+    SDL_WINDOWEVENT_RESIZED,        /**< Window has been resized to data1xdata2 */
+    SDL_WINDOWEVENT_SIZE_CHANGED,   /**< The window size has changed, either as
+                                         a result of an API call or through the
+                                         system or user changing the window size. */
+    SDL_WINDOWEVENT_MINIMIZED,      /**< Window has been minimized */
+    SDL_WINDOWEVENT_MAXIMIZED,      /**< Window has been maximized */
+    SDL_WINDOWEVENT_RESTORED,       /**< Window has been restored to normal size
+                                         and position */
+    SDL_WINDOWEVENT_ENTER,          /**< Window has gained mouse focus */
+    SDL_WINDOWEVENT_LEAVE,          /**< Window has lost mouse focus */
+    SDL_WINDOWEVENT_FOCUS_GAINED,   /**< Window has gained keyboard focus */
+    SDL_WINDOWEVENT_FOCUS_LOST,     /**< Window has lost keyboard focus */
+    SDL_WINDOWEVENT_CLOSE,          /**< The window manager requests that the window be closed */
+    SDL_WINDOWEVENT_TAKE_FOCUS,     /**< Window is being offered a focus (should SetWindowInputFocus() on itself or a subwindow, or ignore) */
+    SDL_WINDOWEVENT_HIT_TEST        /**< Window had a hit test that wasn't SDL_HITTEST_NORMAL. */
+} SDL_WindowEventID;
+
 struct SDL_KeyboardEvent {
   unsigned int type;
   unsigned int timestamp;
@@ -559,6 +589,7 @@ void SDL_RenderPresent(struct SDL_Renderer *) __attribute__((visibility("default
 int SDL_RenderCopy(struct SDL_Renderer *, struct SDL_Texture *, const struct SDL_Rect *, const struct SDL_Rect *) __attribute__((visibility("default")));
 struct SDL_Texture *SDL_CreateTexture(struct SDL_Renderer *, unsigned int, int, int, int) __attribute__((visibility("default")));
 int SDL_UpdateTexture(struct SDL_Texture *, const struct SDL_Rect *, const void *, int) __attribute__((visibility("default")));
+void SDL_DestroyTexture(SDL_Texture* texture);
 void SDL_SetWindowTitle(struct SDL_Window *, const char *) __attribute__((visibility("default")));
 typedef enum SDL_bool {
     SDL_FALSE = 0,

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -23,8 +23,8 @@ function framebuffer:init()
 end
 
 function framebuffer:resize(w, h)
-    local w = w or SDL.w
-    local h = h or SDL.h
+    w = w or SDL.w
+    h = h or SDL.h
 
     if not self.dummy then
         self:_newBB(w, h)
@@ -41,8 +41,8 @@ function framebuffer:resize(w, h)
 end
 
 function framebuffer:_newBB(w, h)
-    local w = w or SDL.w
-    local h = h or SDL.h
+    w = w or SDL.w
+    h = h or SDL.h
 
     if self.sdl_bb then self.sdl_bb:free() end
     if self.bb then self.bb:free() end

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -29,6 +29,7 @@ function framebuffer:resize(w, h)
     if not self.dummy then
         self:_newBB(w, h)
     else
+        self.bb:free()
         self.bb = BB.new(600, 800)
     end
 
@@ -45,6 +46,7 @@ function framebuffer:_newBB(w, h)
 
     if self.sdl_bb then self.sdl_bb:free() end
     if self.bb then self.bb:free() end
+    if self.invert_bb then self.invert_bb:free() end
 
     -- we present this buffer to the outside
     local bb = BB.new(w, h, BB.TYPE_BBRGB32)

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -11,18 +11,7 @@ local framebuffer = {
 function framebuffer:init()
     if not self.dummy then
         SDL.open()
-        -- we present this buffer to the outside
-        local bb = BB.new(SDL.w, SDL.h, BB.TYPE_BBRGB32)
-        local flash = os.getenv("EMULATE_READER_FLASH")
-        if flash then
-            -- in refresh emulation mode, we use a shadow blitbuffer
-            -- and blit refresh areas from it.
-            self.sdl_bb = bb
-            self.bb = BB.new(SDL.w, SDL.h, BB.TYPE_BBRGB32)
-        else
-            self.bb = bb
-        end
-        self.invert_bb = BB.new(SDL.w, SDL.h, BB.TYPE_BBRGB32)
+        self:_newBB()
     else
         self.bb = BB.new(600, 800)
     end
@@ -31,6 +20,44 @@ function framebuffer:init()
     self:refreshFull()
 
     framebuffer.parent.init(self)
+end
+
+function framebuffer:resize(w, h)
+    local w = w or SDL.w
+    local h = h or SDL.h
+
+    if not self.dummy then
+        self:_newBB(w, h)
+    else
+        self.bb = BB.new(600, 800)
+    end
+
+    if SDL.texture then SDL.destroyTexture(SDL.texture) end
+    SDL.texture = SDL.createTexture(w, h)
+
+    self.bb:fill(BB.COLOR_WHITE)
+    self:refreshFull()
+end
+
+function framebuffer:_newBB(w, h)
+    local w = w or SDL.w
+    local h = h or SDL.h
+
+    if self.sdl_bb then self.sdl_bb:free() end
+    if self.bb then self.bb:free() end
+
+    -- we present this buffer to the outside
+    local bb = BB.new(w, h, BB.TYPE_BBRGB32)
+    local flash = os.getenv("EMULATE_READER_FLASH")
+    if flash then
+        -- in refresh emulation mode, we use a shadow blitbuffer
+        -- and blit refresh areas from it.
+        self.sdl_bb = bb
+        self.bb = BB.new(w, h, BB.TYPE_BBRGB32)
+    else
+        self.bb = bb
+    end
+    self.invert_bb = BB.new(w, h, BB.TYPE_BBRGB32)
 end
 
 function framebuffer:_render(bb)


### PR DESCRIPTION
@poire-z There seems to be some kind of memory leak present (unless it's something in front), which is not the biggest issue for what's more of an experimental proof of concept, but I might be missing something obvious.

In front I'm not quite finished with the proof of concept, but basic resizing works as you'd expect (besides the memory leak).

```diff
diff --git a/frontend/device/input.lua b/frontend/device/input.lua
index f595d25c..76de4578 100755
--- a/frontend/device/input.lua
+++ b/frontend/device/input.lua
@@ -345,7 +345,33 @@ function Input:handleKeyBoardEv(ev)
 end
 
 function Input:handleMiscEv(ev)
-    -- should be handled by a misc event protocol plugin
+    -- bit of a hack for passing SDL window resize events
+    local SDL_WINDOWEVENT_RESIZED = 5
+    local x = 0
+    local y = 1
+print("FDSFSDFSDFSDFSD")
+logger.dbg(ev)
+    if ev.code == x then
+        self.new_x = ev.value
+    elseif ev.code == y then
+        self.new_y = ev.value
+    elseif ev.code == SDL_WINDOWEVENT_RESIZED then
+    print("attempting to resize")
+    self.device.screen.screen_size.w = self.new_x
+    self.device.screen.screen_size.h = self.new_y
+        self.device.screen.resize(self.device.screen, self.new_x, self.new_y)
+
+print(self.device.screen:getScreenWidth())
+
+return Event:new("SetDimensions", self.device.screen:getSize())
+    end
 end
```