### PR TITLE
[fix] Android nightmode landscape

### DIFF
--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -47,6 +47,7 @@ function framebuffer:refreshFullImp()
         bb:setInverse(ext_bb:getInverse())
         -- adapt to possible rotation changes
         bb:setRotation(ext_bb:getRotation())
+        self.invert_bb:setRotation(ext_bb:getRotation())
 
         if ext_bb:getInverse() == 1 then
             self.invert_bb:invertblitFrom(ext_bb)


### PR DESCRIPTION
Forgot to set rotation on the second blitbuffer. Fixes https://github.com/koreader/koreader/issues/3945.