### PR TITLE
Switch to GNU basename in ffi.util

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -67,7 +67,7 @@ cdecl_func(usleep)
 cdecl_func(statvfs)
 cdecl_func(gettimeofday)
 cdecl_func(realpath)
-cdecl_func(basename)
+cdecl_func(basename) // NOTE: We'll want the GNU one (c.f., https://github.com/koreader/koreader/issues/4543)
 cdecl_func(dirname)
 
 cdecl_func(malloc)

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -67,7 +67,7 @@ int usleep(unsigned int);
 int statvfs(const char *restrict, struct statvfs *restrict) __attribute__((__nothrow__, __leaf__));
 int gettimeofday(struct timeval *restrict, struct timezone *restrict) __attribute__((__nothrow__, __leaf__));
 char *realpath(const char *restrict, char *restrict) __attribute__((__nothrow__, __leaf__));
-char *basename(char *) __asm__("__xpg_basename") __attribute__((__nothrow__, __leaf__));
+char *basename(char *) __attribute__((__nothrow__, __leaf__));
 char *dirname(char *) __attribute__((__nothrow__, __leaf__));
 void *malloc(size_t) __attribute__((malloc, leaf, nothrow));
 void free(void *) __attribute__((leaf, nothrow));

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    v1.10.1
+    v1.10.2
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/lpeg/CMakeLists.txt
+++ b/thirdparty/lpeg/CMakeLists.txt
@@ -18,7 +18,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
-    URL http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-${LPEG_VER}.tar.gz
+    URL http://gentoo.osuosl.org/distfiles/lpeg-${LPEG_VER}.tar.gz
     URL_MD5 049e0cc18fd540ccddab701a1d771e46
     BUILD_IN_SOURCE 1
     # skip configure


### PR DESCRIPTION
The POSIX variant is unavailable on Android (c.f., #4543).

Fix https://github.com/koreader/koreader/issues/4543