### PR TITLE
Fix undefined _dewarpBuildPageModel_ex symbol in k2pdfopt

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -613,7 +613,7 @@ GLIB=$(GLIB_DIR)/lib/libglib-2.0$(if $(DARWIN),.dylib,.so.0)
 GLIB_STATIC=$(GLIB_DIR)/lib/libglib-2.0.a
 ZLIB=$(OUTPUT_DIR)/libs/$(if $(WIN32),zlib1.dll,$(if $(DARWIN),libz.1.dylib,libz.so.1))
 
-LEPT_LIB_EXT=$(if $(WIN32),-5.0.1.dll,$(if $(DARWIN),.5.0.1.dylib,.so.5.0.1))
+LEPT_LIB_EXT=$(if $(WIN32),-5.dll,$(if $(DARWIN),.5.dylib,.so.5))
 LEPTONICA_LIB=$(OUTPUT_DIR)/libs/liblept$(LEPT_LIB_EXT)
 TESS_LIB_EXT=$(if $(WIN32),-3.dll,$(if $(DARWIN),.3.dylib,.so.3))
 TESSERACT_LIB=$(OUTPUT_DIR)/libs/libtesseract$(TESS_LIB_EXT)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -613,7 +613,7 @@ GLIB=$(GLIB_DIR)/lib/libglib-2.0$(if $(DARWIN),.dylib,.so.0)
 GLIB_STATIC=$(GLIB_DIR)/lib/libglib-2.0.a
 ZLIB=$(OUTPUT_DIR)/libs/$(if $(WIN32),zlib1.dll,$(if $(DARWIN),libz.1.dylib,libz.so.1))
 
-LEPT_LIB_EXT=$(if $(WIN32),-4.dll,$(if $(DARWIN),.4.dylib,.so.4))
+LEPT_LIB_EXT=$(if $(WIN32),-5.0.1.dll,$(if $(DARWIN),.5.0.1.dylib,.so.5.0.1))
 LEPTONICA_LIB=$(OUTPUT_DIR)/libs/liblept$(LEPT_LIB_EXT)
 TESS_LIB_EXT=$(if $(WIN32),-3.dll,$(if $(DARWIN),.3.dylib,.so.3))
 TESSERACT_LIB=$(OUTPUT_DIR)/libs/libtesseract$(TESS_LIB_EXT)

--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -5,13 +5,13 @@ local dummy = require("ffi/koptcontext_h")
 local Blitbuffer = require("ffi/blitbuffer")
 local leptonica, k2pdfopt
 if ffi.os == "Windows" then
-    leptonica = ffi.load("libs/liblept-4.dll")
+    leptonica = ffi.load("libs/liblept-5.0.1.dll")
     k2pdfopt = ffi.load("libs/libk2pdfopt-2.dll")
 elseif ffi.os == "OSX" then
-    leptonica = ffi.load("libs/liblept.4.dylib")
+    leptonica = ffi.load("libs/liblept.5.0.1.dylib")
     k2pdfopt = ffi.load("libs/libk2pdfopt.2.dylib")
 else
-    leptonica = ffi.load("libs/liblept.so.4")
+    leptonica = ffi.load("libs/liblept.so.5.0.1")
     k2pdfopt = ffi.load("libs/libk2pdfopt.so.2")
 end
 

--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -235,7 +235,7 @@ function KOPTContext_mt.__index:findPageBlocks()
         leptonica.pixDestroy(ffi.new('PIX *[1]', pixs))
 
         local pixtb = ffi.new("PIX *[1]")
-        local status = leptonica.pixGetRegionsBinary(pixr, nil, nil, pixtb, 0)
+        local status = leptonica.pixGetRegionsBinary(pixr, nil, nil, pixtb, nil)
         if status == 0 then
             self.nboxa = leptonica.pixSplitIntoBoxa(pixtb[0], 5, 10, 20, 80, 10, 0)
             for i = 0, leptonica.boxaGetCount(self.nboxa) - 1 do

--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -5,13 +5,13 @@ local dummy = require("ffi/koptcontext_h")
 local Blitbuffer = require("ffi/blitbuffer")
 local leptonica, k2pdfopt
 if ffi.os == "Windows" then
-    leptonica = ffi.load("libs/liblept-5.0.1.dll")
+    leptonica = ffi.load("libs/liblept-5.dll")
     k2pdfopt = ffi.load("libs/libk2pdfopt-2.dll")
 elseif ffi.os == "OSX" then
