### PR TITLE
[fix] Return fail status for SDL

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -431,8 +431,8 @@ function util.ffiLoadCandidates(candidates)
         end
     end
 
-    -- we failed, this is the error message
-    return lib
+    -- we failed, lib is the error message
+    return lib_loaded, lib
 end
 
 --- Returns true if isWindows…


### PR DESCRIPTION
Fixes minor typo with embarrassing consequences from https://github.com/koreader/koreader-base/pull/873

The file I committed accidentally wasn't 100 % the same as the one I tested. That would've blown up in a pretty embarrassing way.