### PR TITLE
Flip the switch on the Mark 7 codepath

### DIFF
--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    7c753adf8ad2c9dec0a4ef449abe9947704ab8de
+    v1.0.0
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Fix #694

\o/

(Based on data from a Clara HD, but appears consistent with what we've seen from the other Mk7 kernels).

(I'll fold a bump to FBInk 1.0.0 in there once testing's done and it's actually tagged ;p).