### PR TITLE
[feat] SDL2: preliminary gamepad support

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -37,7 +37,9 @@ function S.open()
 
     SDL.SDL_SetMainReady()
 
-    if SDL.SDL_Init(SDL.SDL_INIT_VIDEO) ~= 0 then
+    if SDL.SDL_Init(bit.bor(SDL.SDL_INIT_VIDEO,
+                            SDL.SDL_INIT_JOYSTICK,
+                            SDL.SDL_INIT_GAMECONTROLLER)) ~= 0 then
         error("Cannot initialize SDL.")
     end
 
@@ -63,6 +65,21 @@ function S.open()
 
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
     S.texture = S.createTexture()
+
+    local joystick_counter
+    for joystick_counter = 0, SDL.SDL_NumJoysticks()-1 do
+        if SDL.SDL_IsGameController(joystick_counter) ~= 0 then
+            S.controller = SDL.SDL_GameControllerOpen(joystick_counter);
+            if S.controller ~= nil then
+                io.write("SDL: opened gamecontroller ",joystick_counter, ": ",
+                         ffi.string(SDL.SDL_GameControllerNameForIndex(joystick_counter)), "\n");
+                break
+            else
+                io.write("SDL: could not open gamecontroller ",joystick_counter, ": ",
+                         ffi.string(SDL.SDL_GameControllerNameForIndex(joystick_counter)), "\n");
+            end
+        end
+    end
 end
 
 function S.createTexture(w, h)
@@ -127,6 +144,9 @@ end
 
 local is_in_touch = false
 local dropped_file_path
+local last_joystick_axes = {}
+local last_joystick_event_s = 0
+local last_joystick_event_us = 0
 
 function S.waitForEvent(usecs)
     usecs = usecs or -1
@@ -217,6 +237,103 @@ function S.waitForEvent(usecs)
             genEmuEvent(ffi.C.EV_MSC, SDL.SDL_DROPFILE, 0)
         elseif event.type == SDL.SDL_WINDOWEVENT then
             handleWindowEvent(event.window)
