### PR TITLE
Sony PRSTUX USB/charging detection + small fix

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -523,7 +523,7 @@ function framebuffer:init()
         self.mech_refresh = refresh_sony_prstux
         self.mech_wait_update_complete = sony_prstux_mxc_wait_for_update_complete
 
-        self.waveform_fast = C.WAVEFORM_MODE_A2
+        self.waveform_fast = C.WAVEFORM_MODE_DU
         self.waveform_ui = C.WAVEFORM_MODE_AUTO
         self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.WAVEFORM_MODE_GC16

--- a/input/input-sony-prstux.h
+++ b/input/input-sony-prstux.h
@@ -18,8 +18,100 @@
 #ifndef _KO_INPUT_SONY_PRSTUX_H
 #define _KO_INPUT_SONY_PRSTUX_H
 
-void generateFakeEvent(int pipefd[2]) {
-    return;
+#define SONY_PRSTUX_BATT_DEVPATH "/devices/platform/imx-i2c.1/i2c-1/1-0049/twl6030_bci/power_supply/twl6030_battery"
+#include "libue.h"
+
+#define SONY_PRSTUX_BATTERY_STATE_CHARGING     0
+#define SONY_PRSTUX_BATTERY_STATE_DISCHARGING  1
+#define SONY_PRSTUX_BATTERY_STATE_NOT_CHARGING 2
+#define SONY_PRSTUX_BATTERY_STATE_FULL         3
+#define SONY_PRSTUX_BATTERY_STATE_UNKNOWN      4
+
+static int getBatteryState(void) {
+    int state = SONY_PRSTUX_BATTERY_STATE_DISCHARGING;
+    FILE* file = NULL;
+    size_t bytes_read;
+    char buffer[256] = { 0 };
+
+    file = fopen("/sys" SONY_PRSTUX_BATT_DEVPATH"/status", "r");
+    bytes_read = fread(buffer, 1, 256, file);
+
+    if (strcmp(buffer, "Charging\n") == 0) {
+        state = SONY_PRSTUX_BATTERY_STATE_CHARGING;
+    } else if (strcmp(buffer, "Full\n") == 0) {
+        state = SONY_PRSTUX_BATTERY_STATE_FULL;
+    } else if (strcmp(buffer, "Discharging\n") == 0) {
+        state = SONY_PRSTUX_BATTERY_STATE_DISCHARGING;
+    } else if (strcmp(buffer, "Not Charging\n") == 0) {
+        state = SONY_PRSTUX_BATTERY_STATE_NOT_CHARGING;
+    } else {
+        state = SONY_PRSTUX_BATTERY_STATE_UNKNOWN;
+    }
+    //fprintf(stderr, "battery state string: %s\n", buffer);
+
+    fclose(file);
+    return state;
 }
- 
+
+static void sendEvent(int fd, struct input_event* ev) {
+    if (write(fd, ev, sizeof(struct input_event)) == -1) {
+        fprintf(stderr, "Failed to generate fake event.\n");
+    }
+}
+
+static void generateFakeEvent(int pipefd[2]) {
+    int re;
+    struct uevent_listener listener;
+    struct uevent uev;
+    struct input_event ev;
+    int prev_battery_state, battery_state;
+
+    close(pipefd[0]);
+
+    battery_state = getBatteryState();
+    prev_battery_state = battery_state;
+
+    //fprintf(stderr, "[fake] initial battery state: %d\n", battery_state);
+
+    ev.type = EV_KEY;
+    ev.value = 1;
+
+    re = ue_init_listener(&listener);
+    if (re < 0) {
+        fprintf(stderr, "[sony-prstux-fake-event] Failed to initilize libue listener, err: %d\n", re);
+        return;
+    }
+
+    while ((re = ue_wait_for_event(&listener, &uev)) == 0) {
+        if (uev.action == UEVENT_ACTION_CHANGE
+                && uev.devpath
+                && (UE_STR_EQ(uev.devpath, SONY_PRSTUX_BATT_DEVPATH))) {
+
+            battery_state = getBatteryState();
+            //fprintf(stderr, "[fake] battery state now: %d\n", battery_state);
+            if (prev_battery_state != battery_state) {
+                switch(battery_state) {
+                    case SONY_PRSTUX_BATTERY_STATE_CHARGING:
+                        ev.code = CODE_FAKE_USB_PLUG_IN;
+                        sendEvent(pipefd[1], &ev);
+                        ev.code = CODE_FAKE_CHARGING;
+                        sendEvent(pipefd[1], &ev);
+                    break;
+                    case SONY_PRSTUX_BATTERY_STATE_FULL:
+                        ev.code = CODE_FAKE_NOT_CHARGING;
+                        sendEvent(pipefd[1], &ev);
+                    break;
+                    case SONY_PRSTUX_BATTERY_STATE_DISCHARGING:
+                        ev.code = CODE_FAKE_USB_PLUG_OUT;
+                        sendEvent(pipefd[1], &ev);
+                        ev.code = CODE_FAKE_NOT_CHARGING;
+                        sendEvent(pipefd[1], &ev);
+                    break;
+                }
+            }
+            prev_battery_state = battery_state;
+        }
+    }
+}
+
 #endif


### PR DESCRIPTION
After using koreader some time on the Sony PRS-T2 I saw that A2 has problems: it starts rendering a lot of artifacts and what should be black appears gray sometimes. DU does not have these problems and is quite fast anyway.

I also added charging/discharging detection to generate fake input events. This allows me to get out of suspend when the cable is plugged in and also to inhibit autosuspend.