### PR TITLE
djvu.c: return internal djvulibre error

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -95,8 +95,9 @@ static int openDocument(lua_State *L) {
 	ddjvu_cache_set_size(doc->context, (unsigned long)cache_size);
 
 	doc->doc_ref = ddjvu_document_create_by_filename_utf8(doc->context, filename, TRUE);
-	if (! doc->doc_ref)
-		return luaL_error(L, "cannot open DjVu file <%s>", filename);
+	if (! doc->doc_ref) {
+		return handle(L, doc->context, FALSE);
+	}
 	while (! ddjvu_document_decoding_done(doc->doc_ref))
 		handle(L, doc->context, True);
 

--- a/djvu.c
+++ b/djvu.c
@@ -96,7 +96,10 @@ static int openDocument(lua_State *L) {
 
 	doc->doc_ref = ddjvu_document_create_by_filename_utf8(doc->context, filename, TRUE);
 	if (! doc->doc_ref) {
-		return handle(L, doc->context, FALSE);
+		int res = handle(L, doc->context, FALSE);
+		if (res != 0) return res;
+		// in case we didn't get a more detailed error message
+		return luaL_error(L, "cannot open DjVu file <%s>", filename);
 	}
 	while (! ddjvu_document_decoding_done(doc->doc_ref))
 		handle(L, doc->context, True);


### PR DESCRIPTION
All of the `GURL` stuff in djvulibre is absurdly complicated and this does nothing to help.

References https://github.com/koreader/koreader/issues/542

```
04/06/18-10:20:48 WARN  cannot open document /mnt/onboard/.books/koreader_test/Михайлов ТФКП.djvu frontend/document/djvudocument.lua:42: ddjvu: ** Unrecognized DjVu Message:
	** Message name:  ByteStream.open_fail
	   Parameter: %D0%9C%D0%B8%D1%85%D0%B0%D0%B9%D0%BB%D0%BE%D0%B2%20%D0%A2%D0%A4%D0%9A%D0%9F.djvu
	   Parameter: No such file or directory
ddjvu: 'ByteStream.cpp:704'
```

@poire-z Not quite sure if a situation is possible where there's no internal error message. in that case it'd return `0` which is no good… 

Basically I want the `handle()` function with a `return luaL_error(L, "cannot open DjVu file <%s>", filename);` at the end instead of `return 0`, I suppose. Any bright suggestions? :-P