### PR TITLE
cre text selection: grab word when just holding and not panning 

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -959,6 +959,69 @@ void BB_alpha_blit_from(BlitBuffer *dst, BlitBuffer *src,
             }
             o_x += 1;
         }
+    } else if (dbb_type == TYPE_BBRGB16 && sbb_type == TYPE_BB8A) {
+        o_x = offs_x;
+        Color8A *srcptr;
+        ColorRGB16 *dstptr;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, Color8A, o_x, o_y, &srcptr);
+                dstptr->v = RGB_To_RGB16(srcptr->a, srcptr->a, srcptr->a);
+                o_y += 1;
+            }
+            o_x += 1;
+        }
+    } else if (dbb_type == TYPE_BBRGB16 && sbb_type == TYPE_BB8) {
+        o_x = offs_x;
+        Color8 *srcptr;
+        ColorRGB16 *dstptr;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, Color8, o_x, o_y, &srcptr);
+                dstptr->v = RGB_To_RGB16(srcptr->a, srcptr->a, srcptr->a);
+                o_y += 1;
+            }
+            o_x += 1;
+        }
+    } else if (dbb_type == TYPE_BBRGB16 && sbb_type == TYPE_BBRGB24) {
+        o_x = offs_x;
+        ColorRGB24 *srcptr;
+        ColorRGB16 *dstptr;
+        uint8_t r, g, b;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, ColorRGB24, o_x, o_y, &srcptr);
+                dstptr->v = RGB_To_RGB16(srcptr->r, srcptr->g, srcptr->b);
+                o_y += 1;
+            }
+            o_x += 1;
+        }
+    } else if (dbb_type == TYPE_BBRGB16 && sbb_type == TYPE_BBRGB32) {
+        o_x = offs_x;
+        ColorRGB32 *srcptr;
+        ColorRGB16 *dstptr;
+        uint8_t r, g, b;
+        for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+            o_y = offs_y;
+            for (d_y = dest_y; d_y < dest_y + h; d_y++) {
+                BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
+                BB_GET_PIXEL(src, sbb_rotation, ColorRGB32, o_x, o_y, &srcptr);
+                alpha = srcptr->alpha;
+                ainv = 0xFF - alpha;
+                r = DIV_255(ColorRGB16_GetR(dstptr->v) * ainv + srcptr->r * alpha);
+                g = DIV_255(ColorRGB16_GetG(dstptr->v) * ainv + srcptr->g * alpha);
+                b = DIV_255(ColorRGB16_GetB(dstptr->v) * ainv + srcptr->b * alpha);
+                dstptr->v = RGB_To_RGB16(r, g, b);
+                o_y += 1;
+            }
+            o_x += 1;
+        }
     } else {
         fprintf(stderr, "incompatible bb (dst: %d, src: %d) in file %s, line %d!\r\n",
                 dbb_type, sbb_type, __FILE__, __LINE__); exit(1);

--- a/cre.cpp
+++ b/cre.cpp
@@ -1136,13 +1136,14 @@ static int getTextFromPositions(lua_State *L) {
 			return 0;
 		r.sort();
 
-		// Only extend to include the whole word when we are actually
-		// holding inside a word. This allows selecting punctuation,
+		// When panning, only extend to include the whole word when we are
+		// actually holding inside a word. This allows selecting punctuation,
 		// quotes or parens at start or end of selection to have them
 		// included in the highlight.
-		if (r.getStart().isVisibleWordChar() && !r.getStart().isVisibleWordStart())
+		bool not_panning = r.getStart() == r.getEnd();
+		if ( (not_panning || r.getStart().isVisibleWordChar()) && !r.getStart().isVisibleWordStart())
 			r.getStart().prevVisibleWordStart();
-		if (r.getEnd().isVisibleWordChar() && !r.getEnd().isVisibleWordEnd())
+		if ( (not_panning || r.getEnd().isVisibleWordChar()) && !r.getEnd().isVisibleWordEnd())
 			r.getEnd().nextVisibleWordEnd();
 		if (r.isNull())
 			return 0;


### PR DESCRIPTION
Fix text selection behaviour introduced in #742 when holding only and not panning.
Otherwise, when holding to just do a dictionary lookup:
- when holding on a space or a punctuation, this char would be and stay highlighted while the dict lookup would not happen because text selection would have been cleaned and become empty.
- when holding on a blank space (eg: after the last word on a non-full last line), no text would be selected here, but getWordFromPosition(), used as a fallback, would return the nearest word on above or below line, which would then be used as dict lookup input, with a few side effects: no highlighting done while looking up; if then Highlighted from the dict window button and bookmarked, the bookmark would have no text and no highlight box would be shown when revisiting the page...

Current behaviour, holding between `deux` and `Angoulême`, with side effects described above:
<kbd>![select_bad](https://user-images.githubusercontent.com/24273478/47303002-323f2a80-d623-11e8-913f-20d7e7350f3c.png)</kbd>

Previous and restored behaviour, holding at the same place:
<kbd>![select_good](https://user-images.githubusercontent.com/24273478/47302999-2fdcd080-d623-11e8-97a3-b140e9b97f82.png)</kbd>
This is still unperfect, but visually consistent (this bad selection would he highlighted and the highlight boxe shown). And then, when panning, depending on the direction, only one of these 2 parts would be considered in the extended selection.

Also adds some code to blitbuffer.c to make it fully usable on 16bpp Kobo (build yet not enabled, as the performance gain is not obvious.)