+        --- Gamepad support ---
+        -- For debugging it can be helpful to use:
+        -- print(ffi.string(SDL.SDL_GameControllerGetStringForButton(button)))
+        -- @TODO Proper support instead of faux keyboard presses
+        --
+        --- Sticks & triggers ---
+        elseif event.type == SDL.SDL_JOYAXISMOTION then
+            local axis_ev = event.jaxis
+            local value = axis_ev.value
+
+            local neutral_max_val = 5000
+            local min_time_since_last_ev = 0.3
+
+            -- ignore random neutral fluctuations
+            if (value > -neutral_max_val) and (value < neutral_max_val) then return end
+
+            local current_ev_s, current_ev_us = util.gettime()
+
+            local since_last_ev = current_ev_s-last_joystick_event_s + (current_ev_us-last_joystick_event_us)/1000000
+
+            local axis = axis_ev.axis
+
+            if not ( since_last_ev > min_time_since_last_ev ) then return end
+
+            -- left stick 0/1
+            if axis == 0 then
+                if value < -neutral_max_val then
+                    -- send left
+                    genEmuEvent(ffi.C.EV_KEY, 80, 1)
+                else
+                    -- send right
+                    genEmuEvent(ffi.C.EV_KEY, 79, 1)
+                end
+            elseif axis == 1 then
+                if value < -neutral_max_val then
+                    -- send up
+                    genEmuEvent(ffi.C.EV_KEY, 82, 1)
+                else
+                    -- send down
+                    genEmuEvent(ffi.C.EV_KEY, 81, 1)
+                end
+            -- right stick 3/4
+            elseif axis == 4 then
+                if value < -neutral_max_val then
+                    -- send page up
+                    genEmuEvent(ffi.C.EV_KEY, 75, 1)
+                else
+                    -- send page down
+                    genEmuEvent(ffi.C.EV_KEY, 78, 1)
+                end
+            -- left trigger 2
+            -- right trigger 5
+            end
+
+            last_joystick_event_s, last_joystick_event_us = util.gettime()
+        --- Buttons (such as A, B, X, Y) ---
+        elseif event.type == SDL.SDL_JOYBUTTONDOWN then
+            local button = event.cbutton.button
+
+            if button == SDL.SDL_CONTROLLER_BUTTON_A then
+                -- send enter
+                genEmuEvent(ffi.C.EV_KEY, 40, 1)
+                -- send end (bound to press)
+                genEmuEvent(ffi.C.EV_KEY, 77, 1)
+            elseif button == SDL.SDL_CONTROLLER_BUTTON_B then
+                -- send escape
+                genEmuEvent(ffi.C.EV_KEY, 41, 1)
+            -- left bumper
+            elseif button == SDL.SDL_CONTROLLER_BUTTON_BACK then
+                -- send page up
+                genEmuEvent(ffi.C.EV_KEY, 75, 1)
+            -- right bumper
+            elseif button == SDL.SDL_CONTROLLER_BUTTON_GUIDE then
+                -- send page down
+                genEmuEvent(ffi.C.EV_KEY, 78, 1)
+            -- On the Xbox One controller, start = start but leftstick = menu button
+            elseif button == SDL.SDL_CONTROLLER_BUTTON_START or button == SDL.SDL_CONTROLLER_BUTTON_LEFTSTICK then
+                -- send F1 (bound to menu in front at the time of writing)
+                genEmuEvent(ffi.C.EV_KEY, 58, 1)
+            end
+        --- D-pad ---
+        elseif event.type == SDL.SDL_JOYHATMOTION then
+            local hat_position = event.jhat.value
+
+            if hat_position == SDL.SDL_HAT_UP then
+                -- send up
+                genEmuEvent(ffi.C.EV_KEY, 82, 1)
+            elseif hat_position == SDL.SDL_HAT_DOWN then
+                -- send down
+                genEmuEvent(ffi.C.EV_KEY, 81, 1)
+            elseif hat_position == SDL.SDL_HAT_LEFT then
+                -- send left
+                genEmuEvent(ffi.C.EV_KEY, 80, 1)
+            elseif hat_position == SDL.SDL_HAT_RIGHT then
+                -- send right
+                genEmuEvent(ffi.C.EV_KEY, 79, 1)
+            end
         elseif event.type == SDL.SDL_QUIT then
             -- send Alt + F4
             genEmuEvent(ffi.C.EV_KEY, 226, 1)

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -66,7 +66,6 @@ function S.open()
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
     S.texture = S.createTexture()
 
-    local joystick_counter
     for joystick_counter = 0, SDL.SDL_NumJoysticks()-1 do
         if SDL.SDL_IsGameController(joystick_counter) ~= 0 then
             S.controller = SDL.SDL_GameControllerOpen(joystick_counter);

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -144,7 +144,6 @@ end
 
 local is_in_touch = false
 local dropped_file_path
-local last_joystick_axes = {}
 local last_joystick_event_s = 0
 local last_joystick_event_us = 0
 

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -599,9 +599,152 @@ SDL_bool SDL_HasClipboardText(void);
 char* SDL_GetClipboardText(void);
 int SDL_SetClipboardText(const char* text);
 const char* SDL_GetError(void);
