### PR TITLE
[mac] mupdf.dylib: load libjpeg from libs/ instead of @rpath

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -92,6 +92,10 @@ $(MUPDF_LIB) $(MUPDF_DIR)/include: $(JPEG_LIB) \
 		-DFREETYPE_LIB=$(CURDIR)/$(FREETYPE_LIB) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/mupdf && \
 		$(MAKE)
+ifdef DARWIN
+	install_name_tool -change @rpath/libjpeg.8.dylib \
+		libs/libjpeg.8.dylib $(MUPDF_LIB)
+endif
 
 $(LODEPNG_LIB) $(LODEPNG_DIR): $(THIRDPARTY_DIR)/lodepng/CMakeLists.txt
 	install -d $(LODEPNG_BUILD_DIR)


### PR DESCRIPTION
Fix this error on mac

```
ffi.load: libs/libmupdf.dylib
ffi.load (warning): dlopen(libs/libmupdf.dylib, 5): @rpath/libjpeg.8.dylib
  Referenced from: /Users/pazos/Desktop/koreader/base/build/x86_64-apple-darwin18.2.0/libs/libmupdf.dylib
  Reason: image not found
./luajit: ./setupkoenv.lua:30: Not able to load dynamic library: libs/libmupdf.dylib
```

https://github.com/koreader/koreader/issues/4375#issuecomment-444688176