### PR TITLE
Bump libjpeg-turbo to 2.0.2

### DIFF
--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -84,7 +84,7 @@ set(CFG_CMD sh -c "${CMAKE_COMMAND} ${CFG_OPTS}")
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/libjpeg-turbo/libjpeg-turbo.git
-    2.0.1
+    2.0.2
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.2