### PR TITLE
Unbreak KOA2 handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(OUTPUT_DIR)/plugins $(LUASOCKET) \
 		$(OUTPUT_DIR)/ffi $(OUTPUT_DIR)/data \
 		$(if $(WIN32),,$(LUASEC)) \
-		$(if $(WIN32),,$(LUACOMPAT52) $(LUALONGNUMBER) $(EVERNOTE_LIB)) \
+		$(if $(ANDROID),$(LUACOMPAT52) $(LUALONGNUMBER),) \
+		$(if $(WIN32),,$(EVERNOTE_LIB)) \
 		$(LUASERIAL_LIB) \
 		$(TURBOJPEG_LIB) \
 		$(LODEPNG_LIB) \

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,7 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(OUTPUT_DIR)/plugins $(LUASOCKET) \
 		$(OUTPUT_DIR)/ffi $(OUTPUT_DIR)/data \
 		$(if $(WIN32),,$(LUASEC)) \
-		$(if $(ANDROID),$(LUACOMPAT52) $(LUALONGNUMBER),) \
-		$(if $(WIN32),,$(EVERNOTE_LIB)) \
+		$(if $(WIN32),,$(LUACOMPAT52) $(LUALONGNUMBER) $(EVERNOTE_LIB)) \
 		$(LUASERIAL_LIB) \
 		$(TURBOJPEG_LIB) \
 		$(LODEPNG_LIB) \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -342,6 +342,9 @@ ifdef EMULATE_READER
 		CMAKE_CXX_COMPILER_LAUNCHER:=$(CCACHE)
 	endif
 	# Regular
+	REALCC:=$(HOSTCC)
+	REALCXX:=$(HOSTCXX)
+	REALAR:=$(HOSTAR)
 	HOSTCC:=$(strip $(CCACHE) $(HOSTCC))
 	HOSTCXX:=$(strip $(CCACHE) $(HOSTCXX))
 	HOSTAR:=$(strip $(CCACHE) $(HOSTAR))
@@ -362,6 +365,9 @@ else
 		CMAKE_C_COMPILER_LAUNCHER:=$(CCACHE)
 		CMAKE_CXX_COMPILER_LAUNCHER:=$(CCACHE)
 	endif
+	REALCC:=$(CC)
+	REALCXX:=$(CXX)
+	REALAR:=$(AR)
 	# Don't let libtool piss on our parade...
 	# See what was mentioned around STATIC_LIBSTDCPP on ~L#93 for more details
 	# (cf. https://www.gnu.org/software/libtool/manual/html_node/Stripped-link-flags.html#Stripped-link-flags)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -629,6 +629,7 @@ NANOSVG_HEADERS=$(addprefix $(NANOSVG_INCLUDE_DIR)/, $(NANOSVG_HEADER_FILES))
 # also, dynamic libraries must be compiled with "-shared" and "-fPIC".
 # having all symbols included (-E) won't hurt, too.
 DYNLIB_CFLAGS=-L$(CURDIR)/$(OUTPUT_DIR)/libs $(CFLAGS) -I$(LUAJIT_DIR)/src -shared
+DYNLIB_CMAKE_CFLAGS=-L$(CURDIR)/$(OUTPUT_DIR)/libs $(CFLAGS) -I$(LUAJIT_DIR)/src -shared
 ifdef DARWIN
 	DYNLIB_CFLAGS+= -dynamiclib -undefined dynamic_lookup
 else
@@ -640,6 +641,11 @@ endif
 # \\\$$\\\$$ORIGIN   \\\$\\\$ORIGIN   \$\$ORIGIN   $$ORIGIN     $$ORIGIN   $ORIGIN
 ORIGIN_CMAKE_TO_AUTOCFG=\\\$$\\\$$ORIGIN
 
+ifdef DARWIN
+	DYNLIB_CMAKE_CFLAGS+= -dynamiclib -undefined dynamic_lookup
+else
+	DYNLIB_CMAKE_CFLAGS+= -Wl,-E -Wl,-rpath,'$(ORIGIN_CMAKE_TO_AUTOCFG)'
+endif
 
 LPEG_BUILD_DIR=$(THIRDPARTY_DIR)/lpeg/build/$(MACHINE)
 LPEG_DIR=$(CURDIR)/$(LPEG_BUILD_DIR)/lpeg-prefix/src/lpeg

--- a/Makefile.third
+++ b/Makefile.third
@@ -388,7 +388,7 @@ $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build
 	cd $(OPENSSL_BUILD_DIR) && \
