### PR TITLE
BB:dimRect/lightenRect: add missing bounds check when use_cblitbuffer

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1176,6 +1176,8 @@ dim color values in rectangular area
 function BB_mt.__index:dimRect(x, y, w, h, by)
     local color = Color8A(255, 255*(by or 0.5))
     if use_cblitbuffer then
+        w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
+        h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
         cblitbuffer.BB_blend_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h, color:getColorRGB32())
     else
@@ -1195,6 +1197,8 @@ lighten color values in rectangular area
 function BB_mt.__index:lightenRect(x, y, w, h, by)
     local color = Color8A(0, 255*(by or 0.5))
     if use_cblitbuffer then
+        w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
+        h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
         cblitbuffer.BB_blend_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h, color:getColorRGB32())
     else


### PR DESCRIPTION
Fix segfaults with highlights spanning multiple pages (not possible when selecting, but possible with previous highlights after changing font size or other layout parameters).
The added `BB.checkBounds()` are exactly the same that are done in `self:paintRect()` in the `else` (so, it was properly done when `not use_cblitbuffer`)
Similar to what was done in #589.