### PR TITLE
cre: adds getCacheFilePath()

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -12,7 +12,7 @@ export TESSDATA_PREFIX
 cd build/* && TESSDATA_PREFIX=$(pwd)/data && mkdir -p data/tessdata
 mv ../../tesseract-ocr/tessdata/* data/tessdata/ && cd ../../ || exit
 # fetch font for base test
-travis_retry wget https://github.com/koreader/koreader/raw/master/resources/fonts/droid/DroidSansMono.ttf
+travis_retry wget https://github.com/koreader/koreader-fonts/raw/master/droid/DroidSansMono.ttf
 export OUTPUT_DIR
 if [ -n "${KODEBUG+x}" ]; then
     KODEBUG_SUFFIX=-debug

--- a/cre.cpp
+++ b/cre.cpp
@@ -510,6 +510,15 @@ static int invalidateCacheFile(lua_State *L) {
     return 0;
 }
 
+static int getCacheFilePath(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    lString16 cache_path = doc->dom_doc->getCacheFilePath();
+    if (cache_path.empty())
+        return 0;
+    lua_pushstring(L, UnicodeToLocal(cache_path).c_str());
+    return 1;
+}
+
 static int getDocumentProps(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 
@@ -1691,6 +1700,7 @@ static const struct luaL_Reg credocument_meth[] = {
 	{"isBuiltDomStale", isBuiltDomStale},
 	{"hasCacheFile", hasCacheFile},
 	{"invalidateCacheFile", invalidateCacheFile},
+	{"getCacheFilePath", getCacheFilePath},
 	{"gotoPage", gotoPage},
 	{"gotoPercent", gotoPercent},
 	{"gotoPos", gotoPos},


### PR DESCRIPTION
So we can manage the cache file from lua side (delete, add/remove a ".keep" extension, etc...)
Bump crengine for _Adds tinyNodeCollection::getCacheFilePath()_ https://github.com/koreader/crengine/pull/190