### PR TITLE
Dust up setScreenMode's logic

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -24,8 +24,8 @@ local fb = {
 --[[
 Codes for rotation modes:
 
-1 for no rotation,
-2 for landscape with bottom on the right side of screen, etc.
+0 for no rotation (i.e., Portrait),
+1 for landscape with bottom on the right side of screen, etc.
 
            2
    +--------------+
@@ -42,9 +42,12 @@ Codes for rotation modes:
    |              |
    +--------------+
           0
+
+i.e., this matches <linux/fb.h> FB_ROTATE_* constants ;).
 --]]
 fb.ORIENTATION_PORTRAIT = 0
 fb.ORIENTATION_LANDSCAPE = 1
+-- And now for Inverted orientations...
 fb.ORIENTATION_PORTRAIT_ROTATED = 2
 fb.ORIENTATION_LANDSCAPE_ROTATED = 3
 
@@ -303,21 +306,33 @@ function fb:setRotationMode(mode)
     self.cur_rotation_mode = mode
 end
 
+-- Handles orientation changes as requested...
+-- If current orientation is already Portrait, swap to Inverted Portrait
+-- If current orientation is already Landscape, swap to Inverted Landscape
+-- For Landscape, if swapping from any Portrait orientation,
+-- swap straight to Inverted Landscape if DLANDSCAPE_CLOCKWISE_ROTATION is false
+-- Things to remember to make sense of the logic:
+-- All even orientations are Portrait (0 and 2)
+-- All odd orientations are Landscape (1 and 3)
 function fb:setScreenMode(mode)
     if mode == "portrait" then
-        if self.cur_rotation_mode ~= 0 then
+        if (self.cur_rotation_mode % 2) == 1 then
+            -- We were in a Landscape orientation (odd number), swap to Portrait (UR)
             self:setRotationMode(self.ORIENTATION_PORTRAIT)
+        else
+            -- We were in a Portrait orientation (even number), swap to its Inverted variant (^= 2)
+            self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
     elseif mode == "landscape" then
-        if self.cur_rotation_mode == self.ORIENTATION_PORTRAIT
-        or self.cur_rotation_mode == self.ORIENTATION_PORTRAIT_ROTATED then
+        if (self.cur_rotation_mode % 2) == 0 then
+            -- We were in a Portrait orientation (even number), swap to Landscape (CW or CCW, depending on user preference)
             self:setRotationMode(
                 DLANDSCAPE_CLOCKWISE_ROTATION
                 and self.ORIENTATION_LANDSCAPE
                 or self.ORIENTATION_LANDSCAPE_ROTATED)
-        elseif self.cur_rotation_mode == self.ORIENTATION_LANDSCAPE
-        or self.cur_rotation_mode == self.ORIENTATION_LANDSCAPE_ROTATED then
-            self:setRotationMode((self.cur_rotation_mode + 2) % 4)
+        else
+            -- We were in a Landscape orientation (odd number), swap to its Inverted variant (^= 2)
+            self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
     end
 end

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -312,8 +312,8 @@ end
 -- For Landscape, if swapping from any Portrait orientation,
 -- swap straight to Inverted Landscape if DLANDSCAPE_CLOCKWISE_ROTATION is false
 -- Things to remember to make sense of the logic:
--- All even orientations are Portrait (0 and 2)
--- All odd orientations are Landscape (1 and 3)
+-- All even orientations are Portrait (0 and 2), the larger one being the Inverted variant
+-- All odd orientations are Landscape (1 and 3), the larger one being the Inverted variant
 -- NOTE: We only swap to Inverted variants when that was requested interactively by the user,
 --       to avoid doing unrequested inversions during the few manual setScreenMode calls we might do,
 --       (f.g., user selected default orientation)
@@ -323,7 +323,7 @@ function fb:setScreenMode(mode, interactive)
             -- We were in a Landscape orientation (odd number), swap to Portrait (UR)
             self:setRotationMode(self.ORIENTATION_PORTRAIT)
         elseif interactive == true then
-            -- We were in a Portrait orientation (even number), swap to its Inverted variant (^= 2),
+            -- We were in a Portrait orientation (even number), swap to its Inverted variant (^= 2, i.e., 0 <-> 2),
             -- only if that was an interactive request.
             self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
@@ -335,7 +335,7 @@ function fb:setScreenMode(mode, interactive)
                 and self.ORIENTATION_LANDSCAPE
                 or self.ORIENTATION_LANDSCAPE_ROTATED)
         elseif interactive == true then
