### PR TITLE
A few minor buildsystem tweaks

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -264,8 +264,10 @@ ifeq ($(TARGET), kobo)
 	# NOTE: If we only care about Kobos w/ a Touch screen, we're good.
 	ARM_ARCH:=$(ARMV7_A8_ARCH)
 	ARM_ARCH+=-mfloat-abi=hard
-	COMPAT_CFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
-	COMPAT_CXXFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
+	ifeq ($(shell PATH='$(PATH)' $(CC) -dumpmachine 2>/dev/null), arm-linux-gnueabihf)
+		COMPAT_CFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
+		COMPAT_CXXFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
+	endif
 else ifeq ($(TARGET), ubuntu-touch)
 	ARM_ARCH:=$(ARMV7_A8_ARCH)
 	ARM_ARCH+=-mfloat-abi=hard
@@ -293,9 +295,11 @@ else ifeq ($(TARGET), kindlepw2)
 else ifeq ($(TARGET), kindle-legacy)
 	ARM_ARCH:=$(ARMV6_1136_ARCH)
 	ARM_ARCH+=-mfloat-abi=softfp
-	COMPAT_CFLAGS:=$(MG2K12_COMPAT_CFLAGS)
-	COMPAT_CXXFLAGS:=$(MG2K12_COMPAT_CXXFLAGS)
-	#COMPAT_CFLAGS:=$(NILUJE_COMPAT_CFLAGS)
+	ifeq ($(shell PATH='$(PATH)' $(CC) -dumpmachine 2>/dev/null), arm-linux-gnueabi)
+		COMPAT_CFLAGS:=$(MG2K12_COMPAT_CFLAGS)
+		COMPAT_CXXFLAGS:=$(MG2K12_COMPAT_CXXFLAGS)
+	endif
+	COMPAT_CFLAGS:=$(NILUJE_COMPAT_CFLAGS)
 	# Avoid pulling stuff from GLIBC_2.7 & 2.9 in glib
 	export glib_cv_eventfd=no
 	export ac_cv_func_pipe2=no

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -527,7 +527,7 @@ AES_LIB=$(MINIZIP_DIR)/libaes.a
 
 MUPDF_BUILD_DIR=$(CURDIR)/$(THIRDPARTY_DIR)/mupdf/build/$(MACHINE)
 MUPDF_DIR=$(MUPDF_BUILD_DIR)/mupdf-prefix/src/mupdf
-MUPDF_LIB_DIR=$(MUPDF_DIR)/build/release
+MUPDF_LIB_DIR=$(MUPDF_DIR)/build/$(if $(KODEBUG),debug,release)
 MUPDF_LIB_STATIC=$(MUPDF_LIB_DIR)/libmupdf.a
 MUPDF_THIRDPARTY_LIBS=$(MUPDF_LIB_DIR)/libmupdfthird.a \
 			$(AES_LIB)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -210,7 +210,8 @@ BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 #BASE_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer -frename-registers -fweb
 # Use this for debugging:
 ifdef KODEBUG
-	BASE_CFLAGS:=-Og -g -pipe
+	BASE_CFLAGS:=-Og -g -pipe -fno-omit-frame-pointer
+	# Prevent runaway buildsystems from screwing with us and stripping stuff behind our backs...
 	STRIP:=true
 endif
 

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -10,7 +10,12 @@ enable_language(C)
 assert_var_defined(HOSTCFLAGS)
 assert_var_defined(HOSTCC)
 assert_var_defined(OS)
-set(BUILD_CMD_GENERATE sh -c "env CFLAGS=\"${HOSTCFLAGS}\" $(MAKE) -j${PARALLEL_JOBS} generate build=\"release\" CC=\"${HOSTCC}\" verbose=1")
+if($ENV{KODEBUG})
+    set(MUPDF_BUILD_TYPE "debug")
+else()
+    set(MUPDF_BUILD_TYPE "release")
+endif()
+set(BUILD_CMD_GENERATE sh -c "env CFLAGS=\"${HOSTCFLAGS}\" $(MAKE) -j${PARALLEL_JOBS} generate build=\"${MUPDF_BUILD_TYPE}\" CC=\"${HOSTCC}\" verbose=\"yes\"")
 
 assert_var_defined(LDFLAGS)
 assert_var_defined(XCFLAGS)
