### PR TITLE
Bump FreeType to v2.10.0

### DIFF
--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -14,7 +14,7 @@ assert_var_defined(LDFLAGS)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
-set(CFG_ENV_VAR "CC=\"${CC}\" CXX=\"${CXX}\" CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\"")
+set(CFG_ENV_VAR "CC=\"${CC}\" CXX=\"${CXX}\" CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ac_cv_func_mmap_fixed_mapped=\"yes\"")
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --disable-static --enable-shared --with-zlib=no --with-bzip2=no --with-png=no --with-harfbuzz=no --host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 
@@ -29,7 +29,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://gitlab.com/koreader/freetype2.git
-    VER-2-9-1
+    VER-2-10-0
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Also, enforce a working mmap, as it gets disabled for safety when
x-compiling.