-		$(CMAKE) -UCMAKE_C_COMPILER_LAUNCHER -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
+		$(CMAKE) -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
 		-DSHARED_LDFLAGS="$(LDFLAGS)" \
 		-DLD="$(LD)" -DRANLIB="$(RANLIB)" $(if $(or $(WIN32),$(ANDROID)),-DCHOST="$(CHOST)",) \
 		-DCONFIG_SCRIPT="$(if $(EMULATE_READER),$(if $(DARWIN),Configure darwin64-x86_64-cc,config),Configure $(if $(WIN32),mingw,linux-generic32))" \

--- a/Makefile.third
+++ b/Makefile.third
@@ -383,11 +383,12 @@ $(LUASOCKET): $(THIRDPARTY_DIR)/luasocket/CMakeLists.txt
 		$(CURDIR)/$(THIRDPARTY_DIR)/luasocket && \
 		$(MAKE)
 
+# NOTE: We bypass ccache because OpenSSL's build-system is a Jenga tower waiting to fall.
 $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build
 	cd $(OPENSSL_BUILD_DIR) && \
-		$(CMAKE) -DCC="$(CC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
+		$(CMAKE) -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
 		-DSHARED_LDFLAGS="$(LDFLAGS)" \
 		-DLD="$(LD)" -DRANLIB="$(RANLIB)" $(if $(or $(WIN32),$(ANDROID)),-DCHOST="$(CHOST)",) \
 		-DCONFIG_SCRIPT="$(if $(EMULATE_READER),$(if $(DARWIN),Configure darwin64-x86_64-cc,config),Configure $(if $(WIN32),mingw,linux-generic32))" \

--- a/Makefile.third
+++ b/Makefile.third
@@ -388,7 +388,9 @@ $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build
 	cd $(OPENSSL_BUILD_DIR) && \
-		$(CMAKE) -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
+		$(CMAKE) \
+		-DREALCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
+		-DCC="$(CC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
 		-DSHARED_LDFLAGS="$(LDFLAGS)" \
 		-DLD="$(LD)" -DRANLIB="$(RANLIB)" $(if $(or $(WIN32),$(ANDROID)),-DCHOST="$(CHOST)",) \
 		-DCONFIG_SCRIPT="$(if $(EMULATE_READER),$(if $(DARWIN),Configure darwin64-x86_64-cc,config),Configure $(if $(WIN32),mingw,linux-generic32))" \

--- a/Makefile.third
+++ b/Makefile.third
@@ -384,7 +384,13 @@ $(LUASOCKET): $(THIRDPARTY_DIR)/luasocket/CMakeLists.txt
 		$(MAKE)
 
 # RPATH for OPENSSL is even uglier because its Makefile uses single quote :/
-OPENSSL_RPATH_ORIGIN=\\\"'$(ORIGIN_CMAKE_TO_AUTOCFG)'\\\"
+#OPENSSL_RPATH_ORIGIN=\\\"'$(ORIGIN_CMAKE_TO_AUTOCFG)'\\\"
+# FIXME: Possibly because CMake is *also* terrible, this doesn't work either.
+#        So go with a cheap-ass better than nothing (maybe?) workaround.
+OPENSSL_RPATH_ORIGIN="'.'"
+# FWIW, when doing thing manually, passing \\\$\$\$\$ORIGIN works
+#       f.g., make libssl.so.1.0.0 SHARED_LDFLAGS="${LDFLAGS} -Wl,-rpath,\\\$\$\$\$ORIGIN"
+# SO if anyone can replicate that w/ CMake, bully for you.
 $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build

--- a/Makefile.third
+++ b/Makefile.third
@@ -548,7 +548,7 @@ $(EVERNOTE_LIB): $(THIRDPARTY_DIR)/evernote-sdk-lua/CMakeLists.txt
 		$(CMAKE) -DCC="$(CC) $(CFLAGS)" \
 		-DOUTPUT_DIR="$(CURDIR)/$(EVERNOTE_PLUGIN_DIR)/lib" \
 		-DLDFLAGS="$(LDFLAGS) $(if $(or $(ANDROID),$(WIN32)),-lm $(CURDIR)/$(LUAJIT_LIB))" \
-		-DDYNLIB_CFLAGS="$(DYNLIB_CFLAGS)" \
+		-DDYNLIB_CFLAGS="$(DYNLIB_CMAKE_CFLAGS)" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/evernote-sdk-lua && \
 		$(MAKE)
 