@@ -20,8 +25,8 @@ assert_var_defined(XCFLAGS)
 set(XCFLAGS "${XCFLAGS} -DFZ_PLOTTERS_CMYK=0 -DFZ_ENABLE_JS=0")
 set(STATIC_BUILD_CMD "$(MAKE) -j${PARALLEL_JOBS}")
 set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} LDFLAGS=\"${LDFLAGS}\" XCFLAGS=\"${XCFLAGS}\"")
-set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} CC=\"${CC}\" CXX=\"${CXX}\" AR=\"${AR}\" build=\"release\" MUDRAW= MUTOOL= CURL_LIB= OS=${OS}")
-set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} verbose=1 FREETYPE_DIR=nonexisting JPEG_DIR=nonexisting ZLIB_DIR=nonexisting CROSSCOMPILE=yes")
+set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} CC=\"${CC}\" CXX=\"${CXX}\" AR=\"${AR}\" build=\"${MUPDF_BUILD_TYPE}\" MUDRAW= MUTOOL= CURL_LIB= OS=${OS}")
+set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} verbose=\"yes\" FREETYPE_DIR=nonexisting JPEG_DIR=nonexisting ZLIB_DIR=nonexisting CROSSCOMPILE=\"yes\"")
 set(STATIC_BUILD_CMD sh -c "${STATIC_BUILD_CMD} third libs")
 
 # by default, mupdf compiles to a static library:
@@ -46,7 +51,7 @@ else()
     set(LINK_OPTS "${LINK_OPTS} -Wl,--whole-archive ${MUPDF_LIB_STATIC}")
     set(LINK_OPTS "${LINK_OPTS} -Wl,--no-whole-archive ${MUPDF_THIRDPARTY_LIBS}")
     set(LINK_OPTS "${LINK_OPTS} -Wl,-soname=${MUPDF_SONAME}")
-    set(LINK_OPTS "${LINK_OPTS} build/release/libmupdfthird.a")
+    set(LINK_OPTS "${LINK_OPTS} build/${MUPDF_BUILD_TYPE}/libmupdfthird.a")
 endif()
 set(SHARED_BUILD_STR "${CC} -shared ${CFLAGS} ${LINK_OPTS} ${AES_LIB} ${ZLIB} ${JPEG_LIB} ${FREETYPE_LIB} -o ${MUPDF_LIB} -lm")
 
@@ -62,6 +67,10 @@ set(PATCH_CMD1 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/external_fonts.
 set(PATCH_CMD2 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/encrypted_zip.patch || true")
 # use libjpeg as a shared library
 set(PATCH_CMD3 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libjpeg_shared.patch || true")
+# Disable potentially crashy ARM ASM (it's 7 years old, and hell to debug)
+# NOTE: There's also a few ARCH_UNALIGNED_OK checks, but we never did pass that define.
+#       (FWIW, we *could*, on anything not kindle-legacy).
+set(PATCH_CMD4 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/no_arm_asm.patch || true")
 
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
@@ -78,7 +87,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -15,7 +15,7 @@ if($ENV{KODEBUG})
 else()
     set(MUPDF_BUILD_TYPE "release")
 endif()
-set(BUILD_CMD_GENERATE sh -c "env CFLAGS=\"${HOSTCFLAGS}\" $(MAKE) -j${PARALLEL_JOBS} generate build=\"${MUPDF_BUILD_TYPE}\" CC=\"${HOSTCC}\" verbose=\"yes\"")
+set(BUILD_CMD_GENERATE sh -c "env CFLAGS=\"${HOSTCFLAGS}\" $(MAKE) -j${PARALLEL_JOBS} generate build=\"${MUPDF_BUILD_TYPE}\" CC=\"${HOSTCC}\" verbose=\"no\"")
 
 assert_var_defined(LDFLAGS)
 assert_var_defined(XCFLAGS)
@@ -26,7 +26,7 @@ set(XCFLAGS "${XCFLAGS} -DFZ_PLOTTERS_CMYK=0 -DFZ_ENABLE_JS=0")
 set(STATIC_BUILD_CMD "$(MAKE) -j${PARALLEL_JOBS}")
 set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} LDFLAGS=\"${LDFLAGS}\" XCFLAGS=\"${XCFLAGS}\"")
 set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} CC=\"${CC}\" CXX=\"${CXX}\" AR=\"${AR}\" build=\"${MUPDF_BUILD_TYPE}\" MUDRAW= MUTOOL= CURL_LIB= OS=${OS}")
