### PR TITLE
[chore] SDL2: less hackish SDL event approach

### DIFF
--- a/ffi/input_SDL2_0.lua
+++ b/ffi/input_SDL2_0.lua
@@ -8,7 +8,6 @@ return {
     fakeTapInput = function() end,
     -- NOP:
     closeAll = function() end,
-    getDroppedFilePath = SDL.getDroppedFilePath,
     hasClipboardText = SDL.hasClipboardText,
     getClipboardText = SDL.getClipboardText,
     setClipboardText = SDL.setClipboardText,


### PR DESCRIPTION
It wouldn't make much sense to continue adding endless workarounds along the lines
of the getDroppedFile() function. For SDL multitouch events we could emit a number
of fake Linux kernel multitouch events but it seems more sensible to construct
gesture events out of SDL event information directly in front.

Emits a made up EV_SDL code to tap into the existing event system.

Also added SDL_MULTIGESTURE and SDL_WHEEL passthrough.