### PR TITLE
[fix] Makefile.defs: add lj-wpaclient to CMAKE_THIRDPARTY_LIBS

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -768,6 +768,7 @@ CMAKE_THIRDPARTY_LIBS = kpvcrlib,nanosvg
 CMAKE_THIRDPARTY_LIBS += ,evernote-sdk-lua,luajit,lpeg,turbo
 CMAKE_THIRDPARTY_LIBS += ,zsync,zyre,czmq,filemq,libzmq
 CMAKE_THIRDPARTY_LIBS += ,libk2pdfopt,tesseract,leptonica
+CMAKE_THIRDPARTY_LIBS += ,lj-wpaclient
 CMAKE_THIRDPARTY_LIBS += ,lua-Spore,luasec,luasocket,libffi,lua-serialize,glib,lodepng,minizip
 CMAKE_THIRDPARTY_LIBS += ,djvulibre,mupdf,freetype2,harfbuzz,giflib,libpng,zlib
 CMAKE_THIRDPARTY_LIBS += ,tar,sdcv,libiconv,gettext,libjpeg-turbo,popen-noshell,sqlite


### PR DESCRIPTION
Like https://github.com/koreader/koreader-base/pull/865 but only occurs when cross-compiling for certain platforms.

Cf. https://github.com/koreader/koreader-base/pull/866 for a possible solution where this could never be a problem.