### PR TITLE
 Make the JIT loopunroll tweak mandatory when not using the C blitter

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -122,6 +122,14 @@ void free(void *ptr);
 ]]
 
 local use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
+-- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,
+--       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).
+--       c.f., #4137, #4752, #4782
+if not use_cblitbuffer then
+    io.write("Tweaking LuaJIT's max loop unroll factor (15 -> 45)\n")
+    io.flush()
+    jit.opt.start("loopunroll=45")
+end
 
 -- color value types
 local Color4U = ffi.typeof("Color4U")


### PR DESCRIPTION
We've found more corner-cases not limited to 16bpp since the last
time...
Some of them barely even corner-y ;).

Re: https://github.com/koreader/koreader/pull/4782