### PR TITLE
Prettier koptcontext FFI :D

### DIFF
--- a/ffi-cdecl/koptcontext_cdecl.c
+++ b/ffi-cdecl/koptcontext_cdecl.c
@@ -1,4 +1,5 @@
 // CPPFLAGS="-I../koreader-base/ -I../koreader-base/thirdparty/libk2pdfopt/libk2pdfopt/k2pdfoptlib -I../koreader-base/thirdparty/libk2pdfopt/libk2pdfopt -I../koreader-base/thirdparty/libk2pdfopt/libk2pdfopt/willuslib -I../koreader-base/thirdparty/libk2pdfopt/libk2pdfopt/include_mod -I../koreader-base/thirdparty/leptonica/leptonica/src -I/usr/include/luajit-2.0" ./ffi-cdecl ...
+//#include "alltypes.h"
 #include "koptcontext.h"
 #include "koptreflow.h"
 #include "koptcrop.h"

--- a/ffi-cdecl/pthread_cdecl.c
+++ b/ffi-cdecl/pthread_cdecl.c
@@ -4,6 +4,9 @@
 
 cdecl_type(pthread_t)
 
+// NOTE: This is... annoying. The array's size depends on the arch (c.f., __SIZEOF_PTHREAD_ATTR_T).
+//cdecl_const(__SIZEOF_PTHREAD_ATTR_T)
+//cdecl_union(pthread_attr_t)
 cdecl_type(pthread_attr_t)
 
 cdecl_func(pthread_attr_init)

--- a/ffi-cdecl/pthread_cdecl.c
+++ b/ffi-cdecl/pthread_cdecl.c
@@ -6,7 +6,9 @@ cdecl_type(pthread_t)
 
 // NOTE: This is... annoying. The array's size depends on the arch (c.f., __SIZEOF_PTHREAD_ATTR_T).
 //       We dispatch loading the right one with a bit of trickery in ffi/pthread_h.lua
+//       c.f., https://github.com/koreader/koreader/pull/4016#issuecomment-399692355 for the full story
 //cdecl_const(__SIZEOF_PTHREAD_ATTR_T)
+
 //cdecl_union(pthread_attr_t)
 cdecl_type(pthread_attr_t)
 

--- a/ffi-cdecl/pthread_cdecl.c
+++ b/ffi-cdecl/pthread_cdecl.c
@@ -5,6 +5,7 @@
 cdecl_type(pthread_t)
 
 // NOTE: This is... annoying. The array's size depends on the arch (c.f., __SIZEOF_PTHREAD_ATTR_T).
+//       We dispatch loading the right one with a bit of trickery in ffi/pthread_h.lua
 //cdecl_const(__SIZEOF_PTHREAD_ATTR_T)
 //cdecl_union(pthread_attr_t)
 cdecl_type(pthread_attr_t)

--- a/ffi/koptcontext_h.lua
+++ b/ffi/koptcontext_h.lua
@@ -132,10 +132,10 @@ struct KOPTContext {
   int precache;
   int debug;
   int cjkchar;
-  struct Boxa *rboxa;
-  struct Numa *rnai;
-  struct Boxa *nboxa;
-  struct Numa *nnai;
+  BOXA* rboxa;
+  NUMA* rnai;
+  BOXA* nboxa;
+  NUMA* nnai;
   WRECTMAPS rectmaps;
   PAGEREGIONS pageregions;
   BBox bbox;

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -891,7 +891,7 @@ function page_mt.__index:reflow(kopt_context)
     if kopt_context.precache ~= 0 then
         local pthread = get_pthread()
         local rf_thread = ffi.new("pthread_t[1]")
-        local attr = ffi.new("pthread_attr_t")
+        local attr = ffi.new("pthread_attr_t[1]")
         pthread.pthread_attr_init(attr)
         pthread.pthread_attr_setdetachstate(attr, pthread.PTHREAD_CREATE_DETACHED)
         pthread.pthread_create(rf_thread, attr, k2pdfopt.k2pdfopt_reflow_bmp, ffi.cast("void*", kopt_context))

--- a/ffi/pthread_def_h.lua
+++ b/ffi/pthread_def_h.lua
@@ -1,0 +1,14 @@
+local ffi = require("ffi")
+
+ffi.cdef[[
+typedef long unsigned int pthread_t;
+typedef union {
+  char __size[36];
+  long int __align;
+} pthread_attr_t;
+int pthread_attr_init(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_setdetachstate(pthread_attr_t *, int) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_destroy(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+static const int PTHREAD_CREATE_DETACHED = 1;
+int pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict) __attribute__((__nothrow__));
+]]

--- a/ffi/pthread_h.lua
+++ b/ffi/pthread_h.lua
@@ -3,7 +3,7 @@ local ffi = require("ffi")
 ffi.cdef[[
 typedef long unsigned int pthread_t;
 typedef union {
-  char __size[36];
+  char __size[56];
   long int __align;
 } pthread_attr_t;
 int pthread_attr_init(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));

--- a/ffi/pthread_h.lua
+++ b/ffi/pthread_h.lua
@@ -1,14 +1,12 @@
 local ffi = require("ffi")
 
-ffi.cdef[[
-typedef long unsigned int pthread_t;
-typedef union {
-  char __size[56];
-  long int __align;
-} pthread_attr_t;
-int pthread_attr_init(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
-int pthread_attr_setdetachstate(pthread_attr_t *, int) __attribute__((__nothrow__, __leaf__));
-int pthread_attr_destroy(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
-static const int PTHREAD_CREATE_DETACHED = 1;
-int pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict) __attribute__((__nothrow__));
-]]
+-- The declaration vary depending on the arch, load the right one...
+
+if ffi.arch == "x64" then
+    require("ffi/pthread_x64_h")
+elseif ffi.arch == "x86" then
+    require("ffi/pthread_x86_h")
+else
+    require("ffi/pthread_def_h")
+end
+

--- a/ffi/pthread_x64_h.lua
+++ b/ffi/pthread_x64_h.lua
@@ -1,0 +1,14 @@
+local ffi = require("ffi")
+
+ffi.cdef[[
+typedef long unsigned int pthread_t;
+typedef union {
+  char __size[56];
+  long int __align;
+} pthread_attr_t;
+int pthread_attr_init(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_setdetachstate(pthread_attr_t *, int) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_destroy(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+static const int PTHREAD_CREATE_DETACHED = 1;
+int pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict) __attribute__((__nothrow__));
+]]

--- a/ffi/pthread_x86_h.lua
+++ b/ffi/pthread_x86_h.lua
@@ -1,0 +1,14 @@
+local ffi = require("ffi")
+
+ffi.cdef[[
+typedef long unsigned int pthread_t;
+typedef union {
+  char __size[32];
+  long int __align;
+} pthread_attr_t;
+int pthread_attr_init(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_setdetachstate(pthread_attr_t *, int) __attribute__((__nothrow__, __leaf__));
+int pthread_attr_destroy(pthread_attr_t *) __attribute__((__nothrow__, __leaf__));
+static const int PTHREAD_CREATE_DETACHED = 1;
+int pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict) __attribute__((__nothrow__));
+]]


### PR DESCRIPTION
(Use leptonica types directly. Functionally identical).
It already needs postprocessing for the leptonica require anyway...