--- a/Makefile.third
+++ b/Makefile.third
@@ -388,7 +388,7 @@ $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build
 	cd $(OPENSSL_BUILD_DIR) && \
-		$(CMAKE) -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
+		$(CMAKE) -UCMAKE_C_COMPILER_LAUNCHER -DCC="$(REALCC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
 		-DSHARED_LDFLAGS="$(LDFLAGS)" \
 		-DLD="$(LD)" -DRANLIB="$(RANLIB)" $(if $(or $(WIN32),$(ANDROID)),-DCHOST="$(CHOST)",) \
 		-DCONFIG_SCRIPT="$(if $(EMULATE_READER),$(if $(DARWIN),Configure darwin64-x86_64-cc,config),Configure $(if $(WIN32),mingw,linux-generic32))" \

--- a/Makefile.third
+++ b/Makefile.third
@@ -383,20 +383,12 @@ $(LUASOCKET): $(THIRDPARTY_DIR)/luasocket/CMakeLists.txt
 		$(CURDIR)/$(THIRDPARTY_DIR)/luasocket && \
 		$(MAKE)
 
-# RPATH for OPENSSL is even uglier because its Makefile uses single quote :/
-#OPENSSL_RPATH_ORIGIN=\\\"'$(ORIGIN_CMAKE_TO_AUTOCFG)'\\\"
-# FIXME: Possibly because CMake is *also* terrible, this doesn't work either.
-#        So go with a cheap-ass better than nothing (maybe?) workaround.
-OPENSSL_RPATH_ORIGIN="'.'"
-# FWIW, when doing thing manually, passing \\\$\$\$\$ORIGIN works
-#       f.g., make libssl.so.1.0.0 SHARED_LDFLAGS="${LDFLAGS} -Wl,-rpath,\\\$\$\$\$ORIGIN"
-# SO if anyone can replicate that w/ CMake, bully for you.
 $(OPENSSL_LIB) $(OPENSSL_DIR): $(THIRDPARTY_DIR)/openssl/CMakeLists.txt
 	install -d $(OPENSSL_BUILD_DIR)
 	-rm -f $(OPENSSL_DIR)/../openssl-stamp/openssl-build
 	cd $(OPENSSL_BUILD_DIR) && \
 		$(CMAKE) -DCC="$(CC) $(if $(DARWIN),$(DYNLIB_CFLAGS),$(CFLAGS))" \
-		-DSHARED_LDFLAGS="$(LDFLAGS) -Wl,-rpath,$(OPENSSL_RPATH_ORIGIN)" \
+		-DSHARED_LDFLAGS="$(LDFLAGS)" \
 		-DLD="$(LD)" -DRANLIB="$(RANLIB)" $(if $(or $(WIN32),$(ANDROID)),-DCHOST="$(CHOST)",) \
 		-DCONFIG_SCRIPT="$(if $(EMULATE_READER),$(if $(DARWIN),Configure darwin64-x86_64-cc,config),Configure $(if $(WIN32),mingw,linux-generic32))" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/openssl && \

--- a/ffi-cdecl/SDL2_0_decl.c
+++ b/ffi-cdecl/SDL2_0_decl.c
@@ -87,6 +87,7 @@ cdecl_func(SDL_RenderPresent)
 cdecl_func(SDL_RenderCopy)
 cdecl_func(SDL_CreateTexture)
 cdecl_func(SDL_UpdateTexture)
+cdecl_func(SDL_DestroyTexture)
 cdecl_func(SDL_SetWindowTitle)
 
 cdecl_type(SDL_blit)

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -667,6 +667,7 @@ void SDL_RenderPresent(SDL_Renderer *) __attribute__((visibility("default")));
 int SDL_RenderCopy(SDL_Renderer *, SDL_Texture *, const SDL_Rect *, const SDL_Rect *) __attribute__((visibility("default")));
 SDL_Texture *SDL_CreateTexture(SDL_Renderer *, Uint32, int, int, int) __attribute__((visibility("default")));
 int SDL_UpdateTexture(SDL_Texture *, const SDL_Rect *, const void *, int) __attribute__((visibility("default")));
