### PR TITLE
Bump zsync to git master

### DIFF
--- a/thirdparty/zsync/CMakeLists.txt
+++ b/thirdparty/zsync/CMakeLists.txt
@@ -17,15 +17,18 @@ ep_get_binary_dir(BINARY_DIR)
 set(RECONF_CMD sh -c "cd c && autoreconf -fi")
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --host=\"${HOST}\"")
 set(CFG_CMD sh -c "CC=\"${CC}\" CFLAGS=\"$(CFLAGS) -I${SOURCE_DIR}/c\" LIBS=\"${LIBS}\" ${SOURCE_DIR}/c/configure ${CFG_OPTS}")
+# Pickup some build fixes from https://github.com/ahmedammar/zsync
+# Plus, abort if we hit an OpenStack container to avoid infinite loops
+set(PATCH_CMD1 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync-openstack-abort.patch || true")
 # don't check missing definition of in_port_t in NDK <netinet/in.h>
-set(PATCH_CMD1 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync.patch || true")
+set(PATCH_CMD2 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync-android-build-p1.patch || true")
 # fix "rename: Invalid cross-device link" error for Android
-set(PATCH_CMD2 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync-rename.patch  || true")
+set(PATCH_CMD3 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/zsync-android-build-p2.patch  || true")
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://gitlab.com/koreader/zsync.git
-    b89a03f304f9761fe4029fff8f33db6cb12ae002
+    6cfe374f8f2310cbd624664ca98e5bb28244ba7a
     ${SOURCE_DIR}
 )
 
@@ -33,7 +36,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${RECONF_CMD}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${RECONF_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND $(MAKE) -j${PARALLEL_JOBS} --silent
     # skip install

--- a/thirdparty/zsync/zsync-android-build-p1.patch
+++ b/thirdparty/zsync/zsync-android-build-p1.patch
@@ -1,8 +1,8 @@
 diff --git a/c/configure.ac b/c/configure.ac
-index 87b0be1..6b5596f 100644
+index 4b7566b..c745218 100644
 --- a/c/configure.ac
 +++ b/c/configure.ac
-@@ -32,7 +32,7 @@ AC_TYPE_SIZE_T
+@@ -35,7 +35,7 @@ AC_TYPE_SIZE_T
  AC_CHECK_FUNCS(memcpy pwrite pread mkstemp)
  
  X_TYPE_SOCKLEN_T

--- a/thirdparty/zsync/zsync-android-build-p2.patch
+++ b/thirdparty/zsync/zsync-android-build-p2.patch
@@ -1,5 +1,5 @@
 diff --git a/c/libzsync/zsync.c b/c/libzsync/zsync.c
-index 8b18d42..971d2c6 100644
+index 6a7486c..99f4381 100644
 --- a/c/libzsync/zsync.c
 +++ b/c/libzsync/zsync.c
 @@ -41,6 +41,8 @@
@@ -8,10 +8,10 @@ index 8b18d42..971d2c6 100644
  #include <time.h>
 +#include <errno.h>
 +#include <fcntl.h>
-
+ 
  #include <arpa/inet.h>
-
-@@ -533,6 +535,17 @@ int zsync_rename_file(struct zsync_state *zs, const char *f) {
+ 
+@@ -535,6 +537,17 @@ int zsync_rename_file(struct zsync_state *zs, const char *f) {
          free(rf);
          zs->cur_filename = strdup(f);
      }
@@ -28,4 +28,4 @@ index 8b18d42..971d2c6 100644
 +    }
      else
          perror("rename");
-
+ 

--- a/thirdparty/zsync/zsync-openstack-abort.patch
+++ b/thirdparty/zsync/zsync-openstack-abort.patch
@@ -1,0 +1,256 @@
+diff --git a/c/Makefile.am b/c/Makefile.am
+index d39b3ad..f82b64d 100644
+--- a/c/Makefile.am
++++ b/c/Makefile.am
+@@ -7,7 +7,7 @@ SUBDIRS = librcksum zlib libzsync doc
+ bin_PROGRAMS = zsyncmake zsync
+ 
+ zsyncmake_SOURCES = make.c makegz.c makegz.h format_string.h progress.c progress.h
+-zsyncmake_LDADD = libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a zlib/libdeflate.a -lm
++zsyncmake_LDADD = libzsync/libzsync.a librcksum/librcksum.a zlib/libdeflate.a zlib/libinflate.a -lm
+ 
+ zsync_SOURCES = client.c http.c http.h url.c url.h progress.c progress.h base64.c format_string.h zsglobal.h
+ zsync_LDADD = libzsync/libzsync.a librcksum/librcksum.a zlib/libinflate.a $(LIBOBJS)
+diff --git a/c/client.c b/c/client.c
+index 2a2e4bf..ec565ab 100644
+--- a/c/client.c
++++ b/c/client.c
+@@ -4,8 +4,8 @@
+  *   Copyright (C) 2004,2005,2007,2009 Colin Phipps <cph@moria.org.uk>
+  *
+  *   This program is free software; you can redistribute it and/or modify
+- *   it under the terms of the Artistic License v2 (see the accompanying 
+- *   file COPYING for the full license terms), or, at your option, any later 
++ *   it under the terms of the Artistic License v2 (see the accompanying
++ *   file COPYING for the full license terms), or, at your option, any later
+  *   version of the same license.
+  *
+  *   This program is distributed in the hope that it will be useful,
+@@ -280,7 +280,7 @@ static float calc_zsync_progress(const struct zsync_state *zs) {
+  * For the given zsync_state, using the given absolute HTTP URL (which is a
+  * copy of the actual content of the target file is type == 0, or a compressed
+  * copy of it if type == 1), retrieve the parts of the target that are
+- * currently missing. 
++ * currently missing.
+  * Returns 0 if this URL was useful, non-zero if we crashed and burned.
+  */
+ #define BUFFERSIZE 8192
+@@ -353,7 +353,7 @@ int fetch_remaining_blocks_http(struct zsync_state *z, const char *u,
+                             range_fetch_bytes_down(rf));
+ 
+             // Needed in case next call returns len=0 and we need to signal where the EOF was.
+-            zoffset += len;     
++            zoffset += len;
+         }
+ 
+         /* If error, we need to flag that to our caller */
+@@ -379,7 +379,7 @@ int fetch_remaining_blocks_http(struct zsync_state *z, const char *u,
+ /* fetch_remaining_blocks_from_url(struct zsync_state*, url, type)
+  * For the given zsync_state, using the given URL (which is a copy of the
+  * actual content of the target file is type == 0, or a compressed copy of it
+- * if type == 1), retrieve the parts of the target that are currently missing. 
++ * if type == 1), retrieve the parts of the target that are currently missing.
+  * Returns true if this URL was useful, false if we crashed and burned.
+  */
+ int fetch_remaining_blocks_from_url(struct zsync_state *zs, const char *url,
+@@ -403,7 +403,7 @@ int fetch_remaining_blocks_from_url(struct zsync_state *zs, const char *url,
+ 
+ /* int fetch_remaining_blocks(struct zsync_state*)
+  * Using the URLs in the supplied zsync state, downloads data to complete the
+- * target file. 
++ * target file.
+  * Returns 0 if there were no URLs to download from, 1 if there were (in which
+  * case consult zsync_status to see how far it got).
+  */
+@@ -446,7 +446,7 @@ static int set_mtime(char* filename, time_t mtime) {
+         perror("stat");
+         return -1;
+     }
+-    
++
+     /* Set the modification time. */
+     u.actime = s.st_atime;
+     u.modtime = mtime;
+@@ -621,10 +621,10 @@ int main(int argc, char **argv) {
+             fprintf(stderr,
+                 "%s. Incomplete transfer left in %s.\n(If this is the download filename with .part appended, zsync will automatically pick this up and reuse the data it has already done if you retry in this dir.)\n",
+                 fetch_status == 0
+-                ? "No download URLs are known, so no data could be downloaded. The .zsync file is probably incomplete."
++                ? "No download URLs are known, so no data could be downloaded. The .zsync file is probably incomplete"
+                 : target_status == 0
+                     ? "No data downloaded - none of the download URLs worked"
+-                    : "Not all of the required data could be downloaded, and the remaining data could not be retrieved from any of the download URLs.",
++                    : "Not all of the required data could be downloaded, and the remaining data could not be retrieved from any of the download URLs",
+                 temp_file);
+             exit(3);
+         }
+@@ -673,7 +673,7 @@ int main(int argc, char **argv) {
+              * the link below will catch any failure */
+             unlink(oldfile_backup);
+ 
+-            /* Try linking the filename to the backup file name, so we will 
++            /* Try linking the filename to the backup file name, so we will
+                atomically replace the target file in the next step.
+                If that fails due to EPERM, it is probably a filesystem that
+                doesn't support hard-links - so try just renaming it to the
+diff --git a/c/http.c b/c/http.c
+index e861cca..95be2d5 100644
+--- a/c/http.c
++++ b/c/http.c
+@@ -4,8 +4,8 @@
+  *   Copyright (C) 2004,2005,2007,2009 Colin Phipps <cph@moria.org.uk>
+  *
+  *   This program is free software; you can redistribute it and/or modify
+- *   it under the terms of the Artistic License v2 (see the accompanying 
+- *   file COPYING for the full license terms), or, at your option, any later 
++ *   it under the terms of the Artistic License v2 (see the accompanying
++ *   file COPYING for the full license terms), or, at your option, any later
+  *   version of the same license.
+  *
+  *   This program is distributed in the hope that it will be useful,
+@@ -85,7 +85,7 @@ int connect_to(const char *node, const char *service) {
+  * Converts a socket into a stream, and reads the first line from it as an HTTP
+  * status line (response to a request that the caller should have already sent)
+  * and returns the stream, and the status code to the location specified by the
+- * second parameter. 
++ * second parameter.
+  */
+ FILE *http_get_stream(int fd, int *code) {
+     FILE *f = fdopen(fd, "r");
+@@ -108,7 +108,7 @@ FILE *http_get_stream(int fd, int *code) {
+  * Reads the HTTP response from the given stream and extracts the Location
+  * header, making this URL absolute using the current URL. Returned as a
+  * malloced string.
+- * (it ought to be absolute anyway, by the RFC, but many servers send 
++ * (it ought to be absolute anyway, by the RFC, but many servers send
+  * relative URIs). */
+ char *get_location_url(FILE * f, const char *cur_url) {
+     char buf[1024];
+@@ -492,8 +492,8 @@ FILE *http_get(const char *orig_url, char **track_referer, const char *tfname) {
+ 
+ /****************************************************************************
+  *
+- * HTTP Range: / 206 response interface 
+- * 
++ * HTTP Range: / 206 response interface
++ *
+  * The state engine here is:
+  * If sd == -1, not connected;
+  * else, if block_left is 0
+@@ -539,7 +539,7 @@ struct range_fetch {
+ /* range_fetch methods */
+ 
+ /* range_fetch_set_url(rf, url)
+- * Set up a range_fetch to fetch from a given URL. Private method. 
++ * Set up a range_fetch to fetch from a given URL. Private method.
+  * C is a nightmare for memory allocation here. At least the errors should be
+  * caught, but minor memory leaks may occur on some error paths. */
+ static int range_fetch_set_url(struct range_fetch* rf, const char* orig_url) {
+@@ -586,8 +586,8 @@ static int range_fetch_set_url(struct range_fetch* rf, const char* orig_url) {
+ 
+ /* get_more_data - this is the method which owns all reads from the remote.
+  * Nothing else reads from the remote. This buffers data, so that the
+- * higher-level methods below can easily read whole lines from the remote. 
+- * The higher-level methods call this function when they need more data: 
++ * higher-level methods below can easily read whole lines from the remote.
++ * The higher-level methods call this function when they need more data:
+  * it refills the buffer with data from the network. Returns the bytes read. */
+ static int get_more_data(struct range_fetch *rf) {
+     /* First, garbage collect - move the 'live' data in the buffer to the start
+@@ -762,7 +762,7 @@ static void range_fetch_getmore(struct range_fetch *rf) {
+         int i = rf->rangessent;
+         int lastrange = 0;
+ 
+-        /* Add at least one byterange to the request; but is this the last one? 
++        /* Add at least one byterange to the request; but is this the last one?
+          * That's decided based on whether there are any more to add, whether
+          * we've reached our self-imposed limit per request, and whether
+          * there's buffer space to add more.
+@@ -940,6 +940,12 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
+             }
+         }
+ 
++        /* Die in a fire if we hit an OpenStack server, because we're going to loop forever otherwise... */
++        if (status == 206 && !strcasecmp(buf, "X-Openstack-Request-Id")) {
++            fprintf(stderr, "\nError: Remote appears to be an OpenStack container, aborting to avoid a softlock\n");
++            break;
++        }
++
+         /* If remote is telling us to change URL */
+         if ((status == 302 || status == 301)
+             && !strcmp(buf, "location")) {
+@@ -948,7 +954,7 @@ int range_fetch_read_http_headers(struct range_fetch *rf) {
+                 break;
+             }
+ 
+-            /* Set new target URL 
++            /* Set new target URL
+              * NOTE: we are violating the "the client SHOULD continue to use
+              * the Request-URI for future requests" of RFC2616 10.3.3 for 302s.
+              * It's not practical given the number of requests we are making to
+diff --git a/c/librcksum/Makefile.am b/c/librcksum/Makefile.am
+index 0216e49..fd63dad 100644
+--- a/c/librcksum/Makefile.am
++++ b/c/librcksum/Makefile.am
+@@ -3,7 +3,7 @@
+ noinst_LIBRARIES = librcksum.a
+ 
+ TESTS = md4test rsumtest
+-noinst_PROGRAMS = md4test rsumtest
++#noinst_PROGRAMS = md4test rsumtest
+ 
+ md4test_SOURCES = md4test.c md4.h md4.c
+ rsumtest_SOURCES = rsum.c rsumtest.c hash.c range.c state.c md4.c ../progress.c
+diff --git a/c/librcksum/md4.h b/c/librcksum/md4.h
+index e90603a..f2a23d4 100644
+--- a/c/librcksum/md4.h
++++ b/c/librcksum/md4.h
+@@ -17,6 +17,7 @@
+ #define _MD4_H_
+ 
+ #include "zsglobal.h"
++#include <stdint.h>
+ 
+ #ifdef HAVE_INTTYPES_H
+ #include <inttypes.h>
+diff --git a/c/libzsync/zsync.c b/c/libzsync/zsync.c
+index 793a426..6a7486c 100644
+--- a/c/libzsync/zsync.c
++++ b/c/libzsync/zsync.c
+@@ -116,7 +116,7 @@ struct zsync_state {
+ };
+ 
+ static int zsync_read_blocksums(struct zsync_state *zs, FILE * f,
+-                                int rsum_bytes, int checksum_bytes,
++                                int rsum_bytes, unsigned int checksum_bytes,
+                                 int seq_matches);
+ static int zsync_sha1(struct zsync_state *zs, int fh);
+ static int zsync_recompress(struct zsync_state *zs);
+@@ -442,12 +442,12 @@ const char *const *zsync_get_urls(struct zsync_state *zs, int *n, int *t) {
+     if (zs->zmap && zs->nzurl) {
+         *n = zs->nzurl;
+         *t = 1;
+-        return zs->zurl;
++        return (const char *const *)zs->zurl;
+     }
+     else {
+         *n = zs->nurl;
+         *t = 0;
+-        return zs->url;
++        return (const char *const *)zs->url;
+     }
+ }
+ 
+diff --git a/c/make.c b/c/make.c
+index a5173cc..c07a336 100644
+--- a/c/make.c
++++ b/c/make.c
+@@ -844,7 +844,7 @@ int main(int argc, char **argv) {
+                     fprintf(fout, "MTime: %s\n", buf);
+             }
+             else {
+-                fprintf(stderr, "error converting %d to struct tm\n", mtime);
++                fprintf(stderr, "error converting %ld to struct tm\n", mtime);
+             }
+         }
+     }


### PR DESCRIPTION
Plus a new patch to:
  * make it actually build
  * make it abort gracefully when encountering the HTTP frontend of an
    OpenStack container, instead of busy-looping for ever.

Addresses https://github.com/koreader/koreader/pull/4043/commits/0b448a0f0f7cc7f878f3717827a9838a32cd55ff from another angle.