### PR TITLE
[build] Drop Android NDK r11c; also test build on Docker `koandroid`

### DIFF
--- a/.ci/android_install.sh
+++ b/.ci/android_install.sh
@@ -5,11 +5,7 @@ sudo dpkg --add-architecture i386
 sudo apt-get update
 sudo apt-get install zlib1g:i386 libc6-dev-i386 linux-libc-dev:i386
 
-if [ "$NDKREV" = "r11c" ]; then
-    curl -L "http://dl.google.com/android/repository/android-ndk-${NDKREV}-linux-x86_64.zip" -O
-    echo "extracting android ndk"
-    unzip -q "android-ndk-${NDKREV}-linux-x86_64.zip"
-elif [ "$NDKREV" = "r12b" ]; then
+if [ "$NDKREV" = "r12b" ]; then
     wget "https://dl.google.com/android/repository/android-ndk-${NDKREV}-linux-x86_64.zip"
     echo "extracting android ndk"
     unzip -q "android-ndk-${NDKREV}-linux-x86_64.zip"

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -7,7 +7,19 @@ source "${CI_DIR}/common.sh"
 
 travis_retry make fetchthirdparty
 
-if [ "$TARGET" = "kobo" ]; then
+if [ "$TARGET" = "android" ] && [ -n "${DOCKER_IMG}" ]; then
+    sudo chmod -R 777 "${HOME}/.ccache"
+    docker run -t \
+        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
+        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
+        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make android-toolchain && make TARGET=android all'
+elif [ "$TARGET" = "cervantes" ]; then
+    sudo chmod -R 777 "${HOME}/.ccache"
+    docker run -t \
+        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
+        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
+        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=cervantes all'
+elif [ "$TARGET" = "kobo" ]; then
     sudo chmod -R 777 "${HOME}/.ccache"
     docker run -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
@@ -31,12 +43,6 @@ elif [ "$TARGET" = "sony-prstux" ]; then
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
         /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make VERBOSE=1 TARGET=sony-prstux all"
-elif [ "$TARGET" = "cervantes" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=cervantes all'
 else
     make all
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,8 @@ env:
     - TARGET=sony-prstux DOCKER_IMG=phreakuencies/prstux-dev:16.04
     - TARGET=cervantes DOCKER_IMG=frenzie/kocervantes:0.1.0
     # ANDROID_ARCH=x86 is currently broken on these older NDKs (at least on Travis), so no point in testing it
-    - TARGET=android NDKREV=r11c
     - TARGET=android NDKREV=r12b
+    - TARGET=android DOCKER_IMG=frenzie/koandroid:0.1.0
     # API level 14 is the minimum target for NDK 15
     - TARGET=android NDKREV=r15c NDKABI=14
     - TARGET=android NDKREV=r15c NDKABI=14 ANDROID_ARCH=x86


### PR DESCRIPTION
This deprecates the outdated r11c to "it may not break" status while ensuring that our nightly builds will succeed.