-            -- We were in a Landscape orientation (odd number), swap to its Inverted variant (^= 2),
+            -- We were in a Landscape orientation (odd number), swap to its Inverted variant (^= 2, i.e., 1 <-> 3),
             -- only if that was an interactive request.
             self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -318,7 +318,6 @@ end
 --       to avoid doing unrequested inversions during the few manual setScreenMode calls we might do,
 --       (f.g., user selected default orientation)
 function fb:setScreenMode(mode, interactive)
-    self.debug("Called fb:setScreenMode with mode:", mode, "and interactive:", interactive or "nil")
     if mode == "portrait" then
         if bit.band(self.cur_rotation_mode, 1) == 1 then
             -- We were in a Landscape orientation (odd number), swap to Portrait (UR)

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -320,7 +320,7 @@ end
 function fb:setScreenMode(mode, interactive)
     self.debug("Called fb:setScreenMode with mode:", mode, "and interactive:", interactive or "nil")
     if mode == "portrait" then
-        if (self.cur_rotation_mode % 2) == 1 then
+        if bit.band(self.cur_rotation_mode, 1) == 1 then
             -- We were in a Landscape orientation (odd number), swap to Portrait (UR)
             self:setRotationMode(self.ORIENTATION_PORTRAIT)
         elseif interactive == true then
@@ -329,7 +329,7 @@ function fb:setScreenMode(mode, interactive)
             self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
     elseif mode == "landscape" then
-        if (self.cur_rotation_mode % 2) == 0 then
+        if bit.band(self.cur_rotation_mode, 1) == 0 then
             -- We were in a Portrait orientation (even number), swap to Landscape (CW or CCW, depending on user preference)
             self:setRotationMode(
                 DLANDSCAPE_CLOCKWISE_ROTATION

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -307,8 +307,8 @@ function fb:setRotationMode(mode)
 end
 
 -- Handles orientation changes as requested...
--- If current orientation is already Portrait, swap to Inverted Portrait
--- If current orientation is already Landscape, swap to Inverted Landscape
+-- If current orientation is already Portrait, swap to Inverted Portrait (and vice versa)
+-- If current orientation is already Landscape, swap to Inverted Landscape (and vice versa)
 -- For Landscape, if swapping from any Portrait orientation,
 -- swap straight to Inverted Landscape if DLANDSCAPE_CLOCKWISE_ROTATION is false
 -- Things to remember to make sense of the logic:

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -314,13 +314,18 @@ end
 -- Things to remember to make sense of the logic:
 -- All even orientations are Portrait (0 and 2)
 -- All odd orientations are Landscape (1 and 3)
-function fb:setScreenMode(mode)
+-- NOTE: We only swap to Inverted variants when that was requested interactively by the user,
+--       to avoid doing unrequested inversions during the few manual setScreenMode calls we might do,
+--       (f.g., user selected default orientation)
+function fb:setScreenMode(mode, interactive)
+    self.debug("Called fb:setScreenMode with mode:", mode, "and interactive:", interactive or "nil")
     if mode == "portrait" then
         if (self.cur_rotation_mode % 2) == 1 then
             -- We were in a Landscape orientation (odd number), swap to Portrait (UR)
             self:setRotationMode(self.ORIENTATION_PORTRAIT)
-        else
-            -- We were in a Portrait orientation (even number), swap to its Inverted variant (^= 2)
+        elseif interactive == true then
+            -- We were in a Portrait orientation (even number), swap to its Inverted variant (^= 2),
+            -- only if that was an interactive request.
             self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
     elseif mode == "landscape" then
@@ -330,8 +335,9 @@ function fb:setScreenMode(mode)
                 DLANDSCAPE_CLOCKWISE_ROTATION
                 and self.ORIENTATION_LANDSCAPE
                 or self.ORIENTATION_LANDSCAPE_ROTATED)
-        else
-            -- We were in a Landscape orientation (odd number), swap to its Inverted variant (^= 2)
+        elseif interactive == true then
+            -- We were in a Landscape orientation (odd number), swap to its Inverted variant (^= 2),
+            -- only if that was an interactive request.
             self:setRotationMode(bit.bxor(self.cur_rotation_mode, 2))
         end
     end


### PR DESCRIPTION
Make it human readable (hopefully), heavily commented, simpler, and symmetrical, so we actually get easy access to Inverted Portrait.

Attempt to fix [KO#3002](https://github.com/koreader/koreader/issues/3002) in the process by making sure inversion trickery is only applied on explicit UI interaction (other end of that in [KO#4291](https://github.com/koreader/koreader/issues/4291).

AFAICT, that works as expected \o/.