### PR TITLE
[Cervantes]: waveforms & flags

### DIFF
--- a/ffi-cdecl/include/mxcfb-cervantes.h
+++ b/ffi-cdecl/include/mxcfb-cervantes.h
@@ -99,7 +99,6 @@ struct mxcfb_rect {
 
 #define FB_POWERDOWN_DISABLE            -1
 
-/* Cervantes 2013+ */
 struct mxcfb_alt_buffer_data {
 	void *virt_addr;
 	__u32 phys_addr;
@@ -116,24 +115,6 @@ struct mxcfb_update_data {
         int temp;
         unsigned int flags;
         struct mxcfb_alt_buffer_data alt_buffer_data;
-};
-
-/* Older devices */
-struct mxcfb_alt_buffer_data_old {
-        __u32 phys_addr;
-        __u32 width;    /* width of entire buffer */
-        __u32 height;   /* height of entire buffer */
-        struct mxcfb_rect alt_update_region; /* region within buffer to update */
-};
-
-struct mxcfb_update_data_old {
-        struct mxcfb_rect update_region;
-        __u32 waveform_mode;
-        __u32 update_mode;
-        __u32 update_marker;
-        int temp;
-        unsigned int flags;
-        struct mxcfb_alt_buffer_data_old alt_buffer_data;
 };
 
 /*
@@ -191,7 +172,6 @@ struct mxcfb_csc_matrix {
 #define MXCFB_SET_TEMPERATURE		_IOW('F', 0x2C, int32_t)
 #define MXCFB_SET_AUTO_UPDATE_MODE	_IOW('F', 0x2D, __u32)
 #define MXCFB_SEND_UPDATE		_IOW('F', 0x2E, struct mxcfb_update_data)
-#define MXCFB_SEND_UPDATE_OLD		_IOW('F', 0x2E, struct mxcfb_update_data_old)
 #define MXCFB_WAIT_FOR_UPDATE_COMPLETE	_IOW('F', 0x2F, __u32)
 #define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
 #define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)

--- a/ffi-cdecl/include/mxcfb-cervantes.h
+++ b/ffi-cdecl/include/mxcfb-cervantes.h
@@ -41,9 +41,21 @@
 #define WAVEFORM_MODE_GLR16		6	/* Ghost compensation waveform */
 #define WAVEFORM_MODE_GLD16		7	/* Ghost compensation waveform with dithering */
 
+/* common flags */
 #define EPDC_FLAG_ENABLE_INVERSION      0x01
 #define EPDC_FLAG_FORCE_MONOCHROME      0x02
 #define EPDC_FLAG_USE_ALT_BUFFER        0x100
+
+/* introduced in Cervantes2013 */
+#define EPDC_FLAG_USE_CMAP		0x04
+#define EPDC_FLAG_TEST_COLLISION	0x200
+#define EPDC_FLAG_GROUP_UPDATE		0x400
+#define EPDC_FLAG_USE_DITHERING_Y1	0x2000
+#define EPDC_FLAG_USE_DITHERING_Y4	0x4000
+
+/* introduced in Cervantes3 */
+#define EPDC_FLAG_USE_AAD		0x1000
+#define EPDC_FLAG_USE_DITHERING_NTX_D8	0x100000
 
 struct mxcfb_rect {
         __u32 top;

--- a/ffi-cdecl/include/mxcfb-cervantes.h
+++ b/ffi-cdecl/include/mxcfb-cervantes.h
@@ -23,58 +23,6 @@
 #ifndef __ASM_ARCH_MXCFB_H__
 #define __ASM_ARCH_MXCFB_H__
 
-#define FB_SYNC_OE_LOW_ACT	0x80000000
-#define FB_SYNC_CLK_LAT_FALL	0x40000000
-#define FB_SYNC_DATA_INVERT	0x20000000
-#define FB_SYNC_CLK_IDLE_EN	0x10000000
-#define FB_SYNC_SHARP_MODE	0x08000000
-#define FB_SYNC_SWAP_RGB	0x04000000
-
-struct mxcfb_gbl_alpha {
-	int enable;
-	int alpha;
-};
-
-struct mxcfb_loc_alpha {
-	int enable;
-	int alpha_in_pixel;
-	unsigned long alpha_phy_addr0;
-	unsigned long alpha_phy_addr1;
-};
-
-struct mxcfb_color_key {
-	int enable;
-	__u32 color_key;
-};
-
-struct mxcfb_pos {
-	__u16 x;
-	__u16 y;
-};
-
-struct mxcfb_gamma {
-	int enable;
-	int constk[16];
-	int slopek[16];
-};
-
-struct mxcfb_rect {
-	__u32 top;
-	__u32 left;
-	__u32 width;
-	__u32 height;
-};
-
-#define GRAYSCALE_8BIT			0x1
-#define GRAYSCALE_8BIT_INVERTED		0x2
-
-#define AUTO_UPDATE_MODE_REGION_MODE	0
-#define AUTO_UPDATE_MODE_AUTOMATIC_MODE 1
-
-#define UPDATE_SCHEME_SNAPSHOT		0
-#define UPDATE_SCHEME_QUEUE		1
-#define UPDATE_SCHEME_QUEUE_AND_MERGE	2
-
 #define UPDATE_MODE_PARTIAL		0x0
 #define UPDATE_MODE_FULL		0x1
 
@@ -97,7 +45,12 @@ struct mxcfb_rect {
 #define EPDC_FLAG_FORCE_MONOCHROME      0x02
 #define EPDC_FLAG_USE_ALT_BUFFER        0x100
 
-#define FB_POWERDOWN_DISABLE            -1
+struct mxcfb_rect {
+        __u32 top;
+        __u32 left;
+        __u32 width;
+        __u32 height;
+};
 
 struct mxcfb_alt_buffer_data {
 	void *virt_addr;
@@ -117,89 +70,8 @@ struct mxcfb_update_data {
         struct mxcfb_alt_buffer_data alt_buffer_data;
 };
 
-/*
- * Structure used to define waveform modes for driver
- * Needed for driver to perform auto-waveform selection
- */
-
-/* Cervantes 2013+ */
-struct mxcfb_waveform_modes {
-	int mode_init;
-	int mode_du;
-	int mode_gc4;
-	int mode_gc8;
-	int mode_gc16;
-	int mode_gc32;
-	int mode_aa;
-	int mode_aad;
-	int mode_gl16;
-	int mode_a2;
-};
-
-/* Older devices */
-struct mxcfb_waveform_modes_old {
-        int mode_init;
-        int mode_du;
-        int mode_gc4;
-        int mode_gc8;
-        int mode_gc16;
-        int mode_gc32;
-};
-
-/*
- * Structure used to define a 5*3 matrix of parameters for
- * setting IPU DP CSC module related to this framebuffer.
- */
-struct mxcfb_csc_matrix {
-	int param[5][3];
-};
-
-#define MXCFB_WAIT_FOR_VSYNC	_IOW('F', 0x20, u_int32_t)
-#define MXCFB_SET_GBL_ALPHA     _IOW('F', 0x21, struct mxcfb_gbl_alpha)
-#define MXCFB_SET_CLR_KEY       _IOW('F', 0x22, struct mxcfb_color_key)
-#define MXCFB_SET_OVERLAY_POS   _IOWR('F', 0x24, struct mxcfb_pos)
-#define MXCFB_GET_FB_IPU_CHAN 	_IOR('F', 0x25, u_int32_t)
-#define MXCFB_SET_LOC_ALPHA     _IOWR('F', 0x26, struct mxcfb_loc_alpha)
-#define MXCFB_SET_LOC_ALP_BUF    _IOW('F', 0x27, unsigned long)
-#define MXCFB_SET_GAMMA	       _IOW('F', 0x28, struct mxcfb_gamma)
-#define MXCFB_GET_FB_IPU_DI 	_IOR('F', 0x29, u_int32_t)
-#define MXCFB_GET_DIFMT	       _IOR('F', 0x2A, u_int32_t)
-#define MXCFB_GET_FB_BLANK     _IOR('F', 0x2B, u_int32_t)
-#define MXCFB_SET_DIFMT		_IOW('F', 0x2C, u_int32_t)
-
 /* IOCTLs for E-ink panel updates */
-#define MXCFB_SET_WAVEFORM_MODES	_IOW('F', 0x2B, struct mxcfb_waveform_modes)
-#define MXCFB_SET_TEMPERATURE		_IOW('F', 0x2C, int32_t)
-#define MXCFB_SET_AUTO_UPDATE_MODE	_IOW('F', 0x2D, __u32)
 #define MXCFB_SEND_UPDATE		_IOW('F', 0x2E, struct mxcfb_update_data)
 #define MXCFB_WAIT_FOR_UPDATE_COMPLETE	_IOW('F', 0x2F, __u32)
-#define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
-#define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)
-#define MXCFB_SET_UPDATE_SCHEME		_IOW('F', 0x32, __u32)
-#define MXCFB_SET_MERGE_ON_WAVEFORM_MISMATCH	_IOW('F', 0x37, int32_t)
 
-#ifdef __KERNEL__
-
-
-extern struct fb_videomode mxcfb_modedb[];
-extern int mxcfb_modedb_sz;
-
-enum {
-	MXC_DISP_SPEC_DEV = 0,
-	MXC_DISP_DDC_DEV = 1,
-};
-
-enum {
-	MXCFB_REFRESH_OFF,
-	MXCFB_REFRESH_AUTO,
-	MXCFB_REFRESH_PARTIAL,
-};
-
-int mxcfb_set_refresh_mode(struct fb_info *fbi, int mode,
-			   struct mxcfb_rect *update_region);
-int mxc_elcdif_frame_addr_setup(dma_addr_t phys);
-void mxcfb_elcdif_register_mode(const struct fb_videomode *modedb,
-		int num_modes, int dev_mode);
-
-#endif				/* __KERNEL__ */
 #endif

--- a/ffi-cdecl/mxcfb_cervantes_decl.c
+++ b/ffi-cdecl/mxcfb_cervantes_decl.c
@@ -27,9 +27,6 @@ cdecl_struct(mxcfb_rect)
 cdecl_struct(mxcfb_alt_buffer_data)
 cdecl_struct(mxcfb_update_data)
 
-cdecl_struct(mxcfb_alt_buffer_data_old)
-cdecl_struct(mxcfb_update_data_old)
 
 cdecl_const(MXCFB_SEND_UPDATE)
-cdecl_const(MXCFB_SEND_UPDATE_OLD)
 cdecl_const(MXCFB_WAIT_FOR_UPDATE_COMPLETE)

--- a/ffi-cdecl/mxcfb_cervantes_decl.c
+++ b/ffi-cdecl/mxcfb_cervantes_decl.c
@@ -21,6 +21,13 @@ cdecl_const(WAVEFORM_MODE_GLD16)
 cdecl_const(EPDC_FLAG_ENABLE_INVERSION)
 cdecl_const(EPDC_FLAG_FORCE_MONOCHROME)
 cdecl_const(EPDC_FLAG_USE_ALT_BUFFER)
+cdecl_const(EPDC_FLAG_USE_CMAP)
+cdecl_const(EPDC_FLAG_TEST_COLLISION)
+cdecl_const(EPDC_FLAG_GROUP_UPDATE)
+cdecl_const(EPDC_FLAG_USE_DITHERING_Y1)
+cdecl_const(EPDC_FLAG_USE_DITHERING_Y4)
+cdecl_const(EPDC_FLAG_USE_AAD)
+cdecl_const(EPDC_FLAG_USE_DITHERING_NTX_D8)
 
 cdecl_struct(mxcfb_rect)
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -396,9 +396,8 @@ local function refresh_sony_prstux(fb, refreshtype, waveform_mode, x, y, w, h)
     return mxc_update(fb, C.MXCFB_SEND_UPDATE, refarea, refreshtype, waveform_mode, x, y, w, h)
 end
 
-local function refresh_cervantes_old(fb, refreshtype, waveform_mode, x, y, w, h)
+local function refresh_cervantes(fb, refreshtype, waveform_mode, x, y, w, h)
     local refarea = ffi.new("struct mxcfb_update_data[1]")
-    refarea[0].alt_buffer_data.virt_addr = nil
     refarea[0].temp = C.TEMP_USE_AMBIENT
 
     if waveform_mode == C.WAVEFORM_MODE_A2 then
@@ -406,12 +405,6 @@ local function refresh_cervantes_old(fb, refreshtype, waveform_mode, x, y, w, h)
     else
         refarea[0].flags = 0
     end
-    return mxc_update(fb, C.MXCFB_SEND_UPDATE_OLD, refarea, refreshtype, waveform_mode, x, y, w, h)
-end
-
-local function refresh_cervantes(fb, refreshtype, waveform_mode, x, y, w, h)
-    local refarea = ffi.new("struct mxcfb_update_data[1]")
-    refarea[0].temp = C.TEMP_USE_AMBIENT
     return mxc_update(fb, C.MXCFB_SEND_UPDATE, refarea, refreshtype, waveform_mode, x, y, w, h)
 end
 
@@ -599,7 +592,7 @@ function framebuffer:init()
     elseif self.device:isCervantes() then
         require("ffi/mxcfb_cervantes_h")
 
-        self.mech_refresh = refresh_cervantes_old
+        self.mech_refresh = refresh_cervantes
         self.mech_wait_update_complete = cervantes_mxc_wait_for_update_complete
 
         self.waveform_fast = C.WAVEFORM_MODE_A2
@@ -618,7 +611,6 @@ function framebuffer:init()
         end
 
         if is_new then
-            self.mech_refresh = refresh_cervantes
             self.waveform_fast = C.WAVEFORM_MODE_DU
             self.waveform_reagl = C.WAVEFORM_MODE_GLD16
             self.waveform_partial = self.waveform_reagl

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -402,6 +402,8 @@ local function refresh_cervantes(fb, refreshtype, waveform_mode, x, y, w, h)
 
     if waveform_mode == C.WAVEFORM_MODE_A2 then
         refarea[0].flags = C.EPDC_FLAG_FORCE_MONOCHROME
+    elseif waveform_mode == C.WAVEFORM_MODE_GLD16 then
+        refarea[0].flags = C.EPDC_FLAG_USE_AAD
     else
         refarea[0].flags = 0
     end
@@ -601,16 +603,16 @@ function framebuffer:init()
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
 
-        -- new devices
-        local is_new = false
-        if self.device.model == "Cervantes2013"
+        -- reagl aware devices. TODO: test on Cervantes2013
+        local is_reagl = false
+        if self.device.model == "Cervantes4"
         or self.device.model == "Cervantes3"
-        or self.device.model == "Cervantes4"
+        --or self.device.model == "Cervantes2013"
         then
-            is_new = true
+            is_reagl = true
         end
 
-        if is_new then
+        if is_reagl then
             self.waveform_fast = C.WAVEFORM_MODE_DU
             self.waveform_reagl = C.WAVEFORM_MODE_GLD16
             self.waveform_partial = self.waveform_reagl

--- a/ffi/mxcfb_cervantes_h.lua
+++ b/ffi/mxcfb_cervantes_h.lua
@@ -37,22 +37,6 @@ struct mxcfb_update_data {
   unsigned int flags;
   struct mxcfb_alt_buffer_data alt_buffer_data;
 };
-struct mxcfb_alt_buffer_data_old {
-  unsigned int phys_addr;
-  unsigned int width;
-  unsigned int height;
-  struct mxcfb_rect alt_update_region;
-};
-struct mxcfb_update_data_old {
-  struct mxcfb_rect update_region;
-  unsigned int waveform_mode;
-  unsigned int update_mode;
-  unsigned int update_marker;
-  int temp;
-  unsigned int flags;
-  struct mxcfb_alt_buffer_data_old alt_buffer_data;
-};
 static const int MXCFB_SEND_UPDATE = 1078216238;
-static const int MXCFB_SEND_UPDATE_OLD = 1077954094;
 static const int MXCFB_WAIT_FOR_UPDATE_COMPLETE = 1074021935;
 ]]

--- a/ffi/mxcfb_cervantes_h.lua
+++ b/ffi/mxcfb_cervantes_h.lua
@@ -15,6 +15,13 @@ static const int WAVEFORM_MODE_GLD16 = 7;
 static const int EPDC_FLAG_ENABLE_INVERSION = 1;
 static const int EPDC_FLAG_FORCE_MONOCHROME = 2;
 static const int EPDC_FLAG_USE_ALT_BUFFER = 256;
+static const int EPDC_FLAG_USE_CMAP = 4;
+static const int EPDC_FLAG_TEST_COLLISION = 512;
+static const int EPDC_FLAG_GROUP_UPDATE = 1024;
+static const int EPDC_FLAG_USE_DITHERING_Y1 = 8192;
+static const int EPDC_FLAG_USE_DITHERING_Y4 = 16384;
+static const int EPDC_FLAG_USE_AAD = 4096;
+static const int EPDC_FLAG_USE_DITHERING_NTX_D8 = 1048576;
 struct mxcfb_rect {
   unsigned int top;
   unsigned int left;


### PR DESCRIPTION
Removed a bunch of unused structs & kernel code. Not really needed but makes the file easier to read/understand.

Use same MXCFB_SEND_UPDATE because MXCFB_SEND_UPDATE_OLD was borked and made all legacy devices stupid enough to not update the screen :sob:

Add a bunch of epdc flags from Cervantes 2013 - Cervantes 4 kernels.
Rename is_new to is_reagl to be a little more descriptive.

This fixes #754 (in particular: https://github.com/koreader/koreader-base/issues/754#issuecomment-438485877)