-    leptonica = ffi.load("libs/liblept.5.0.1.dylib")
+    leptonica = ffi.load("libs/liblept.5.dylib")
     k2pdfopt = ffi.load("libs/libk2pdfopt.2.dylib")
 else
-    leptonica = ffi.load("libs/liblept.so.5.0.1")
+    leptonica = ffi.load("libs/liblept.so.5")
     k2pdfopt = ffi.load("libs/libk2pdfopt.so.2")
 end
 

--- a/ffi/leptonica_h.lua
+++ b/ffi/leptonica_h.lua
@@ -95,7 +95,7 @@ PIX *pixConvertTo32(PIX *);
 PIX *pixDrawBoxaRandom(PIX *, BOXA *, l_int32);
 PIX *pixMultiplyByColor(PIX *, PIX *, BOX *, l_uint32);
 PIX *pixBlendBackgroundToColor(PIX *, PIX *, BOX *, l_uint32, l_float32, l_int32, l_int32);
-l_int32 pixGetRegionsBinary(PIX *, PIX **, PIX **, PIX **, l_int32);
+l_int32 pixGetRegionsBinary(PIX *, PIX **, PIX **, PIX **, struct Pixa *);
 BOXA *pixSplitIntoBoxa(PIX *, l_int32, l_int32, l_int32, l_int32, l_int32, l_int32);
 PIX *pixReduceRankBinaryCascade(PIX *, l_int32, l_int32, l_int32, l_int32);
 ]]

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -7,6 +7,8 @@ include("koreader_thirdparty_git")
 
 ep_get_source_dir(SOURCE_DIR)
 
+# NOTE: Needs to match the version used by whatever version of libk2pdfopt we're currently using...
+#       Probably applies to mupdf & tesseract, too...
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/DanBloomberg/leptonica.git

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -10,7 +10,7 @@ ep_get_source_dir(SOURCE_DIR)
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/DanBloomberg/leptonica.git
-    v1.74.1
+    1.74.1
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -10,7 +10,7 @@ ep_get_source_dir(SOURCE_DIR)
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/DanBloomberg/leptonica.git
-    v1.72
+    v1.74.1
     ${SOURCE_DIR}
 )
 
@@ -25,7 +25,7 @@ ko_write_gitclone_script(
 # there's a 1.74 version of the patch already in our tree for when that time
 # comes ;).
 if(${ARM_GLIBC_GTE_2_22})
-    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.72-fmemopen-arm-compat-symbol.patch)
+    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.74-fmemopen-arm-compat-symbol.patch)
 else()
     set(PATCH_CMD "")
 endif()

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -25,7 +25,7 @@ ko_write_gitclone_script(
 # there's a 1.74 version of the patch already in our tree for when that time
 # comes ;).
 if(${ARM_GLIBC_GTE_2_22})
-    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.74-fmemopen-arm-compat-symbol.patch)
+    set(PATCH_CMD patch -N -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/leptonica-1.74.1-fmemopen-arm-compat-symbol.patch)
 else()
     set(PATCH_CMD "")
 endif()

--- a/thirdparty/leptonica/leptonica-1.74.1-fmemopen-arm-compat-symbol.patch
+++ b/thirdparty/leptonica/leptonica-1.74.1-fmemopen-arm-compat-symbol.patch
@@ -1,8 +1,8 @@
-diff --git a/src/utils.c b/src/utils.c
-index bb3507c..9caf08f 100644
---- a/src/utils.c
-+++ b/src/utils.c
-@@ -1903,6 +1903,7 @@ FILE  *fp;
+diff --git a/src/utils2.c b/src/utils2.c
+index bac9621..4f7c696 100644
+--- a/src/utils2.c
++++ b/src/utils2.c
+@@ -1632,6 +1632,7 @@ FILE  *fp;
          return (FILE *)ERROR_PTR("data not defined", procName, NULL);
  
  #if HAVE_FMEMOPEN

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/libk2pdfopt.git
-    3628a77b8e062d34455dca38a9cd5a31dd902011
+    d5405c89a086fcb800d53a9f81ac9ba446378b12
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Involves bumping Leptonica to v1.74.1, the one k2pdfopt 2.42 expects, as well as fixing our buildsystem to include k2pdfopt's new patches to Leptonica.

Re: https://github.com/koreader/koreader/issues/4448
Re: https://github.com/koreader/koreader/issues/4467