### PR TITLE
Minor cleanups after #724, part two!

### DIFF
--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -7,30 +7,30 @@ source "${CI_DIR}/common.sh"
 
 travis_retry make fetchthirdparty
 
-if [ "$TARGET" = kobo ]; then
+if [ "$TARGET" = "kobo" ]; then
     sudo chmod -R 777 "${HOME}/.ccache"
     docker run -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
         /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=kobo all'
-elif [ "$TARGET" = kindle ]; then
+elif [ "$TARGET" = "kindle" ]; then
     sudo chmod -R 777 "${HOME}/.ccache"
     docker run -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
         /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=kindle all'
-elif [ "$TARGET" = pocketbook ]; then
+elif [ "$TARGET" = "pocketbook" ]; then
     sudo chmod -R 777 "${HOME}/.ccache"
     docker run -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
         /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make pocketbook-toolchain && make VERBOSE=1 TARGET=pocketbook all"
-elif [ "$TARGET" = sony_prstux ]; then
+elif [ "$TARGET" = "sony-prstux" ]; then
     sudo chmod -R 777 "${HOME}/.ccache"
     docker run -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make VERBOSE=1 TARGET=sony_prstux all"
+        /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make VERBOSE=1 TARGET=sony-prstux all"
 else
     make all
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - TARGET=kindle DOCKER_IMG=frenzie/kokindle:0.0.5
     - TARGET=kobo DOCKER_IMG=frenzie/kokobo:0.0.5
     - TARGET=pocketbook DOCKER_IMG=houqp/kopb:0.0.1
-    - TARGET=sony_prstux DOCKER_IMG=phreakuencies/prstux-dev:16.04
+    - TARGET=sony-prstux DOCKER_IMG=phreakuencies/prstux-dev:16.04
     # ANDROID_ARCH=x86 is currently broken on these older NDKs (at least on Travis), so no point in testing it
     - TARGET=android NDKREV=r11c
     - TARGET=android NDKREV=r12b

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -92,7 +92,7 @@ else ifeq ($(TARGET), pocketbook)
     export POCKETBOOK=1
     export PATH:=$(POCKETBOOK_TOOLCHAIN)/bin:$(PATH)
     export SYSROOT=$(POCKETBOOK_TOOLCHAIN)/arm-obreey-linux-gnueabi/sysroot
-else ifeq ($(TARGET), sony_prstux)
+else ifeq ($(TARGET), sony-prstux)
     CHOST?=arm-linux-gnueabihf
     export SONY_PRSTUX=1 
     export USE_LJ_WPACLIENT=1
@@ -283,7 +283,7 @@ else ifeq ($(TARGET), android)
 		ARM_ARCH+=-mfloat-abi=softfp
 		export ac_cv_type_in_port_t=yes
 	endif
-else ifeq ($(TARGET), sony_prstux)
+else ifeq ($(TARGET), sony-prstux)
         ARM_ARCH:=$(ARMV7_A8_ARCH)
         ARM_ARCH+=-mfloat-abi=hard
 else ifeq ($(TARGET), arm-generic)

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    v1.6.1
+    v1.6.2
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Namely, the highly nitpicky renaming from `sony_prstux` to `sony-prstux` (c.f., [KO#4198](https://github.com/koreader/koreader/pull/4198)) ;).
* Bump FBInk to 1.6.2, which includes a fix for progress bars' width that could be off by 1px, potentially causing unsightly artifacts depending on the speed and eInk controller...