### PR TITLE
[chore] Remove luajit-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,9 +193,6 @@ dist-clean:
 	-rm -rf build
 	-rm -rf $(THIRDPARTY_DIR)/{$(CMAKE_THIRDPARTY_LIBS)}/build
 
-luajit-clean:
-	$(MAKE) -C $(LUAJIT_DIR) clean
-
 # ===========================================================================
 # start of unit tests section
 


### PR DESCRIPTION
Deprecated by https://github.com/koreader/koreader-base/pull/567.

Originally added in https://github.com/koreader/koreader-base/pull/531 and https://github.com/koreader/koreader-base/pull/533.