### PR TITLE
[fix, build] AppImage use `-mtune=generic -march=x86-64`

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -278,6 +278,10 @@ ifdef CLANG
 endif
 
 HOST_ARCH:=-march=native
+ifdef APPIMAGE
+    # We want to run the AppImage on any 64-bit CPU
+    HOST_ARCH:=-mtune=generic -march=x86-64
+endif
 HOSTCFLAGS:=$(HOST_ARCH) $(BASE_CFLAGS) $(QFLAGS)
 
 CFLAGS:=$(BASE_CFLAGS) $(QFLAGS)


### PR DESCRIPTION
`-march=native` is good for the emulator but not for an AppImage that needs to support various CPU models.

References https://github.com/koreader/koreader/issues/3853.