### PR TITLE
Fix build on Archlinux

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -30,6 +30,16 @@ endif
 # CMAKE=cmake --no-warn-unused-cli
 CMAKE=cmake
 
+ifneq (, $(DARWINHOST))
+LUAROCKS = luarocks-5.1
+else ifneq (, $(shell command -v luarocks-5.1 2> /dev/null))
+# On some distribution, multiple version of luarocks are installed at the same time, so choose
+# the right one.
+LUAROCKS = luarocks-5.1
+else
+LUAROCKS=luarocks
+endif
+
 # set this to your ARM cross compiler:
 # set CC CXX AR LD RANLIB
 ifeq ($(TARGET), arm-generic)
@@ -594,7 +604,7 @@ LUA_SPORE_BUILD_DIR=$(THIRDPARTY_DIR)/lua-Spore/build/$(MACHINE)
 LUA_SPORE_DIR=$(CURDIR)/$(LUA_SPORE_BUILD_DIR)/lua-Spore-prefix/src/lua-Spore
 SPORE_VER=0.3.1-1
 LUA_SPORE_VER=lua-spore-$(SPORE_VER)
-LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks
+LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks/
 LUA_SPORE_ROCK=$(LUAROCKS_DIR)/lua-spore/$(SPORE_VER)/$(LUA_SPORE_VER).rockspec
 
 SQLITE_BUILD_DIR=$(THIRDPARTY_DIR)/sqlite/build/$(MACHINE)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -604,7 +604,7 @@ LUA_SPORE_BUILD_DIR=$(THIRDPARTY_DIR)/lua-Spore/build/$(MACHINE)
 LUA_SPORE_DIR=$(CURDIR)/$(LUA_SPORE_BUILD_DIR)/lua-Spore-prefix/src/lua-Spore
 SPORE_VER=0.3.1-1
 LUA_SPORE_VER=lua-spore-$(SPORE_VER)
-LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks/
+LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks-5.1/
 LUA_SPORE_ROCK=$(LUAROCKS_DIR)/lua-spore/$(SPORE_VER)/$(LUA_SPORE_VER).rockspec
 
 SQLITE_BUILD_DIR=$(THIRDPARTY_DIR)/sqlite/build/$(MACHINE)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -604,7 +604,7 @@ LUA_SPORE_BUILD_DIR=$(THIRDPARTY_DIR)/lua-Spore/build/$(MACHINE)
 LUA_SPORE_DIR=$(CURDIR)/$(LUA_SPORE_BUILD_DIR)/lua-Spore-prefix/src/lua-Spore
 SPORE_VER=0.3.1-1
 LUA_SPORE_VER=lua-spore-$(SPORE_VER)
-LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks-5.1/
+LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks/
 LUA_SPORE_ROCK=$(LUAROCKS_DIR)/lua-spore/$(SPORE_VER)/$(LUA_SPORE_VER).rockspec
 
 SQLITE_BUILD_DIR=$(THIRDPARTY_DIR)/sqlite/build/$(MACHINE)

--- a/Makefile.third
+++ b/Makefile.third
@@ -520,7 +520,7 @@ $(LUA_SPORE_ROCK): $(THIRDPARTY_DIR)/lua-Spore/CMakeLists.txt
 		$(CMAKE) -DOUTPUT_DIR="$(CURDIR)/$(OUTPUT_DIR)" \
 		-DLUA_SPORE_VER=$(LUA_SPORE_VER) -DLD="$(CC)" \
 		-DCC="$(CC)" -DCFLAGS="$(CFLAGS) -I$(LUAJIT_DIR)/src" \
-		-DLUAROCKS=$(if $(DARWINHOST),luarocks-5.1,luarocks) \
+		-DLUAROCKS=$(LUAROCKS) \
 		-DLUA_INCDIR="$(LUAJIT_DIR)/src" -DLUA_LIBDIR="$(CURDIR)/$(dir $(LUAJIT_LIB))" \
 		$(if $(ANDROID),-DLIBFLAG="$(LDFLAGS) $(CURDIR)/$(LUAJIT_LIB) -nostartfiles",) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/lua-Spore && \


### PR DESCRIPTION
- On archlinux, `luarocks` is symlinked to `luarocks-5.3` 
Now the makefile use `luarocks-5.1` if found in the path, else it default to `luarocks` as before.

- Look like the path used by luarocks is now `luarocks/rocks-5.1/` instead of `luarocks/rocks`
This cause `make` to always rebuild lua-spore.
Does this also happen on other distrbution like ubuntu or my installation is messed up ?