### PR TITLE
Bump FBInk to 1.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(or $(DARWIN),$(WIN32),$(ANDROID),$(UBUNTUTOUCH),$(APPIMAGE)),,$(OUTPUT_DIR)/dropbear) \
 		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
 		$(if $(or $(DARWIN),$(WIN32)),,$(OUTPUT_DIR)/tar) \
-		$(if $(KOBO),$(OUTPUT_DIR)/fbink,) \
+		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/fbink,) \
 		$(SQLITE_LIB) \
 		$(LUA_LJ_SQLITE) $(OUTPUT_DIR)/common/xsys.lua
 ifndef EMULATE_READER
@@ -37,7 +37,7 @@ ifndef KODEBUG
 		$(if $(or $(DARWIN),$(WIN32),$(ANDROID),$(UBUNTUTOUCH),$(APPIMAGE)),,$(OUTPUT_DIR)/dropbear) \
 		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
 		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/scp,) \
-		$(if $(KOBO),$(OUTPUT_DIR)/fbink,) \
+		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/fbink,) \
 		$(if $(ANDROID),,$(LUAJIT)) \
 		$(OUTPUT_DIR)/libs/$(if $(WIN32),*.dll,*.so*)" ;\
 	$(STRIP) --strip-unneeded $${STRIP_FILES} ;\

--- a/Makefile.third
+++ b/Makefile.third
@@ -423,7 +423,7 @@ ifdef ANDROID
 endif
 
 # ===========================================================================
-# FBInk: visual feedback on Kobo
+# FBInk: visual feedback on Kobo/Kindle
 
 $(OUTPUT_DIR)/fbink: $(THIRDPARTY_DIR)/fbink/CMakeLists.txt
 	install -d $(FBINK_BUILD_DIR)

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -14,8 +14,17 @@ assert_var_defined(LDFLAGS)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
-# Minimal, statically linked build, we don't care about extra fonts
-set(BUILD_CMD sh -c "$(MAKE) MINIMAL=1 CROSS_TC=\"${CROSS_TC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" strip")
+# Choose your own adventure!
+if($ENV{LEGACY})
+    set(FBINK_TARGET "legacy")
+elseif($ENV{KINDLE})
+    set(FBINK_TARGET "kindle")
+else()
+    set(FBINK_TARGET "strip")
+endif()
+
+# Minimal, statically linked build, we don't care about extra fonts or image support
+set(BUILD_CMD sh -c "$(MAKE) MINIMAL=1 CROSS_TC=\"${CROSS_TC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ${FBINK_TARGET}")
 # We build in-tree...
 set(INSTALL_CMD1 ${CMAKE_COMMAND} -E make_directory ${BINARY_DIR})
 if($ENV{DEBUG})

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    v1.4.1
+    v1.5.0
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
And bundle it on Kindle too, because I'm going to need it there to move everything to FBInk

That'll allow us to get rid of some shell shenanigans to handle eips properly everywhere, as well as unify a couple of scripts between Kindle & Kobo.