### PR TITLE
[build] Pull in thirdparty repos with --depth 50

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -564,7 +564,7 @@ GLIB=$(GLIB_DIR)/lib/libglib-2.0$(if $(DARWIN),.dylib,.so.0)
 GLIB_STATIC=$(GLIB_DIR)/lib/libglib-2.0.a
 ZLIB=$(OUTPUT_DIR)/libs/$(if $(WIN32),zlib1.dll,$(if $(DARWIN),libz.1.dylib,libz.so.1))
 
-LEPT_LIB_EXT=$(if $(WIN32),-5.dll,$(if $(DARWIN),.5.dylib,.so.5))
+LEPT_LIB_EXT=$(if $(WIN32),-4.dll,$(if $(DARWIN),.4.dylib,.so.4))
 LEPTONICA_LIB=$(OUTPUT_DIR)/libs/liblept$(LEPT_LIB_EXT)
 TESS_LIB_EXT=$(if $(WIN32),-3.dll,$(if $(DARWIN),.3.dylib,.so.3))
 TESSERACT_LIB=$(OUTPUT_DIR)/libs/libtesseract$(TESS_LIB_EXT)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -564,7 +564,7 @@ GLIB=$(GLIB_DIR)/lib/libglib-2.0$(if $(DARWIN),.dylib,.so.0)
 GLIB_STATIC=$(GLIB_DIR)/lib/libglib-2.0.a
 ZLIB=$(OUTPUT_DIR)/libs/$(if $(WIN32),zlib1.dll,$(if $(DARWIN),libz.1.dylib,libz.so.1))
 
-LEPT_LIB_EXT=$(if $(WIN32),-4.dll,$(if $(DARWIN),.4.dylib,.so.4))
+LEPT_LIB_EXT=$(if $(WIN32),-5.dll,$(if $(DARWIN),.5.dylib,.so.5))
 LEPTONICA_LIB=$(OUTPUT_DIR)/libs/liblept$(LEPT_LIB_EXT)
 TESS_LIB_EXT=$(if $(WIN32),-3.dll,$(if $(DARWIN),.3.dylib,.so.3))
 TESSERACT_LIB=$(OUTPUT_DIR)/libs/libtesseract$(TESS_LIB_EXT)

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -134,7 +134,15 @@ execute_process(
   RESULT_VARIABLE error_code
 )
 if(error_code)