-static const int SDL_INIT_AUDIO = 16;
-static const int SDL_INIT_VIDEO = 32;
-static const int SDL_INIT_EVENTS = 16384;
+struct _SDL_Joystick;
+typedef struct _SDL_Joystick SDL_Joystick;
+typedef struct {
+    Uint8 data[16];
+} SDL_JoystickGUID;
+typedef Sint32 SDL_JoystickID;
+int SDL_NumJoysticks(void);
+const char * SDL_JoystickNameForIndex(int device_index);
+SDL_Joystick * SDL_JoystickOpen(int device_index);
+const char * SDL_JoystickName(SDL_Joystick * joystick);
+SDL_JoystickGUID SDL_JoystickGetDeviceGUID(int device_index);
+SDL_JoystickGUID SDL_JoystickGetGUID(SDL_Joystick * joystick);
+void SDL_JoystickGetGUIDString(SDL_JoystickGUID guid, char *pszGUID, int cbGUID);
+SDL_JoystickGUID SDL_JoystickGetGUIDFromString(const char *pchGUID);
+SDL_bool SDL_JoystickGetAttached(SDL_Joystick * joystick);
+SDL_JoystickID SDL_JoystickInstanceID(SDL_Joystick * joystick);
+int SDL_JoystickNumAxes(SDL_Joystick * joystick);
+int SDL_JoystickNumBalls(SDL_Joystick * joystick);
+int SDL_JoystickNumHats(SDL_Joystick * joystick);
+int SDL_JoystickNumButtons(SDL_Joystick * joystick);
+void SDL_JoystickUpdate(void);
+int SDL_JoystickEventState(int state);
+Sint16 SDL_JoystickGetAxis(SDL_Joystick * joystick,
+                                                   int axis);
+Uint8 SDL_JoystickGetHat(SDL_Joystick * joystick,
+                                                 int hat);
+int SDL_JoystickGetBall(SDL_Joystick * joystick,
+                                                int ball, int *dx, int *dy);
+Uint8 SDL_JoystickGetButton(SDL_Joystick * joystick,
+                                                    int button);
+void SDL_JoystickClose(SDL_Joystick * joystick);
+struct _SDL_GameController;
+typedef struct _SDL_GameController SDL_GameController;
+typedef enum
+{
+    SDL_CONTROLLER_BINDTYPE_NONE = 0,
+    SDL_CONTROLLER_BINDTYPE_BUTTON,
+    SDL_CONTROLLER_BINDTYPE_AXIS,
+    SDL_CONTROLLER_BINDTYPE_HAT
+} SDL_GameControllerBindType;
+typedef struct SDL_GameControllerButtonBind
+{
+    SDL_GameControllerBindType bindType;
+    union
+    {
+        int button;
+        int axis;
+        struct {
+            int hat;
+            int hat_mask;
+        } hat;
+    } value;
+} SDL_GameControllerButtonBind;
+int SDL_GameControllerAddMapping( const char* mappingString );
+char * SDL_GameControllerMappingForGUID( SDL_JoystickGUID guid );
+char * SDL_GameControllerMapping( SDL_GameController * gamecontroller );
+SDL_bool SDL_IsGameController(int joystick_index);
+const char * SDL_GameControllerNameForIndex(int joystick_index);
+SDL_GameController * SDL_GameControllerOpen(int joystick_index);
+const char * SDL_GameControllerName(SDL_GameController *gamecontroller);
+SDL_bool SDL_GameControllerGetAttached(SDL_GameController *gamecontroller);
+SDL_Joystick * SDL_GameControllerGetJoystick(SDL_GameController *gamecontroller);
+int SDL_GameControllerEventState(int state);
+void SDL_GameControllerUpdate(void);
+typedef enum
+{
+    SDL_CONTROLLER_AXIS_INVALID = -1,
+    SDL_CONTROLLER_AXIS_LEFTX,
+    SDL_CONTROLLER_AXIS_LEFTY,
+    SDL_CONTROLLER_AXIS_RIGHTX,
+    SDL_CONTROLLER_AXIS_RIGHTY,
+    SDL_CONTROLLER_AXIS_TRIGGERLEFT,
+    SDL_CONTROLLER_AXIS_TRIGGERRIGHT,
+    SDL_CONTROLLER_AXIS_MAX
+} SDL_GameControllerAxis;
+SDL_GameControllerAxis SDL_GameControllerGetAxisFromString(const char *pchString);
+const char* SDL_GameControllerGetStringForAxis(SDL_GameControllerAxis axis);
+SDL_GameControllerButtonBind
+SDL_GameControllerGetBindForAxis(SDL_GameController *gamecontroller,
+                                 SDL_GameControllerAxis axis);
+Sint16
+SDL_GameControllerGetAxis(SDL_GameController *gamecontroller,
+                          SDL_GameControllerAxis axis);
+typedef enum
+{
+    SDL_CONTROLLER_BUTTON_INVALID = -1,
+    SDL_CONTROLLER_BUTTON_A,
+    SDL_CONTROLLER_BUTTON_B,
+    SDL_CONTROLLER_BUTTON_X,
+    SDL_CONTROLLER_BUTTON_Y,
+    SDL_CONTROLLER_BUTTON_BACK,
+    SDL_CONTROLLER_BUTTON_GUIDE,
+    SDL_CONTROLLER_BUTTON_START,
+    SDL_CONTROLLER_BUTTON_LEFTSTICK,
+    SDL_CONTROLLER_BUTTON_RIGHTSTICK,
+    SDL_CONTROLLER_BUTTON_LEFTSHOULDER,
+    SDL_CONTROLLER_BUTTON_RIGHTSHOULDER,
+    SDL_CONTROLLER_BUTTON_DPAD_UP,
+    SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+    SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+    SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+    SDL_CONTROLLER_BUTTON_MAX
+} SDL_GameControllerButton;
+SDL_GameControllerButton SDL_GameControllerGetButtonFromString(const char *pchString);
+const char* SDL_GameControllerGetStringForButton(SDL_GameControllerButton button);
+SDL_GameControllerButtonBind
+SDL_GameControllerGetBindForButton(SDL_GameController *gamecontroller,
+                                   SDL_GameControllerButton button);
+Uint8 SDL_GameControllerGetButton(SDL_GameController *gamecontroller,
+                                                          SDL_GameControllerButton button);
+void SDL_GameControllerClose(SDL_GameController *gamecontroller);
+enum {
+SDL_HAT_CENTERED    = 0x00,
+SDL_HAT_UP          = 0x01,
+SDL_HAT_RIGHT       = 0x02,
+SDL_HAT_DOWN        = 0x04,
+SDL_HAT_LEFT        = 0x08,
+SDL_HAT_RIGHTUP     = (SDL_HAT_RIGHT|SDL_HAT_UP),
+SDL_HAT_RIGHTDOWN   = (SDL_HAT_RIGHT|SDL_HAT_DOWN),
+SDL_HAT_LEFTUP      = (SDL_HAT_LEFT|SDL_HAT_UP),
+SDL_HAT_LEFTDOWN    = (SDL_HAT_LEFT|SDL_HAT_DOWN)
+};
+typedef Sint64 SDL_TouchID;
+typedef Sint64 SDL_FingerID;
+typedef struct SDL_Finger
+{
+    SDL_FingerID id;
+    float x;
+    float y;
+    float pressure;
+} SDL_Finger;
+int SDL_GetNumTouchDevices(void);
+SDL_TouchID SDL_GetTouchDevice(int index);
+int SDL_GetNumTouchFingers(SDL_TouchID touchID);
+SDL_Finger * SDL_GetTouchFinger(SDL_TouchID touchID, int index);
+enum {
+SDL_INIT_TIMER          = 0x00000001,
+SDL_INIT_AUDIO          = 0x00000010,
+SDL_INIT_VIDEO          = 0x00000020,
+SDL_INIT_JOYSTICK       = 0x00000200,
+SDL_INIT_HAPTIC         = 0x00001000,
+SDL_INIT_GAMECONTROLLER = 0x00002000,
+SDL_INIT_EVENTS         = 0x00004000,
+SDL_INIT_NOPARACHUTE    = 0x00100000,
+SDL_INIT_EVERYTHING     = ( SDL_INIT_TIMER | SDL_INIT_AUDIO | SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_JOYSTICK | SDL_INIT_HAPTIC | SDL_INIT_GAMECONTROLLER )
+};
 static const int SDL_WINDOWPOS_UNDEFINED = 536805376;
 static const int SDL_WINDOW_FULLSCREEN = 1;
 static const int SDL_WINDOW_FULLSCREEN_DESKTOP = 4097;


### PR DESCRIPTION
This is a "dumb" implementation that spits out fake keyboard events.

* Left stick & d-pad: arrow keys
* Bumpers and right stick: page up/down
* Menu button: menu
* A: enter
* B: back

This is sufficient to use most of the program.

Made possible by @onde2rock's recent efforts in https://github.com/koreader/koreader/pull/3796
https://github.com/koreader/koreader/pull/3785 https://github.com/koreader/koreader/pull/3774
https://github.com/koreader/koreader/pull/3765 and https://github.com/koreader/koreader/pull/3745