-set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} verbose=\"yes\" FREETYPE_DIR=nonexisting JPEG_DIR=nonexisting ZLIB_DIR=nonexisting CROSSCOMPILE=\"yes\"")
+set(STATIC_BUILD_CMD "${STATIC_BUILD_CMD} verbose=\"no\" FREETYPE_DIR=nonexisting JPEG_DIR=nonexisting ZLIB_DIR=nonexisting CROSSCOMPILE=\"yes\"")
 set(STATIC_BUILD_CMD sh -c "${STATIC_BUILD_CMD} third libs")
 
 # by default, mupdf compiles to a static library:

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -71,6 +71,8 @@ set(PATCH_CMD3 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/libjpeg_shared.
 # NOTE: There's also a few ARCH_UNALIGNED_OK checks, but we never did pass that define.
 #       (FWIW, we *could*, on anything not kindle-legacy).
 set(PATCH_CMD4 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/no_arm_asm.patch || true")
+# Honor CFLAGS
+set(PATCH_CMD5 sh -c "patch -N -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/honor_cflags.patch || true")
 
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
@@ -87,7 +89,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/honor_cflags.patch
+++ b/thirdparty/mupdf/honor_cflags.patch
@@ -1,0 +1,17 @@
+diff --git a/Makerules b/Makerules
+index 57065f32..6fd40fe3 100644
+--- a/Makerules
++++ b/Makerules
+@@ -25,10 +25,10 @@ SANITIZE_FLAGS := -fsanitize=address
+ SANITIZE_FLAGS += -fsanitize=leak
+ 
+ ifeq "$(build)" "debug"
+-CFLAGS += -pipe -g
++CFLAGS += -g
+ LDFLAGS += -g
+ else ifeq "$(build)" "release"
+-CFLAGS += -pipe -O2 -DNDEBUG -fomit-frame-pointer
++CFLAGS += -DNDEBUG
+ LDFLAGS += $(LDREMOVEUNREACH) -Wl,-s
+ else ifeq "$(build)" "small"
+ CFLAGS += -pipe -Os -DNDEBUG -fomit-frame-pointer

--- a/thirdparty/mupdf/no_arm_asm.patch
+++ b/thirdparty/mupdf/no_arm_asm.patch
@@ -1,0 +1,18 @@
+diff --git a/include/mupdf/fitz/system.h b/include/mupdf/fitz/system.h
+index c480bd7c..8190fc36 100644
+--- a/include/mupdf/fitz/system.h
++++ b/include/mupdf/fitz/system.h
+@@ -47,11 +47,13 @@ typedef unsigned __int64 uint64_t;
+ 	Spot architectures where we have optimisations.
+ */
+ 
++/*
+ #if defined(__arm__) || defined(__thumb__)
+ #ifndef ARCH_ARM
+ #define ARCH_ARM
+ #endif
+ #endif
++*/
+ 
+ /*
+ 	Some differences in libc can be smoothed over


### PR DESCRIPTION
* Avoid compat CFLAGS on kobo & kindle-legacy when using our TCs
* Disable ARM ASM in MµPDF, and honor debug builds