### PR TITLE
[build] Download GNU deps from mirror

### DIFF
--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -31,7 +31,7 @@ set(GETTEXT_VER "0.19.8.1")
 include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
-    URL http://ftp.gnu.org/pub/gnu/gettext/gettext-${GETTEXT_VER}.tar.gz
+    URL http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz
     URL_MD5 97e034cf8ce5ba73a28ff6c3c0638092
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/libiconv/CMakeLists.txt
+++ b/thirdparty/libiconv/CMakeLists.txt
@@ -19,7 +19,7 @@ set(GETTEXT_VER "1.15")
 include(ExternalProject)
 ExternalProject_Add(
     libiconv
-    URL http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${GETTEXT_VER}.tar.gz
+    URL http://ftpmirror.gnu.org/libiconv/libiconv-${GETTEXT_VER}.tar.gz
     URL_MD5 ace8b5f2db42f7b3b3057585e80d9808
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -53,7 +53,7 @@ include(ExternalProject)
 set(TAR_VER "1.31")
 ExternalProject_Add(
     ${PROJECT_NAME}
-    URL http://ftp.gnu.org/gnu/tar/tar-${TAR_VER}.tar.gz
+    URL http://ftpmirror.gnu.org/tar/tar-${TAR_VER}.tar.gz
     URL_MD5 f2d3b2c7130390f2fd204527c4c22aa5
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     PATCH_COMMAND COMMAND ${PATCH_CMD1}


### PR DESCRIPTION
Fixes #823.

This is a simple one. https://ftp.gnu.org/ is currently offline but we shouldn't actually be using it anyway.

https://www.gnu.org/server/mirror.en.html

> First, for users/downloaders: the address http://ftpmirror.gnu.org/ multiplexes between the mirrors, trying to choose one that is nearby and up to date. E.g., http://ftpmirror.gnu.org/emacs/ goes to a mirror's directory of GNU Emacs. We recommend using this generic ftpmirror.gnu.org address wherever possible in links, documentation, etc., to reduce load on the main GNU server.

tl;dr http://ftpmirror.gnu.org should be more stable.