### PR TITLE
cre: fix highlight/link boxes in 2-pages mode

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1262,7 +1262,10 @@ bool docToWindowRect(LVDocView *tv, lvRect &rc) {
     else {
         return false;
     }
-    if (tv->docToWindowPoint(bottomRight)) {
+    if (tv->docToWindowPoint(bottomRight, true)) {
+        // isRectBottom=true: allow this bottom point (outside of the
+        // rect content) to be considered in this page, if it is
+        // actually the top of the next page.
         rc.setBottomRight(bottomRight);
     }
     else {


### PR DESCRIPTION
Bump crengine for: docToWindowPoint(): adds isRectBottom parameter
cre.cpp: logical fix for getting boxes coordinates on screen, but fix mostly an issue in 2-pages mode where the top line of the second page was not highlighted, and its link couldn't be followed.
See https://github.com/koreader/crengine/pull/268 for details