+void SDL_DestroyTexture(SDL_Texture *) __attribute__((visibility("default")));
 void SDL_SetWindowTitle(SDL_Window *, const char *) __attribute__((visibility("default")));
 typedef int (*SDL_blit)(struct SDL_Surface *, SDL_Rect *, struct SDL_Surface *, SDL_Rect *);
 SDL_Surface *SDL_CreateRGBSurface(Uint32, int, int, int, Uint32, Uint32, Uint32, Uint32) __attribute__((visibility("default")));

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -166,6 +166,9 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
       or (refresh_type == C.UPDATE_MODE_FULL and fb:_isUIWaveFormMode(waveform_mode) and fb:_isFullScreen(w, h)))
       and fb.mech_wait_update_complete
       and (marker >= MARKER_MIN and marker <= MARKER_MAX) then
+        -- NOTE: Disabled collision_test handling, because it's fragile, mysterious, easy to get wrong, hard to do right,
+        --       and might change at a moment's notice, like the KOA2 proved...
+        --[[
         -- NOTE: Setup the slightly mysterious collision_test flag...
         --       This is Kindle-only, but extra arguments are safely ignored in Lua ;).
         if fb:_isREAGLWaveFormMode(waveform_mode) then
@@ -177,6 +180,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
         end
         -- NOTE: The KOA2 also sometimes (flashing? new menu?) waits on a previous (sometimes as far back as ~10 updates ago)
         --       "fast" (i.e., DU) marker, in which case collision is set to 1981826464
+        --]]
         fb.debug("refresh: wait for completion of (previous) marker", marker, "with collision_test", collision_test)
         fb.mech_wait_update_complete(fb, marker, collision_test)
     end
@@ -210,6 +214,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     -- NOTE: We wait for completion after *any kind* of full (i.e., flashing) update.
     if refarea[0].update_mode == C.UPDATE_MODE_FULL
       and fb.mech_wait_update_complete then
+        --[[
         -- NOTE: Again, setup collision_test magic numbers...
         if fb:_isREAGLWaveFormMode(waveform_mode) then
             collision_test = 4
@@ -220,6 +225,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
             -- On a KOA2:
             collision_test = 4096
         end
+        --]]
         fb.debug("refresh: wait for completion of marker", marker, "with collision_test", collision_test)
         fb.mech_wait_update_complete(fb, marker, collision_test)
     end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -431,6 +431,9 @@ function framebuffer:init()
 
             self.waveform_fast = C.WAVEFORM_MODE_DU
             self.waveform_ui = C.WAVEFORM_MODE_AUTO
+            -- NOTE: Possibly to bypass the possibility that AUTO, even when FULL, might not flash (something which holds true for a number of devices, especially on small regions),
+            --       The KOA2 explicitly requests GC16 when flashing an UI element that doesn't cover the full screen...
+            --       And it resorts to AUTO when PARTIAL, because GC16_FAST is no more (it points to GC16).
             self.waveform_flashui = C.WAVEFORM_MODE_GC16
             self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -258,7 +258,7 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
         refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_GC16	-- NOTE: GC16_FAST points to GC16
     end
     -- NOTE: Since there's no longer a distinction between GC16_FAST & GC16, we're done!
-    refarea[0].temp = C.TEMP_USE_KOA2_AUTO
+    refarea[0].temp = C.TEMP_USE_AMBIENT
     refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
     refarea[0].quant_bit = 0;
     -- Enable the appropriate flag when requesting what amounts to a 2bit update

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -255,7 +255,7 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
         refarea[0].hist_gray_waveform_mode = waveform_mode
     else
         refarea[0].hist_bw_waveform_mode = C.WAVEFORM_MODE_DU
-        refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_KOA2_GC16_FAST	-- NOTE: Points to WAVEFORM_MODE_GC16
+        refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_GC16	-- NOTE: GC16_FAST points to GC16
     end
     -- And we're only left with true full updates to special-case.
     if waveform_mode == C.WAVEFORM_MODE_GC16 then
@@ -412,7 +412,7 @@ function framebuffer:init()
             self.waveform_fast = C.WAVEFORM_MODE_DU
             self.waveform_ui = C.WAVEFORM_MODE_AUTO
             self.waveform_full = C.WAVEFORM_MODE_GC16
-            self.waveform_reagl = C.WAVEFORM_MODE_KOA2_REAGL	-- NOTE: Points to WAVEFORM_MODE_GLR16
+            self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl
         end
     elseif self.device:isKobo() then

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -257,10 +257,7 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
         refarea[0].hist_bw_waveform_mode = C.WAVEFORM_MODE_DU
         refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_GC16	-- NOTE: GC16_FAST points to GC16
     end
