### PR TITLE
[fix] ffi/framebuffer: set self.dpi in setDPI

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -274,6 +274,7 @@ end
 
 function fb:setDPI(dpi)
     screen_dpi_override = dpi
+    self.dpi = dpi
 end
 
 function fb:scaleByDPI(px)


### PR DESCRIPTION
Makes sure custom DPI settings actually work for now.
This might not be quite the Right Thing™ but better slightly improprietary than broken.

See https://github.com/koreader/koreader/issues/4726 for discussion.