### PR TITLE
Correctly detect Cervantes3 as "Cervantes 3"

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -574,7 +574,7 @@ function framebuffer:init()
 
         -- new devices
         local is_new = false
-        if self.device.model == "Cervantes2013" or self.device.model == "Cervantes3"
+        if self.device.model == "Cervantes2013" or self.device.model == "Cervantes 3"
             or self.device.model == "Cervantes4" then is_new = true end
 
         if is_new then


### PR DESCRIPTION
Resolves #754.

It'd be good to get @pazos to have a quick look -- should the `Cervantes 4` and `Cervantes 2013` also be fixed as per the device names in https://github.com/koreader/koreader/blob/1e69fae7bc3f65fce516a180ebfd0820651d8c04/frontend/device/cervantes/device.lua?