### PR TITLE
Adds cre.getLatestDomVersion() and cre.requestDomVersion()

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -367,6 +367,17 @@ static int newDocView(lua_State *L) {
 	return 1;
 }
 
+static int getLatestDomVersion(lua_State *L) {
+    lua_pushnumber(L, gDOMVersionCurrent);
+    return 1;
+}
+
+static int requestDomVersion(lua_State *L) {
+    int version = luaL_checkint(L, 1);
+    gDOMVersionRequested = version;
+    return 0;
+}
+
 static int saveDefaults(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	CRPropRef props = doc->text_view->propsGetCurrent();
@@ -1655,6 +1666,8 @@ static const struct luaL_Reg cre_func[] = {
 	{"getHyphDictList", getHyphDictList},
 	{"getSelectedHyphDict", getSelectedHyphDict},
 	{"setHyphDictionary", setHyphDictionary},
+	{"getLatestDomVersion", getLatestDomVersion},
+	{"requestDomVersion", requestDomVersion},
 	{NULL, NULL}
 };
 


### PR DESCRIPTION
The previous usage of `getIntProperty("crengine.dom.version")` and `setIntProperty("crengine.dom.version", version)` had some unwelcome side effects.

Let's wait for https://github.com/koreader/crengine/pull/192 to be merged to bump crengine with this PR too. (I cancelled the Travis checks to save a few trees)