### PR TITLE
Provide a clear screen method that bypasses blitting on Linux fb

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -72,6 +72,7 @@ cdecl_func(dirname)
 
 cdecl_func(malloc)
 cdecl_func(free)
+cdecl_func(memset)
 
 cdecl_func(strdup)
 cdecl_func(strndup)

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -142,6 +142,10 @@ function fb:refreshFast(x, y, w, h, d)
     return self:refreshFastImp(x, y, w, h, d)
 end
 
+-- should be overriden if you want/have a way to clear the screen without going through blitting
+function fb:clear()
+end
+
 -- should be overridden to free resources
 function fb:close()
 end

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -237,6 +237,7 @@ function framebuffer:clear(w, h)
         -- NOTE: We do not rely on self.fb_size, because it's larger than line_length * yres,
         --       and regions of memory outside of the visible screen *may* be used by other things in the system,
         --       for performance reasons, and we do not want to screw them over ;).
+        -- NOTE: This should be equivalent to line_length * yres
         C.memset(self.data, 0xFF, w * (self.fb_bpp / 8) * h)
     end
 end

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -231,6 +231,16 @@ function framebuffer:init()
     framebuffer.parent.init(self)
 end
 
+-- Used to bypass blitting when we just want a white screen
+function framebuffer:clear(w, h)
+    if self.data and w and h then
+        -- NOTE: We do not rely on self.fb_size, because it's larger than line_length * yres,
+        --       and regions of memory outside of the visible screen *may* be used by other things in the system,
+        --       for performance reasons, and we do not want to screw them over ;).
+        C.memset(self.data, 0xFF, w * (self.fb_bpp / 8) * h)
+    end
+end
+
 function framebuffer:close()
     if self.bb ~= nil then
         self.bb:free()

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -71,6 +71,7 @@ char *basename(char *) __attribute__((__nothrow__, __leaf__));
 char *dirname(char *) __attribute__((__nothrow__, __leaf__));
 void *malloc(size_t) __attribute__((malloc, leaf, nothrow));
 void free(void *) __attribute__((leaf, nothrow));
+void *memset(void *, int, size_t) __attribute__((leaf, nothrow));
 char *strdup(const char *) __attribute__((malloc, leaf, nothrow));
 char *strndup(const char *, size_t) __attribute__((malloc, leaf, nothrow));
 struct _IO_FILE *fopen(const char *restrict, const char *restrict);


### PR DESCRIPTION
Useful in combination with a refreshFull to prevent ghosting.