### PR TITLE
[build] bump glib to 2.56.1

### DIFF
--- a/thirdparty/glib/CMakeLists.txt
+++ b/thirdparty/glib/CMakeLists.txt
@@ -57,7 +57,7 @@ set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/GNOME/glib.git
-    2.54.3
+    2.56.1
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Includes commit https://github.com/GNOME/glib/commit/987bf5bbeb25e846617d7bc1ee9b78f049dc0d60 which should fix the problem that prevented 2.56.0 from working on certain platforms in https://github.com/koreader/koreader-base/pull/635