-  message(FATAL_ERROR \"Failed to update submodules in: '${work_dir}/${src_name}'\")
+  message(STATUS \"Fetching full repo\")
+  execute_process(
+    COMMAND \"${git_EXECUTABLE}\" submodule update --depth 999999 --recursive ${git_submodules}
+    WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+    RESULT_VARIABLE error_code
+  )
+  if(error_code)
+    message(FATAL_ERROR \"Failed to update submodules in: '${work_dir}/${src_name}'\")
+  endif()
 endif()
 
 # Complete success, update the script-last-run stamp file:

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -8,7 +8,6 @@ endif()
 
 # Default depth
 set(git_clone_depth 50)
-set(git_submodule_depth 10)
 
 set(run 0)
 
@@ -129,21 +128,12 @@ if(error_code)
 endif()
 
 execute_process(
-  COMMAND \"${git_EXECUTABLE}\" submodule update --depth \${git_submodule_depth} --recursive ${git_submodules}
+  COMMAND \"${git_EXECUTABLE}\" submodule update --recursive ${git_submodules}
   WORKING_DIRECTORY \"${work_dir}/${src_name}\"
   RESULT_VARIABLE error_code
 )
 if(error_code)
-  message(STATUS \"Fetching fuller submodule\")
-  execute_process(
-    # some repos are already unshallow at --depth=10, so go deep
-    COMMAND \"${git_EXECUTABLE}\" submodule foreach \"${git_EXECUTABLE} fetch --depth=9999\" --recursive ${git_submodules}
-    WORKING_DIRECTORY \"${work_dir}/${src_name}\"
-    RESULT_VARIABLE error_code
-  )
-  if(error_code)
-    message(FATAL_ERROR \"Failed to update submodules in: '${work_dir}/${src_name}'\")
-  endif()
+  message(FATAL_ERROR \"Failed to update submodules in: '${work_dir}/${src_name}'\")
 endif()
 
 # Complete success, update the script-last-run stamp file:

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -134,9 +134,10 @@ execute_process(
   RESULT_VARIABLE error_code
 )
 if(error_code)
-  message(STATUS \"Fetching full repo\")
+  message(STATUS \"Fetching fuller submodule\")
   execute_process(
-    COMMAND \"${git_EXECUTABLE}\" submodule update --depth 999999 --recursive ${git_submodules}
+    # some repos are already unshallow at --depth=10, so go deep
+    COMMAND \"${git_EXECUTABLE}\" submodule foreach \"${git_EXECUTABLE} fetch --depth=9999\" --recursive ${git_submodules}
     WORKING_DIRECTORY \"${work_dir}/${src_name}\"
     RESULT_VARIABLE error_code
   )

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -6,6 +6,10 @@ function(_ko_write_gitclone_script script_filename git_EXECUTABLE git_repository
   message(FATAL_ERROR \"Tag for git checkout should not be empty.\")
 endif()
 
+# Default depth
+set(git_clone_depth 50)
+set(git_submodule_depth 10)
+
 set(run 0)
 
 ######################################################################
@@ -53,7 +57,7 @@ if(should_clone)
   set(number_of_tries 0)
   while(error_code AND number_of_tries LESS 3)
     execute_process(
-      COMMAND \"${git_EXECUTABLE}\" clone \"${git_repository}\" \"${src_name}\"
+      COMMAND \"${git_EXECUTABLE}\" clone --depth \${git_clone_depth} \"${git_repository}\" \"${src_name}\"
       WORKING_DIRECTORY \"${work_dir}\"
       RESULT_VARIABLE error_code
     )
@@ -84,7 +88,7 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
     )
     execute_process(
-      COMMAND \"${git_EXECUTABLE}\" fetch
+      COMMAND \"${git_EXECUTABLE}\" fetch origin :refs/remotes/origin/${git_tag}
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
       RESULT_VARIABLE error_code
     )
@@ -97,7 +101,19 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
       RESULT_VARIABLE error_code
     )
     if(error_code)
-      message(FATAL_ERROR \"Failed to checkout tag: '${git_tag}'\")
+      message(STATUS \"Fetching full repo\")
+      execute_process(
+        COMMAND \"${git_EXECUTABLE}\" fetch --all
+        WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+      )
+      execute_process(
+        COMMAND \"${git_EXECUTABLE}\" checkout -f ${git_tag}
+        WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+        RESULT_VARIABLE error_code
+      )
+      if(error_code)
+        message(FATAL_ERROR \"Failed to checkout tag: '${git_tag}'\")
+      endif()
     endif()
   endif()
 endif()
@@ -113,7 +129,7 @@ if(error_code)
 endif()
 
 execute_process(
-  COMMAND \"${git_EXECUTABLE}\" submodule update --recursive ${git_submodules}
+  COMMAND \"${git_EXECUTABLE}\" submodule update --depth \${git_submodule_depth} --recursive ${git_submodules}
   WORKING_DIRECTORY \"${work_dir}/${src_name}\"
   RESULT_VARIABLE error_code
 )

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -103,7 +103,7 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
     if(error_code)
       message(STATUS \"Fetching full repo\")
       execute_process(
-        COMMAND \"${git_EXECUTABLE}\" fetch --depth 999999
+        COMMAND \"${git_EXECUTABLE}\" fetch --unshallow --tags
         WORKING_DIRECTORY \"${work_dir}/${src_name}\"
       )
       execute_process(

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -88,7 +88,7 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
     )
     execute_process(
-      COMMAND \"${git_EXECUTABLE}\" fetch origin :refs/remotes/origin/${git_tag}
+      COMMAND \"${git_EXECUTABLE}\" fetch origin \"${git_tag}\"
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
       RESULT_VARIABLE error_code
     )

--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -88,7 +88,7 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
     )
     execute_process(
-      COMMAND \"${git_EXECUTABLE}\" fetch origin \"${git_tag}\"
+      COMMAND \"${git_EXECUTABLE}\" fetch
       WORKING_DIRECTORY \"${work_dir}/${src_name}\"
       RESULT_VARIABLE error_code
     )
@@ -103,7 +103,7 @@ if(NOT \"\${curr_tag}\" STREQUAL \"${git_tag}\")
     if(error_code)
       message(STATUS \"Fetching full repo\")
       execute_process(
-        COMMAND \"${git_EXECUTABLE}\" fetch --all
+        COMMAND \"${git_EXECUTABLE}\" fetch --depth 999999
         WORKING_DIRECTORY \"${work_dir}/${src_name}\"
       )
       execute_process(


### PR DESCRIPTION
Uses a fairly conservative value of 50 for now. Also implements a fallback to pull in the entire repo if that's not enough.

This will mainly help to speed up the nightly builds and the CI builds, but it will also reduce the space and time investment for potential hackers.