### PR TITLE
cre: allow non-word chars in text selection

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1129,9 +1129,13 @@ static int getTextFromPositions(lua_State *L) {
 			return 0;
 		r.sort();
 
-		if (!r.getStart().isVisibleWordStart())
+		// Only extend to include the whole word when we are actually
+		// holding inside a word. This allows selecting punctuation,
+		// quotes or parens at start or end of selection to have them
+		// included in the highlight.
+		if (r.getStart().isVisibleWordChar() && !r.getStart().isVisibleWordStart())
 			r.getStart().prevVisibleWordStart();
-		if (!r.getEnd().isVisibleWordEnd())
+		if (r.getEnd().isVisibleWordChar() && !r.getEnd().isVisibleWordEnd())
 			r.getEnd().nextVisibleWordEnd();
 		if (r.isNull())
 			return 0;


### PR DESCRIPTION
By starting or ending text selection on a punctuation char, a quote or a paren..., these will now be included in the text selection and the higlighted text. Details and screenshots in https://github.com/koreader/koreader/issues/4134#issuecomment-428617973

bump crengine, which includes:
- Avoid wrap on a space before or after some specific chars https://github.com/koreader/crengine/pull/237