### PR TITLE
bump crengine: fix text selection and cache issues

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -872,7 +872,10 @@ static int gotoPos(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	int pos = luaL_checkint(L, 2);
 
-	doc->text_view->SetPos(pos);
+	doc->text_view->SetPos(pos, true, true);
+	// savePos=true is the default, but we use allowScrollAfterEnd=true
+	// to allow frontend code to control how much we can scroll after end
+	// by adjusting pos
 
 	return 0;
 }


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/264:
- Fix text selection in some tables
- Add known HTML attributes to avoid cache issues
- Make existing context.AddLine() and pb_flag clearer

cre.cpp:
- gotoPos(): allow scrolling after end of document (to avoid not seeing the last line of a document that would be hidden by the footer bar). Will help fixing https://github.com/koreader/koreader/issues/4650