-    -- And we're only left with true full updates to special-case.
-    if waveform_mode == C.WAVEFORM_MODE_GC16 then
-        refarea[0].hist_gray_waveform_mode = waveform_mode
-    end
+    -- NOTE: Since there's no longer a distinction between GC16_FAST & GC16, we're done!
     refarea[0].temp = C.TEMP_USE_KOA2_AUTO
     refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
     refarea[0].quant_bit = 0;

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -443,7 +443,7 @@ function framebuffer:init()
 
         self.waveform_fast = C.WAVEFORM_MODE_A2
         self.waveform_ui = C.WAVEFORM_MODE_AUTO
-        self.waveform_flashui = C.NTX_WFM_MODE_GC16
+        self.waveform_flashui = C.WAVEFORM_MODE_AUTO
         self.waveform_full = C.NTX_WFM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -277,7 +277,7 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
         refarea[0].hist_gray_waveform_mode = waveform_mode
     else
         refarea[0].hist_bw_waveform_mode = C.WAVEFORM_MODE_DU
-        refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_GC16	-- NOTE: GC16_FAST points to GC16
+        refarea[0].hist_gray_waveform_mode = C.WAVEFORM_MODE_GC16 -- NOTE: GC16_FAST points to GC16
     end
     -- NOTE: Since there's no longer a distinction between GC16_FAST & GC16, we're done!
     refarea[0].temp = C.TEMP_USE_AMBIENT
@@ -390,7 +390,7 @@ function framebuffer:init()
 
         self.waveform_fast = C.WAVEFORM_MODE_A2
         self.waveform_ui = C.WAVEFORM_MODE_GC16_FAST
-        self.waveform_flashui = C.WAVEFORM_MODE_GC16_FAST
+        self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.WAVEFORM_MODE_GC16
 
         -- New devices are REAGL-aware, default to REAGL
@@ -419,7 +419,7 @@ function framebuffer:init()
 
         if isREAGL then
             self.mech_wait_update_complete = kindle_carta_mxc_wait_for_update_complete
-            self.waveform_fast = C.WAVEFORM_MODE_DU
+            self.waveform_fast = C.WAVEFORM_MODE_DU -- NOTE: DU, because A2 looks terrible on REAGL devices. Older devices/FW may be using AUTO in this instance.
             self.waveform_reagl = C.WAVEFORM_MODE_REAGL
             self.waveform_partial = self.waveform_reagl
         else
@@ -446,7 +446,7 @@ function framebuffer:init()
 
         self.waveform_fast = C.WAVEFORM_MODE_A2
         self.waveform_ui = C.WAVEFORM_MODE_AUTO
-        self.waveform_flashui = C.WAVEFORM_MODE_AUTO
+        self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.NTX_WFM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
 
@@ -494,7 +494,7 @@ function framebuffer:init()
 
         self.waveform_fast = C.WAVEFORM_MODE_A2
         self.waveform_ui = C.WAVEFORM_MODE_GC16
-        self.waveform_flashui = C.WAVEFORM_MODE_GC16
+        self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_GC16
     else

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -29,7 +29,7 @@ if($ENV{ANDROID})
 endif()
 
 set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
