### PR TITLE
[feat] SDL2: update parts of window like a real device

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -72,12 +72,17 @@ function S.createTexture(w, h)
     return SDL.SDL_CreateTexture(
         S.renderer,
         SDL.SDL_PIXELFORMAT_ABGR8888,
-        SDL.SDL_TEXTUREACCESS_STREAMING,
+        SDL.SDL_TEXTUREACCESS_TARGET,
         w, h)
 end
 
 function S.destroyTexture(texture)
     SDL.SDL_DestroyTexture(texture)
+end
+
+local rect = ffi.metatype("SDL_Rect", {})
+function S.rect(x, y, w, h)
+    return rect(x, y, w, h)
 end
 
 -- one SDL event can generate more than one event for koreader,

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -72,7 +72,7 @@ function S.createTexture(w, h)
     return SDL.SDL_CreateTexture(
         S.renderer,
         SDL.SDL_PIXELFORMAT_ABGR8888,
-        SDL.SDL_TEXTUREACCESS_TARGET,
+        SDL.SDL_TEXTUREACCESS_STREAMING,
         w, h)
 end
 

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -590,7 +590,6 @@ int SDL_RenderCopy(struct SDL_Renderer *, struct SDL_Texture *, const struct SDL
 struct SDL_Texture *SDL_CreateTexture(struct SDL_Renderer *, unsigned int, int, int, int) __attribute__((visibility("default")));
 int SDL_UpdateTexture(struct SDL_Texture *, const struct SDL_Rect *, const void *, int) __attribute__((visibility("default")));
 void SDL_DestroyTexture(SDL_Texture* texture);
-int SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture);
 void SDL_SetWindowTitle(struct SDL_Window *, const char *) __attribute__((visibility("default")));
 typedef enum SDL_bool {
     SDL_FALSE = 0,

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -590,6 +590,7 @@ int SDL_RenderCopy(struct SDL_Renderer *, struct SDL_Texture *, const struct SDL
 struct SDL_Texture *SDL_CreateTexture(struct SDL_Renderer *, unsigned int, int, int, int) __attribute__((visibility("default")));
 int SDL_UpdateTexture(struct SDL_Texture *, const struct SDL_Rect *, const void *, int) __attribute__((visibility("default")));
 void SDL_DestroyTexture(SDL_Texture* texture);
+int SDL_SetRenderTarget(SDL_Renderer *renderer, SDL_Texture *texture);
 void SDL_SetWindowTitle(struct SDL_Window *, const char *) __attribute__((visibility("default")));
 typedef enum SDL_bool {
     SDL_FALSE = 0,
@@ -606,7 +607,12 @@ static const int SDL_WINDOWPOS_UNDEFINED = 536805376;
 static const int SDL_WINDOW_FULLSCREEN = 1;
 static const int SDL_WINDOW_FULLSCREEN_DESKTOP = 4097;
 static const int SDL_WINDOW_RESIZABLE = 32;
-static const int SDL_TEXTUREACCESS_STREAMING = 1;
+typedef enum
+{
+    SDL_TEXTUREACCESS_STATIC,
+    SDL_TEXTUREACCESS_STREAMING,
+    SDL_TEXTUREACCESS_TARGET
+} SDL_TextureAccess;
 static const int SDL_PIXELFORMAT_ARGB8888 = 372645892;
 static const int SDL_PIXELFORMAT_RGBA8888 = 373694468;
 static const int SDL_PIXELFORMAT_ABGR8888 = 376840196;


### PR DESCRIPTION
This commit first renders the full updated blitbuffer to a temporary texture.
Subsequently it renders the updated rectangle from the temporary texture onto
the final texture, which has up to that point retained all of the old pixel
info. That final texture, of which only the one rectangular area was updated,
is then rendered to the window.

Without this, there are cases where a full screen (or at least bigger) refresh
is required that will not be obvious without first testing on a real device.
See https://github.com/koreader/koreader/pull/3804

Also fixes `EMULATE_READER_FLASH`, which was accidentally broken in 981bd40e1ca1c1152b702590fd85ae2d7cbf0ea6