### PR TITLE
Honor dithering requests from UIManager

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -39,24 +39,24 @@
 #define GET_BB_TYPE(bb) (((MASK_TYPE & bb->config) >> SHIFT_TYPE))
 
 #define ColorRGB32_To_Color8(color) \
-    (Color8){(4898*color->r + 9618*color->g + 1869*color->b) >> 14}
+    (Color8){(4898U*color->r + 9618U*color->g + 1869U*color->b) >> 14U}
 #define ColorRGB32_To_Color8A(color) \
-    (Color8A){(4898*color->r + 9618*color->g + 1869*color->b) >> 14, color->alpha}
+    (Color8A){(4898U*color->r + 9618U*color->g + 1869U*color->b) >> 14U, color->alpha}
 #define ColorRGB32_To_Color16(color) \
-    (ColorRGB16){((color->r & 0xF8) << 8) + ((color->g & 0xFC) << 3) + ((color->b >> 3))}
+    (ColorRGB16){((color->r & 0xF8) << 8U) + ((color->g & 0xFC) << 3U) + ((color->b >> 3U))}
 #define ColorRGB32_To_Color24(color) \
     (ColorRGB24){color->r, color->g, color->b}
 
-#define ColorRGB16_GetR(v) (((v >> 11) << 3) + ((v >> 11) >> 2))
-#define ColorRGB16_GetG(v) ((((v >> 5) & 0x3F) << 2) + (((v >> 5) & 0x3F) >> 4))
-#define ColorRGB16_GetB(v) (((v & 0x001F) << 3) + ((v & 0x001F) >> 2))
+#define ColorRGB16_GetR(v) (((v >> 11U) << 3U) + ((v >> 11U) >> 2U))
+#define ColorRGB16_GetG(v) ((((v >> 5U) & 0x3F) << 2U) + (((v >> 5U) & 0x3F) >> 4U))
+#define ColorRGB16_GetB(v) (((v & 0x001F) << 3U) + ((v & 0x001F) >> 2U))
 #define ColorRGB16_To_A(v) \
     ((39919*ColorRGB16_GetR(v) + \
       39185*ColorRGB16_GetG(v) + \
-      15220*ColorRGB16_GetB(v)) >> 14)
-#define RGB_To_RGB16(r, g, b) (((r & 0xF8) << 8) + ((g & 0xFC) << 3) + (b >> 3))
-#define RGB_To_A(r, g, b) ((4898*r + 9618*g + 1869*b) >> 14)
-#define DIV_255(x) ((((x) >> 8) + (x) + 0x01) >> 8)
+      15220*ColorRGB16_GetB(v)) >> 14U)
+#define RGB_To_RGB16(r, g, b) (((r & 0xF8) << 8U) + ((g & 0xFC) << 3U) + (b >> 3U))
+#define RGB_To_A(r, g, b) ((4898U*r + 9618U*g + 1869U*b) >> 14U)
+#define DIV_255(x) ((((x) >> 8U) + (x) + 0x01) >> 8U)
 
 #define BB_GET_PIXEL(bb, rotation, COLOR, x, y, pptr) \
     switch (rotation) { \
@@ -422,8 +422,8 @@ void BB_blit_to_BB16(BlitBuffer *src, BlitBuffer *dst,
                         BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
                         BB_GET_PIXEL(src, sbb_rotation, Color8, o_x, o_y, &srcptr);
                         v = srcptr->a;
-                        v5bit = v >> 3;
-                        dstptr->v = (v5bit << 11) + ((v & 0xFC) << 3) + v5bit;
+                        v5bit = v >> 3U;
+                        dstptr->v = (v5bit << 11U) + ((v & 0xFC) << 3U) + v5bit;
                         o_x += 1;
                     }
                     o_y += 1;
@@ -440,8 +440,8 @@ void BB_blit_to_BB16(BlitBuffer *src, BlitBuffer *dst,
                         BB_GET_PIXEL(dst, dbb_rotation, ColorRGB16, d_x, d_y, &dstptr);
                         BB_GET_PIXEL(src, sbb_rotation, Color8A, o_x, o_y, &srcptr);
                         v = srcptr->a;
-                        v5bit = v >> 3;
-                        dstptr->v = (v5bit << 11) + ((v & 0xFC) << 3) + v5bit;
+                        v5bit = v >> 3U;
+                        dstptr->v = (v5bit << 11U) + ((v & 0xFC) << 3U) + v5bit;
                         o_x += 1;
                     }
                     o_y += 1;
@@ -990,7 +990,6 @@ void BB_alpha_blit_from(BlitBuffer *dst, BlitBuffer *src,
     } else if (dbb_type == TYPE_BBRGB16 && sbb_type == TYPE_BBRGB24) {
         ColorRGB24 *srcptr;
         ColorRGB16 *dstptr;
-        uint8_t r, g, b;
         o_y = offs_y;
         for (d_y = dest_y; d_y < dest_y + h; d_y++) {
             o_x = offs_x;

--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -48,11 +48,11 @@ typedef struct ColorRGB32 {
 } ColorRGB32;
 
 typedef struct BlitBuffer {
-	int w;
-	int h;
-	int pitch;
-	uint8_t *data;
-	uint8_t config;
+    int w;
+    int h;
+    int pitch;
+    uint8_t *data;
+    uint8_t config;
 } BlitBuffer;
 
 typedef struct BlitBuffer8 {

--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -97,6 +97,16 @@ typedef struct BlitBufferRGB32 {
 
 void BB_fill_rect(BlitBuffer *bb, int x, int y, int w, int h, ColorRGB32 *color);
 void BB_blend_rect(BlitBuffer *bb, int x, int y, int w, int h, ColorRGB32 *color);
+void BB_blit_to_BB8(BlitBuffer *src, BlitBuffer *dst,
+                    int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
+void BB_blit_to_BB8A(BlitBuffer *src, BlitBuffer *dst,
+                     int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
+void BB_blit_to_BB16(BlitBuffer *src, BlitBuffer *dst,
+                     int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
+void BB_blit_to_BB24(BlitBuffer *src, BlitBuffer *dst,
+                     int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
+void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
+                     int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
 void BB_blit_to(BlitBuffer *source, BlitBuffer *dest, int dest_x, int dest_y,
                 int offs_x, int offs_y, int w, int h);
 void BB_add_blit_from(BlitBuffer *dest, BlitBuffer *source, int dest_x, int dest_y,

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -91,55 +91,55 @@ function fb:init()
 end
 
 -- the ...Imp methods may be overridden to implement refresh
-function fb:refreshFullImp(x, y, w, h)
+function fb:refreshFullImp(x, y, w, h, d)
     -- the simplest form of refresh implements only this method.
     -- the others default to fall back to this.
 end
-function fb:refreshPartialImp(x, y, w, h)
+function fb:refreshPartialImp(x, y, w, h, d)
     -- default is fallback
-    return self:refreshFullImp(x, y, w, h)
+    return self:refreshFullImp(x, y, w, h, d)
 end
-function fb:refreshFlashPartialImp(x, y, w, h)
+function fb:refreshFlashPartialImp(x, y, w, h, d)
     -- default is fallback
-    return self:refreshFullImp(x, y, w, h)
+    return self:refreshFullImp(x, y, w, h, d)
 end
-function fb:refreshUIImp(x, y, w, h)
+function fb:refreshUIImp(x, y, w, h, d)
     -- default is fallback
-    return self:refreshPartialImp(x, y, w, h)
+    return self:refreshPartialImp(x, y, w, h, d)
 end
-function fb:refreshFlashUIImp(x, y, w, h)
+function fb:refreshFlashUIImp(x, y, w, h, d)
     -- default is fallback
-    return self:refreshFullImp(x, y, w, h)
+    return self:refreshFullImp(x, y, w, h, d)
 end
-function fb:refreshFastImp(x, y, w, h)
+function fb:refreshFastImp(x, y, w, h, d)
     -- default is fallback
-    return self:refreshPartialImp(x, y, w, h)
+    return self:refreshPartialImp(x, y, w, h, d)
 end
 
 -- these should not be overridden, they provide the external refresh API:
-function fb:refreshFull(x, y, w, h)
+function fb:refreshFull(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshFullImp(x, y, w, h)
+    return self:refreshFullImp(x, y, w, h, d)
 end
-function fb:refreshPartial(x, y, w, h)
+function fb:refreshPartial(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshPartialImp(x, y, w, h)
+    return self:refreshPartialImp(x, y, w, h, d)
 end
-function fb:refreshFlashPartial(x, y, w, h)
+function fb:refreshFlashPartial(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshFlashPartialImp(x, y, w, h)
+    return self:refreshFlashPartialImp(x, y, w, h, d)
 end
-function fb:refreshUI(x, y, w, h)
+function fb:refreshUI(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshUIImp(x, y, w, h)
+    return self:refreshUIImp(x, y, w, h, d)
 end
-function fb:refreshFlashUI(x, y, w, h)
+function fb:refreshFlashUI(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshFlashUIImp(x, y, w, h)
+    return self:refreshFlashUIImp(x, y, w, h, d)
 end
-function fb:refreshFast(x, y, w, h)
+function fb:refreshFast(x, y, w, h, d)
     x, y = self:calculateRealCoordinates(x, y)
-    return self:refreshFastImp(x, y, w, h)
+    return self:refreshFastImp(x, y, w, h, d)
 end
 
 -- should be overridden to free resources

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -293,7 +293,7 @@ local function refresh_k51(fb, refreshtype, waveform_mode, x, y, w, h)
     return mxc_update(fb, C.MXCFB_SEND_UPDATE, refarea, refreshtype, waveform_mode, x, y, w, h)
 end
 
-local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
+local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h, dither)
     local refarea = ffi.new("struct mxcfb_update_data_koa2[1]")
     -- only for Amazon's driver, try to mostly follow what the stock reader does...
     if waveform_mode == C.WAVEFORM_MODE_KOA2_GLR16 then
@@ -306,8 +306,20 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
     end
     -- NOTE: Since there's no longer a distinction between GC16_FAST & GC16, we're done!
     refarea[0].temp = C.TEMP_USE_AMBIENT
-    refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
-    refarea[0].quant_bit = 0;
+    -- Did we request HW dithering?
+    if dither then
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
+        if waveform_mode == C.WAVEFORM_MODE_A2 then
+            refarea[0].quant_bit = 1;
+        elseif if waveform_mode == C.WAVEFORM_MODE_DU then
+            refarea[0].quant_bit = 3;
+        else
+            refarea[0].quant_bit = 7;
+        end
+    else
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
+        refarea[0].quant_bit = 0;
+    end
     -- Enable the appropriate flag when requesting what amounts to a 2bit update
     if waveform_mode == C.WAVEFORM_MODE_DU then
         refarea[0].flags = C.EPDC_FLAG_FORCE_MONOCHROME
@@ -319,7 +331,7 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h)
     return mxc_update(fb, C.MXCFB_SEND_UPDATE_KOA2, refarea, refreshtype, waveform_mode, x, y, w, h)
 end
 
-local function refresh_pw4(fb, refreshtype, waveform_mode, x, y, w, h)
+local function refresh_pw4(fb, refreshtype, waveform_mode, x, y, w, h, dither)
     local refarea = ffi.new("struct mxcfb_update_data_pw4[1]")
     -- only for Amazon's driver, try to mostly follow what the stock reader does...
     if waveform_mode == C.WAVEFORM_MODE_KOA2_GLR16 then
@@ -332,8 +344,20 @@ local function refresh_pw4(fb, refreshtype, waveform_mode, x, y, w, h)
     end
     -- NOTE: Since there's no longer a distinction between GC16_FAST & GC16, we're done!
     refarea[0].temp = C.TEMP_USE_AMBIENT
-    refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
-    refarea[0].quant_bit = 0;
+    -- Did we request HW dithering?
+    if dither then
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
+        if waveform_mode == C.WAVEFORM_MODE_A2 then
+            refarea[0].quant_bit = 1;
+        elseif if waveform_mode == C.WAVEFORM_MODE_DU then
+            refarea[0].quant_bit = 3;
+        else
+            refarea[0].quant_bit = 7;
+        end
+    else
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
+        refarea[0].quant_bit = 0;
+    end
     -- Enable the appropriate flag when requesting what amounts to a 2bit update
     if waveform_mode == C.WAVEFORM_MODE_DU then
         refarea[0].flags = C.EPDC_FLAG_FORCE_MONOCHROME
@@ -364,12 +388,22 @@ local function refresh_kobo(fb, refreshtype, waveform_mode, x, y, w, h)
     return mxc_update(fb, C.MXCFB_SEND_UPDATE_V1_NTX, refarea, refreshtype, waveform_mode, x, y, w, h)
 end
 
-local function refresh_kobo_mk7(fb, refreshtype, waveform_mode, x, y, w, h)
+local function refresh_kobo_mk7(fb, refreshtype, waveform_mode, x, y, w, h, dither)
     local refarea = ffi.new("struct mxcfb_update_data_v2[1]")
     -- TEMP_USE_AMBIENT, not that there was ever any other choice on Kobo...
     refarea[0].temp = C.TEMP_USE_AMBIENT
-    refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
-    refarea[0].quant_bit = 0;
+    -- Did we request HW dithering?
+    if dither then
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
+        if waveform_mode == C.WAVEFORM_MODE_A2 then
+            refarea[0].quant_bit = 1;
+        else
+            refarea[0].quant_bit = 7;
+        end
+    else
+        refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_PASSTHROUGH
+        refarea[0].quant_bit = 0;
+    end
     -- Enable the appropriate flag when requesting a 2bit update
     -- NOTE: As of right now (FW 4.9.x), WAVEFORM_MODE_GLD16 appears not to be used by Nickel,
     --       so we don't have to care about EPDC_FLAG_USE_REGAL
@@ -413,37 +447,37 @@ end
 
 --[[ framebuffer API ]]--
 
-function framebuffer:refreshPartialImp(x, y, w, h)
-    self.debug("refresh: partial", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_partial, x, y, w, h)
+function framebuffer:refreshPartialImp(x, y, w, h, dither)
+    self.debug("refresh: partial", x, y, w, h, d and "w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_partial, x, y, w, h, dither)
 end
 
 -- NOTE: UPDATE_MODE_FULL doesn't mean full screen or no region, it means ask for a black flash!
 --       The only exception to that rule is with REAGL waveform modes, where it will *NOT* flash.
 --       But then, REAGL waveform modes will *never* use anything other than FULL update mode anyway ;).
-function framebuffer:refreshFlashPartialImp(x, y, w, h)
-    self.debug("refresh: partial w/ flash", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_partial, x, y, w, h)
+function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
+    self.debug("refresh: partial w/ flash", x, y, w, h, dither and "AND w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_partial, x, y, w, h, dither)
 end
 
-function framebuffer:refreshUIImp(x, y, w, h)
-    self.debug("refresh: ui-mode", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_ui, x, y, w, h)
+function framebuffer:refreshUIImp(x, y, w, h, dither)
+    self.debug("refresh: ui-mode", x, y, w, h, dither and "w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_ui, x, y, w, h, dither)
 end
 
-function framebuffer:refreshFlashUIImp(x, y, w, h)
-    self.debug("refresh: ui-mode w/ flash", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_flashui, x, y, w, h)
+function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
+    self.debug("refresh: ui-mode w/ flash", x, y, w, h, dither and "AND w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_flashui, x, y, w, h, dither)
 end
 
-function framebuffer:refreshFullImp(x, y, w, h)
-    self.debug("refresh: full", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_full, x, y, w, h)
+function framebuffer:refreshFullImp(x, y, w, h, dither)
+    self.debug("refresh: full", x, y, w, h, dither and "w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_full, x, y, w, h, dither)
 end
 
-function framebuffer:refreshFastImp(x, y, w, h)
-    self.debug("refresh: fast", x, y, w, h)
-    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_fast, x, y, w, h)
+function framebuffer:refreshFastImp(x, y, w, h, dither)
+    self.debug("refresh: fast", x, y, w, h, dither and "w/ HW dithering")
+    self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_fast, x, y, w, h, dither)
 end
 
 function framebuffer:init()

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -452,7 +452,7 @@ end
 --       The only exception to that rule is with REAGL waveform modes, where it will *NOT* flash.
 --       But then, REAGL waveform modes will *never* use anything other than FULL update mode anyway ;).
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    self.debug("refresh: partial w/ flash", x, y, w, h, dither and "AND w/ HW dithering")
+    self.debug("refresh: partial w/ flash", x, y, w, h, dither and "w/ HW dithering")
     self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_partial, x, y, w, h, dither)
 end
 
@@ -462,7 +462,7 @@ function framebuffer:refreshUIImp(x, y, w, h, dither)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    self.debug("refresh: ui-mode w/ flash", x, y, w, h, dither and "AND w/ HW dithering")
+    self.debug("refresh: ui-mode w/ flash", x, y, w, h, dither and "w/ HW dithering")
     self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_flashui, x, y, w, h, dither)
 end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -452,7 +452,7 @@ end
 
 -- NOTE: UPDATE_MODE_FULL doesn't mean full screen or no region, it means ask for a black flash!
 --       The only exception to that rule is with REAGL waveform modes, where it will *NOT* flash.
---       But then, REAGL waveform modes will *never* use anything other than FULL update mode anyway ;).
+--       That's regardless of whether the REAGL waveform mode is of the "always enforce FULL" variety or not ;).
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
     self.debug("refresh: partial w/ flash", x, y, w, h, dither and "w/ HW dithering")
     self:mech_refresh(C.UPDATE_MODE_FULL, self.waveform_partial, x, y, w, h, dither)

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -444,7 +444,7 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    self.debug("refresh: partial", x, y, w, h, d and "w/ HW dithering")
+    self.debug("refresh: partial", x, y, w, h, dither and "w/ HW dithering")
     self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_partial, x, y, w, h, dither)
 end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -309,10 +309,8 @@ local function refresh_koa2(fb, refreshtype, waveform_mode, x, y, w, h, dither)
     -- Did we request HW dithering?
     if dither then
         refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
-        if waveform_mode == C.WAVEFORM_MODE_A2 then
+        if waveform_mode == C.WAVEFORM_MODE_A2 or waveform_mode == C.WAVEFORM_MODE_DU then
             refarea[0].quant_bit = 1;
-        elseif if waveform_mode == C.WAVEFORM_MODE_DU then
-            refarea[0].quant_bit = 3;
         else
             refarea[0].quant_bit = 7;
         end
@@ -347,10 +345,8 @@ local function refresh_pw4(fb, refreshtype, waveform_mode, x, y, w, h, dither)
     -- Did we request HW dithering?
     if dither then
         refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
-        if waveform_mode == C.WAVEFORM_MODE_A2 then
+        if waveform_mode == C.WAVEFORM_MODE_A2 or waveform_mode == C.WAVEFORM_MODE_DU then
             refarea[0].quant_bit = 1;
-        elseif if waveform_mode == C.WAVEFORM_MODE_DU then
-            refarea[0].quant_bit = 3;
         else
             refarea[0].quant_bit = 7;
         end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -8,6 +8,8 @@ local dummy = require("ffi/posix_h")
 local MARKER_MIN = 42
 local MARKER_MAX = (42 * 42)
 
+local function yes() return true end
+
 local framebuffer = {
     -- pass device object here for proper model detection:
     device = nil,
@@ -533,6 +535,7 @@ function framebuffer:init()
 
         -- NOTE: The PW4 essentially uses the same driver as the KOA2, it's just passing a slightly smaller mxcfb_update_data struct
         if isKOA2 or isPW4 then
+            self.device.canHWDither = yes
             if isKOA2 then
                 self.mech_refresh = refresh_koa2
             else
@@ -595,6 +598,7 @@ function framebuffer:init()
         --       Nickel doesn't wait for completion of previous markers on those PARTIAL GLR16, so that's enough to keep our heuristics intact,
         --       while still doing the right thing everywhere ;).
         if isMk7 then
+            self.device.canHWDither = yes
             self.mech_refresh = refresh_kobo_mk7
             self.mech_wait_update_complete = kobo_mk7_mxc_wait_for_update_complete
 


### PR DESCRIPTION
... on supported devices.

That is:

Kindle: KOA2+ (KOA2, PW4)
Kobo: Mk.7+ (Clara, Forma)

Possibly Cervantes 3 & 4, but the required "new" codepath isn't implemented in KO (pinging @pazos) ;).

Used by [KO#4541](https://github.com/koreader/koreader/pull/4541)