-set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
+set(CFG_CMD sh -c "${CFG_ENV_VAR} CC=\"${CC}\" ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
 set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
 set(BUILD_CMD sh -c "${BUILD_CMD} depend build_crypto build_ssl")

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -37,7 +37,7 @@ set(BUILD_CMD sh -c "${BUILD_CMD} --silent depend build_crypto build_ssl >/dev/n
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/openssl/openssl.git
-    OpenSSL_1_0_1u
+    OpenSSL_1_0_2o
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -8,6 +8,7 @@ include("koreader_thirdparty_git")
 enable_language(C)
 
 assert_var_defined(CONFIG_SCRIPT)
+assert_var_defined(REALCC)
 assert_var_defined(CC)
 assert_var_defined(SHARED_LDFLAGS)
 assert_var_defined(LD)
@@ -29,10 +30,14 @@ if($ENV{ANDROID})
 endif()
 
 set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
-set(CFG_CMD sh -c "${CFG_ENV_VAR} CC=\"${CC}\" ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
+set(CFG_CMD sh -c "${CFG_ENV_VAR} CC=\"${REALCC}\" ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
-set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
-set(BUILD_CMD sh -c "${BUILD_CMD} depend build_crypto build_ssl")
+set(MAKE_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
+# NOTE: Make depend fails when using ccache, and may fail when // (on some OpenSSL versions, at least)
+set(MAKE_CMD_REALCC "$(MAKE) -j1 CC=\"${REALCC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
+set(BUILD_CMD1 sh -c "${BUILD_CMD_REALCC} depend")
+set(BUILD_CMD2 sh -c "${BUILD_CMD} build_crypto build_ssl")
+
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
@@ -48,7 +53,7 @@ ExternalProject_Add(
     PATCH_COMMAND patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/openssl-origin-rpath.patch
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_IN_SOURCE 1
-    BUILD_COMMAND ${BUILD_CMD}
+    BUILD_COMMAND COMMAND ${BUILD_CMD1} COMMAND ${BUILD_CMD2}
     # skip install
     INSTALL_COMMAND ""
 )

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -45,6 +45,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
+    PATCH_COMMAND patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/openssl-origin-rpath.patch
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_IN_SOURCE 1
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
 set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
-set(BUILD_CMD sh -c "${BUILD_CMD} depend build_crypto build_ssl >/dev/null 2>&1")
+set(BUILD_CMD sh -c "${BUILD_CMD} depend build_crypto build_ssl")
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -35,8 +35,8 @@ set(CFG_CMD sh -c "${CFG_ENV_VAR} CC=\"${REALCC}\" ${SOURCE_DIR}/${CONFIG_SCRIPT
 set(MAKE_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
 # NOTE: Make depend fails when using ccache, and may fail when // (on some OpenSSL versions, at least)
 set(MAKE_CMD_REALCC "$(MAKE) -j1 CC=\"${REALCC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
-set(BUILD_CMD1 sh -c "${BUILD_CMD_REALCC} depend")
-set(BUILD_CMD2 sh -c "${BUILD_CMD} build_crypto build_ssl")
+set(BUILD_CMD1 sh -c "${MAKE_CMD_REALCC} depend")
+set(BUILD_CMD2 sh -c "${MAKE_CMD} build_crypto build_ssl")
 
 
 ko_write_gitclone_script(

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CFG_OPTS "${CFG_OPTS} no-asm no-idea no-mdc2 no-rc5 no-ssl2 no-ssl3")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/${CONFIG_SCRIPT} ${CFG_OPTS}")
 
 set(BUILD_CMD "$(MAKE) CC=\"${CC}\" SHARED_LDFLAGS=\"${SHARED_LDFLAGS}\" LD=\"${LD}\" RANLIB=\"${RANLIB}\"")
-set(BUILD_CMD sh -c "${BUILD_CMD} --silent depend build_crypto build_ssl >/dev/null 2>&1")
+set(BUILD_CMD sh -c "${BUILD_CMD} depend build_crypto build_ssl >/dev/null 2>&1")
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/openssl/openssl-origin-rpath.patch
+++ b/thirdparty/openssl/openssl-origin-rpath.patch
@@ -1,0 +1,16 @@
+diff --git a/Makefile.shared b/Makefile.shared
+index e8d222ac6a..c113e74d5b 100644
+--- a/Makefile.shared
++++ b/Makefile.shared
+@@ -151,9 +151,9 @@ DO_GNU_SO=$(CALC_VERSIONS); \
+ 	SHLIB_SUFFIX=; \
+ 	ALLSYMSFLAGS='-Wl,--whole-archive'; \
+ 	NOALLSYMSFLAGS='-Wl,--no-whole-archive'; \
+-	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
++	SHAREDFLAGS="$(CFLAGS) $(SHARED_LDFLAGS) -Wl,-rpath,"'$$'"ORIGIN -shared -Wl,-Bsymbolic -Wl,-soname=$$SHLIB$$SHLIB_SOVER$$SHLIB_SUFFIX"
+ 
+-DO_GNU_APP=LDFLAGS="$(CFLAGS) -Wl,-rpath,$(LIBRPATH)"
++DO_GNU_APP=LDFLAGS="$(CFLAGS) -Wl,-rpath,"'$$'"ORIGIN/libs"
+ 
+ #This is rather special.  It's a special target with which one can link
+ #applications without bothering with any features that have anything to


### PR DESCRIPTION
... mmmmaaybe?

This time it's based on actual data, so, here's hoping!
Had to get rid of the insane/mysterious collision_test handling, because, of course, it changed behavior.
Since it's fairly obscure and dubiously useful anyway, not a huge loss.
I still documented what I could of its behavior on the KOA2, FOR SCIENCE! :D

This also help confirm that we really shouldn't be using A2 on REAGL Kindles, because it looks awful, so use DU + MONOCHROME, it works much better (even on my PW2).