### PR TITLE
[chore] CMake: deprecate custom processor count logic

### DIFF
--- a/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
@@ -1,9 +1,8 @@
 if(NOT DEFINED PROCESSOR_COUNT)
     include(ProcessorCount)
     ProcessorCount(N)
-    if(NOT N EQUAL 0)
-        set(PROCESSOR_COUNT ${N})
-    endif()
+    # 0 if unknown
+    set(PROCESSOR_COUNT ${N})
 endif()
 
 if(APPLE)

--- a/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
@@ -1,24 +1,9 @@
 if(NOT DEFINED PROCESSOR_COUNT)
-  # Unknown:
-  set(PROCESSOR_COUNT 0)
-
-  # Linux:
-  set(cpuinfo_file "/proc/cpuinfo")
-  if(EXISTS "${cpuinfo_file}")
-    file(STRINGS "${cpuinfo_file}" procs REGEX "^processor.: [0-9]+$")
-    list(LENGTH procs PROCESSOR_COUNT)
-  endif()
-
-  # Mac:
-  if(APPLE)
-    execute_process(COMMAND sysctl -n hw.ncpu OUTPUT_VARIABLE ncpu)
-    set(PROCESSOR_COUNT "${ncpu}")
-  endif()
-
-  # Windows:
-  if(WIN32)
-    set(PROCESSOR_COUNT "$ENV{NUMBER_OF_PROCESSORS}")
-  endif()
+    include(ProcessorCount)
+    ProcessorCount(N)
+    if(NOT N EQUAL 0)
+        set(PROCESSOR_COUNT ${N})
+    endif()
 endif()
 
 if(APPLE)
@@ -54,4 +39,4 @@ macro(ep_get_binary_dir varName)
     set(${varName} "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/src/${PROJECT_NAME}-build")
 endmacro(ep_get_binary_dir)
 
-set(KO_DOWNLOAD_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build/downloads)
+set(KO_DOWNLOAD_DIR "${CMAKE_CURRENT_SOURCE_DIR}/build/downloads")


### PR DESCRIPTION
CMake <ins>2.8.5</ins> shipped with a built-in module.

Also quote `KO_DOWNLOAD_DIR`.