### PR TITLE
[chore, CI] Update to latest Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
     - EMULATE_READER=1 CC=gcc
     - EMULATE_READER=1 CC=gcc KODEBUG=1
     - EMULATE_READER=1 CC=clang
-    - TARGET=kindle DOCKER_IMG=houqp/kokindle:0.0.3
-    - TARGET=kobo DOCKER_IMG=houqp/kokobo:0.0.3
+    - TARGET=kindle DOCKER_IMG=frenzie/kokindle:0.0.5
+    - TARGET=kobo DOCKER_IMG=frenzie/kokobo:0.0.5
     - TARGET=pocketbook DOCKER_IMG=houqp/kopb:0.0.1
     # ANDROID_ARCH=x86 is currently broken on these older NDKs (at least on Travis), so no point in testing it
     - TARGET=android NDKREV=r11c


### PR DESCRIPTION
These are the ones that include the new TC, see https://github.com/koreader/virdevenv/pull/14 and https://github.com/koreader/koxtoolchain/pull/3