### PR TITLE
[build] Unified CMake thirdparty/build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,5 @@ build
 
 kpvcrlib/build
 thirdparty/*/build
+thirdparty/build
 kodebug-*

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -536,10 +536,11 @@ LIB_EXT=$(if $(WIN32),.dll,$(if $(DARWIN),.dylib,.so))
 # you can probably leave these settings alone:
 
 THIRDPARTY_DIR=thirdparty
+THIRDPARTY_BUILD_DIR=$(THIRDPARTY_DIR)/build/$(MACHINE)
 
 LUAFILESYSTEM_DIR=luafilesystem
 
-ZLIB_BUILD_DIR=$(THIRDPARTY_DIR)/zlib/build/$(MACHINE)
+ZLIB_BUILD_DIR=$(THIRDPARTY_BUILD_DIR)/zlib-build
 ZLIB_DIR=$(CURDIR)/$(ZLIB_BUILD_DIR)/zlib-prefix/src/zlib
 ZLIB_STATIC=$(ZLIB_DIR)/libz.a
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -404,7 +404,6 @@ endif
 
 # NOTE: Follow the NDK's lead
 ifeq ($(TARGET), android)
-	ZLIB_LDFLAGS:=-Wl,-soname,libz.so.1
 	LDFLAGS+=-no-canonical-prefixes -Wl,--fix-cortex-a8
 	ifeq ($(ANDROID_ARCH), arm)
 		LDFLAGS+=-march=armv7-a
@@ -541,7 +540,7 @@ THIRDPARTY_BUILD_DIR=$(THIRDPARTY_DIR)/build/$(MACHINE)
 LUAFILESYSTEM_DIR=luafilesystem
 
 ZLIB_BUILD_DIR=$(THIRDPARTY_BUILD_DIR)/zlib-build
-ZLIB_DIR=$(CURDIR)/$(ZLIB_BUILD_DIR)/zlib-prefix/src/zlib
+ZLIB_DIR=$(CURDIR)/$(ZLIB_BUILD_DIR)/zlib-download-prefix/src/zlib-download
 ZLIB_STATIC=$(ZLIB_DIR)/libz.a
 
 MINIZIP_BUILD_DIR=$(THIRDPARTY_DIR)/minizip/build/$(MACHINE)

--- a/Makefile.third
+++ b/Makefile.third
@@ -304,7 +304,7 @@ $(ZLIB) $(ZLIB_STATIC): thirdparty $(THIRDPARTY_DIR)/zlib/CMakeLists.txt
 ifdef WIN32
 	cp -fL $(ZLIB_DIR)/$(notdir $(ZLIB)) $(ZLIB)
 else
-	cp -fL $(ZLIB_DIR)/$(notdir $(ZLIB)) $(ZLIB)
+	cp -fL $(ZLIB_DIR)/lib/$(notdir $(ZLIB)) $(ZLIB)
 endif
 
 # ===========================================================================

--- a/Makefile.third
+++ b/Makefile.third
@@ -300,27 +300,27 @@ $(GLIB_STATIC): $(LIBICONV) $(LIBGETTEXT) $(LIBFFI_DIR)/include $(THIRDPARTY_DIR
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 
 $(ZLIB) $(ZLIB_STATIC): $(THIRDPARTY_DIR)/zlib/CMakeLists.txt
-	install -d $(ZLIB_BUILD_DIR)
+	install -d $(THIRDPARTY_BUILD_DIR)
 	-rm -f $(ZLIB_DIR)/../zlib-stamp/zlib-install $(ZLIB) $(ZLIB_STATIC)
 ifdef ANDROID
-	cd $(ZLIB_BUILD_DIR) && \
+	cd $(THIRDPARTY_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" -DCHOST="$(CHOST)" \
 		-DCFLAGS="$(CFLAGS)" \
 		-DLDFLAGS="$(LDFLAGS) -shared $(ZLIB_LDFLAGS)" \
-		$(CURDIR)/thirdparty/zlib && \
+		$(CURDIR)/$(THIRDPARTY_DIR) && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 else
-	cd $(ZLIB_BUILD_DIR) && \
+	cd $(THIRDPARTY_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" \
 		-DCFLAGS="$(CFLAGS)" \
 		-DLDFLAGS="$(LDFLAGS)" \
-		$(CURDIR)/thirdparty/zlib && \
+		$(CURDIR)/$(THIRDPARTY_DIR) && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 endif
 ifdef WIN32
 	cp -fL $(ZLIB_DIR)/$(notdir $(ZLIB)) $(ZLIB)
 else
-	cp -fL $(ZLIB_DIR)/lib/$(notdir $(ZLIB)) $(ZLIB)
+	cp -fL $(ZLIB_DIR)/$(notdir $(ZLIB)) $(ZLIB)
 endif
 
 # ===========================================================================

--- a/Makefile.third
+++ b/Makefile.third
@@ -299,24 +299,8 @@ $(GLIB_STATIC): $(LIBICONV) $(LIBGETTEXT) $(LIBFFI_DIR)/include $(THIRDPARTY_DIR
 		$(CURDIR)/$(THIRDPARTY_DIR)/glib && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 
-$(ZLIB) $(ZLIB_STATIC): $(THIRDPARTY_DIR)/zlib/CMakeLists.txt
-	install -d $(THIRDPARTY_BUILD_DIR)
+$(ZLIB) $(ZLIB_STATIC): thirdparty $(THIRDPARTY_DIR)/zlib/CMakeLists.txt
 	-rm -f $(ZLIB_DIR)/../zlib-stamp/zlib-install $(ZLIB) $(ZLIB_STATIC)
-ifdef ANDROID
-	cd $(THIRDPARTY_BUILD_DIR) && \
-		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" -DCHOST="$(CHOST)" \
-		-DCFLAGS="$(CFLAGS)" \
-		-DLDFLAGS="$(LDFLAGS) -shared $(ZLIB_LDFLAGS)" \
-		$(CURDIR)/$(THIRDPARTY_DIR) && \
-		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-else
-	cd $(THIRDPARTY_BUILD_DIR) && \
-		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" \
-		-DCFLAGS="$(CFLAGS)" \
-		-DLDFLAGS="$(LDFLAGS)" \
-		$(CURDIR)/$(THIRDPARTY_DIR) && \
-		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-endif
 ifdef WIN32
 	cp -fL $(ZLIB_DIR)/$(notdir $(ZLIB)) $(ZLIB)
 else
@@ -665,6 +649,16 @@ $(NANOSVG_HEADERS): $(THIRDPARTY_DIR)/nanosvg/CMakeLists.txt
 	cp -fL $(NANOSVG_DIR)/nanosvg/src/nanosvg.h $(NANOSVG_INCLUDE_DIR)/
 	cp -fL $(NANOSVG_DIR)/nanosvg/src/nanosvgrast.h $(NANOSVG_INCLUDE_DIR)/
 	cp -fL $(NANOSVG_DIR)/nanosvg/example/stb_image_write.h $(NANOSVG_INCLUDE_DIR)/
+
+.PHONY:thirdparty
+thirdparty: $(THIRDPARTY_DIR)/CMakeLists.txt
+	install -d $(THIRDPARTY_BUILD_DIR)
+	cd $(THIRDPARTY_BUILD_DIR) && \
+		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" -DCHOST="$(CHOST)" \
+		-DCFLAGS="$(CFLAGS)" \
+		-DLDFLAGS="$(LDFLAGS)" \
+		$(CURDIR)/$(THIRDPARTY_DIR) && \
+		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 
 comma:=,
 empty:=

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -1,0 +1,20 @@
+PROJECT(koreader-base-thirdparty)
+cmake_minimum_required(VERSION 3.5.1)
+
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/cmake_modules")
+include("koreader_thirdparty_common")
+
+enable_language(C)
+
+assert_var_defined(CC)
+assert_var_defined(CFLAGS)
+assert_var_defined(LDFLAGS)
+
+message(STATUS "Thirdparty: zlib…")
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/zlib/CMakeLists.txt
+    ${CMAKE_BINARY_DIR}/zlib-src/CMakeLists.txt
+    @ONLY)
+add_subdirectory("${CMAKE_BINARY_DIR}/zlib-src"
+                 "${CMAKE_BINARY_DIR}/zlib-build")
+message(STATUS "Thirdparty: zlib… DONE")

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -10,7 +10,7 @@ assert_var_defined(CC)
 assert_var_defined(CFLAGS)
 assert_var_defined(LDFLAGS)
 
-set(KO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/downloads)
+set(KO_DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/downloads")
 
 message(STATUS "Thirdparty: zlib…")
 configure_file(

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -10,6 +10,8 @@ assert_var_defined(CC)
 assert_var_defined(CFLAGS)
 assert_var_defined(LDFLAGS)
 
+set(KO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/downloads)
+
 message(STATUS "Thirdparty: zlib…")
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/zlib/CMakeLists.txt

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-PROJECT(zlib)
+PROJECT(zlib-download)
 cmake_minimum_required(VERSION 3.5.1)
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
@@ -11,6 +11,10 @@ assert_var_defined(CFLAGS)
 assert_var_defined(LDFLAGS)
 
 ep_get_source_dir(SOURCE_DIR)
+
+if ($ENV{ANDROID})
+    set(LDFLAGS "${LDFLAGS} -shared -Wl,-soname,libz.so.1")
+endif()
 
 if($ENV{WIN32})
     # configure
@@ -44,3 +48,7 @@ ExternalProject_Add(
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}
 )
+
+set(ZLIB_INCLUDE_DIR "${SOURCE_DIR}/include" PARENT_SCOPE)
+set(ZLIB_LIB_DIR "${SOURCE_DIR}/lib" PARENT_SCOPE)
+set(ZLIB_STATIC "${SOURCE_DIR}/lib/libz.${CMAKE_STATIC_LIBRARY_SUFFIX}" PARENT_SCOPE)

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -16,19 +16,19 @@ if($ENV{WIN32})
     # configure
     set(optional_cfg_cmd "")
     # build
-    set(BUILD_VARS DESTDIR=${CMAKE_CURRENT_BINARY_DIR} INCLUDE_PATH=include LIBRARY_PATH=lib BIN_PATH=bin)
+    set(BUILD_VARS DESTDIR=${SOURCE_DIR} INCLUDE_PATH=include LIBRARY_PATH=lib BIN_PATH=bin)
     set(BUILD_ARGS CC="${CC}" CFLAGS="${CFLAGS}" RC="${CHOST}-windres" SHARED_MODE=1)
     # TODO: also use -j for windows?
     set(BUILD_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS})
     # install
-    #set(INSTALL_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS} install)
+    set(INSTALL_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS} install)
 else()
     # configure
-    set(optional_cfg_cmd CONFIGURE_COMMAND sh -c "CC=\"${CC}\" CHOST=\"${CHOST}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}")
+    set(optional_cfg_cmd CONFIGURE_COMMAND sh -c "CC=\"${CC}\" CHOST=\"${CHOST}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ./configure --prefix=${SOURCE_DIR}")
     # build
     set(BUILD_CMD ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} --silent shared static)
     # install
-    #set(INSTALL_CMD ${KO_MAKE_RECURSIVE} install)
+    set(INSTALL_CMD ${KO_MAKE_RECURSIVE} install)
 endif()
 
 include(ExternalProject)

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -16,19 +16,19 @@ if($ENV{WIN32})
     # configure
     set(optional_cfg_cmd "")
     # build
-    set(BUILD_VARS DESTDIR=${SOURCE_DIR} INCLUDE_PATH=include LIBRARY_PATH=lib BIN_PATH=bin)
+    set(BUILD_VARS DESTDIR=${CMAKE_CURRENT_BINARY_DIR} INCLUDE_PATH=include LIBRARY_PATH=lib BIN_PATH=bin)
     set(BUILD_ARGS CC="${CC}" CFLAGS="${CFLAGS}" RC="${CHOST}-windres" SHARED_MODE=1)
     # TODO: also use -j for windows?
     set(BUILD_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS})
     # install
-    set(INSTALL_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS} install)
+    #set(INSTALL_CMD ${BUILD_VARS} ${KO_MAKE_RECURSIVE} -f win32/Makefile.gcc ${BUILD_ARGS} install)
 else()
     # configure
-    set(optional_cfg_cmd CONFIGURE_COMMAND sh -c "CC=\"${CC}\" CHOST=\"${CHOST}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ./configure --prefix=${SOURCE_DIR}")
+    set(optional_cfg_cmd CONFIGURE_COMMAND sh -c "CC=\"${CC}\" CHOST=\"${CHOST}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}")
     # build
     set(BUILD_CMD ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} --silent shared static)
     # install
-    set(INSTALL_CMD ${KO_MAKE_RECURSIVE} install)
+    #set(INSTALL_CMD ${KO_MAKE_RECURSIVE} install)
 endif()
 
 include(ExternalProject)

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -36,7 +36,7 @@ set(ZLIB_VER "1.2.11")
 set(ZLIB_MD5 "1c9f62f0778697a09d36121ead88e08e")
 ExternalProject_Add(
     ${PROJECT_NAME}
-    DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
+    DOWNLOAD_DIR @KO_DOWNLOAD_DIR@
     URL http://gentoo.osuosl.org/distfiles/zlib-${ZLIB_VER}.tar.gz
     URL_MD5 ${ZLIB_MD5}
     BUILD_IN_SOURCE 1


### PR DESCRIPTION
Just a passing thought, putting it up in a PR on GH for public archival/inspiration purposes or possibly to extend upon. This is a proof of concept of building in thirdparty/build/$(MACHINE) instead of thirdparty/build/$DEPENDENCY/$(MACHINE).

That way instead of using the Makefile.third with a lot of complex variable passing to CMake etc. you'd keep the logic almost entirely in CMake (not implemented in this proof of concept), so you should be able to write things like `add_dependencies(mupdf zlib)`.

Also the dist-clean command could be simplified to removing `THIRDPARTY_BUILD_DIR`.

Or to put it another way, if you're using CMake you might as well actually use it, so that errors like https://github.com/koreader/koreader-base/pull/865 can't occur.