### PR TITLE
bump crengine: Harfbuzz light, WTF-8, corrupted ZIPs 

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -394,6 +394,11 @@ function util.utf8charcode(charstring)
         return bit.lshift(bit.band(ptr[0], 0x0F), 12) +
             bit.lshift(bit.band(ptr[1], 0x3F), 6) +
             bit.band(ptr[2], 0x3F)
+    elseif len == 4 then
+        return bit.lshift(bit.band(ptr[0], 0x07), 18) +
+            bit.lshift(bit.band(ptr[1], 0x3F), 12) +
+            bit.lshift(bit.band(ptr[2], 0x3F), 6) +
+            bit.band(ptr[3], 0x3F)
     end
 end
 


### PR DESCRIPTION
Includes from https://github.com/koreader/crengine/pull/252 & https://github.com/koreader/crengine/pull/251 :
- EPUB: workaround ZIP files with corrupted central directories 
- Supports book text encoded in WTF-8
- Harfbuzz kerning (full): fix possible wrong flags 
- (Upstream) Adds new kerning method: Harfbuzz light, without ligatures 

Also adds missing support in ffi/util.lua `utf8charcode()` for 4-bytes UTF-8 chars (text selection from book would be truncated to the first 4-bytes char met).