### PR TITLE
[chore] Makefile: declare all phonies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,4 +215,4 @@ test: $(OUTPUT_DIR)/spec $(OUTPUT_DIR)/.busted
 		--no-auto-insulate \
 		-o ./spec/base/unit/verbose_print ./spec/base/unit
 
-.PHONY: test
+.PHONY: all clean test


### PR DESCRIPTION
It's generally working as expected you're unlikely to have a file named `clean`. But if you were to create a file named `all` or `clean` you could have a pretty difficult time figuring out why nothing's happening anymore.

Cf. https://github.com/koreader/koreader/pull/4819 and https://github.com/koreader/koreader-base/issues/871.