### PR TITLE
PocketBook: Fix hanging on waking up from sleep

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -71,7 +71,10 @@ static int openInputDevice(lua_State *L) {
 
 #ifdef POCKETBOOK
     int inkview_events = luaL_checkint(L, 2);
-    if (inkview_events == 1) { forkInkViewMain(L, inputdevice); }
+    if (inkview_events == 1) { 
+        startInkViewMain(L, fd, inputdevice); 
+        return 0;
+    }
 #endif
 
     if (!strcmp("fake_events", inputdevice)) {


### PR DESCRIPTION
The forked process based implementation of the PocketBook event thread has been replaced with a background thread based one. This should fix the hanging of Koreader process  on waking from suspension state every second time (koreader/koreader#4646). Koreader suspending can be achieved by:

- Pushing the _Home_ button => resume by selecting _koreader_ task in the Task Manager
- Pushing the _Power_ button => Push it again to resume
- Waiting until the _Auto-suspend_ timeout has passed => Push the _Power_ button to resume

The issue root cause is currently unknown, although it seems to be introduced by one of more recent firmware updates. Tested on _PB InkPad3 FW v.5.19.660_ and _PB Touch HD FW v.5.19.673_. Requires testing on more devices. It would be really nice to check if it doesn't break anything on some older firmwares/models.