### PR TITLE
[build] Makefile.defs: add AppImage target

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -58,6 +58,10 @@ else ifeq ($(TARGET), ubuntu-touch)
     CHOST?=arm-linux-gnueabihf
     export SDL=1
     export UBUNTUTOUCH=1
+else ifeq ($(TARGET), appimage)
+    export EMULATE_READER=1
+    export SDL=1
+    export APPIMAGE=1
 else ifeq ($(TARGET), android)
     export ANDROID=1
     export PATH:=$(ANDROID_TOOLCHAIN)/bin:$(PATH)


### PR DESCRIPTION
Nothing fancy here right now but it would technically need to include SDL2 (and maybe Gtk3) as well. An AppImage is supposed to run independently. However, for AppImage purposes those can simply be copied from the host system.