### PR TITLE
Bump CMake minimum version to 3.5.1

### DIFF
--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(czmq)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(djvulibre)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(dropbear)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/evernote-sdk-lua/CMakeLists.txt
+++ b/thirdparty/evernote-sdk-lua/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(evernote-sdk-lua)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(fbink)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/filemq/CMakeLists.txt
+++ b/thirdparty/filemq/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(filemq)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(freetype2)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(gettext)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/giflib/CMakeLists.txt
+++ b/thirdparty/giflib/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(giflib)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/glib/CMakeLists.txt
+++ b/thirdparty/glib/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(glib)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(harfbuzz)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(kpvcrlib)
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5.1)
 enable_language(C CXX ASM)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(leptonica)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libffi/CMakeLists.txt
+++ b/thirdparty/libffi/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libffi)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libiconv/CMakeLists.txt
+++ b/thirdparty/libiconv/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libiconv)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libjpeg-turbo)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libk2pdfopt)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libpng/CMakeLists.txt
+++ b/thirdparty/libpng/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libpng)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libzmq/CMakeLists.txt
+++ b/thirdparty/libzmq/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(libzmq)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lj-wpaclient/CMakeLists.txt
+++ b/thirdparty/lj-wpaclient/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(lj-wpaclient)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lodepng/CMakeLists.txt
+++ b/thirdparty/lodepng/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(lodepng)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lpeg/CMakeLists.txt
+++ b/thirdparty/lpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(lpeg)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lua-Spore/CMakeLists.txt
+++ b/thirdparty/lua-Spore/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(lua-Spore)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lua-serialize/CMakeLists.txt
+++ b/thirdparty/lua-serialize/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(lua-serialize)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(luajit)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luasec/CMakeLists.txt
+++ b/thirdparty/luasec/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(luasec)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luasocket/CMakeLists.txt
+++ b/thirdparty/luasocket/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(luasocket)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(minizip)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(mupdf)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/nanosvg/CMakeLists.txt
+++ b/thirdparty/nanosvg/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(nanosvg)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/openssh/CMakeLists.txt
+++ b/thirdparty/openssh/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(openssh)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(openssl)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/popen-noshell/CMakeLists.txt
+++ b/thirdparty/popen-noshell/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(popen-noshell)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(sdcv)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(sqlite)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(tar)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/tesseract/CMakeLists.txt
+++ b/thirdparty/tesseract/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(tesseract)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(turbo)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(zlib)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zsync/CMakeLists.txt
+++ b/thirdparty/zsync/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(zsync)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zyre/CMakeLists.txt
+++ b/thirdparty/zyre/CMakeLists.txt
@@ -1,5 +1,5 @@
 PROJECT(zyre)
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")


### PR DESCRIPTION
CMake dumbs itself down to the minimum required version and CMake <3.1 is pretty darned dumb.

3.3 is slightly less annoyingly stupid about finding libraries and 3.4 shouldn't get horribly confused about CCache. This is paramount to not making me waste an afternoon rewriting the whole thing in Meson. (Not saying it can't still happen, but at least it should then be based on Meson's merits rather than CMake's relative lack thereof.)

I'd be more inclined to say at least 3.11, but I figured I'd keep this conservative and uncontroversial for the moment.