### PR TITLE
Fix a couple bugs from #878

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -2069,6 +2069,9 @@ void BB_color_blit_from(BlitBuffer *dst, BlitBuffer *src,
                 for (d_y = dest_y; d_y < dest_y + h; d_y++) {
                     o_x = offs_x;
                     for (d_x = dest_x; d_x < dest_x + w; d_x++) {
+                        // NOTE: GCC *may* throw a -Wmaybe-uninitialized about alpha here,
+                        //       because of the lack of default case  in the SET_ALPHA_FROM_A switch.
+                        //       Not a cause for alarm here :).
                         SET_ALPHA_FROM_A(src, sbb_type, sbb_rotation, o_x, o_y, &alpha);
                         if (alpha == 0) {
                             // NOP

--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -88,3 +88,6 @@ cdecl_func(fputc)
 cdecl_const(FIONREAD)
 cdecl_func(fileno)
 cdecl_func(strerror)
+
+cdecl_func(putenv)
+//cdecl_func(_putenv) // Win32

--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -89,5 +89,6 @@ cdecl_const(FIONREAD)
 cdecl_func(fileno)
 cdecl_func(strerror)
 
-cdecl_func(putenv)
+cdecl_func(setenv)
+cdecl_func(unsetenv)
 //cdecl_func(_putenv) // Win32

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -689,7 +689,6 @@ function BB_mt.__index:setPixel(x, y, color)
     local px, py = self:getPhysicalCoordinates(x, y)
     -- NOTE: The cbb exemption is because it's assuming you're using an inverted bb copy to handle nightmode (c.f., Android & SDL2),
     --       and setPixel can be used from outside blitFrom, unlike the other setters.
-    -- NOTE: Speaking of the other setters, some of the alpha = 0xFF fastpaths *might* be skipping the invert?
     if not use_cblitbuffer and self:getInverse() == 1 then color = color:invert() end
     self:getPixelP(px, py)[0]:set(color)
 end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -140,8 +140,9 @@ void free(void *ptr);
 ]]
 
 -- NOTE: Try the C blitter, unless it was disabled by the user
+local no_cbb_flag = os.getenv("KO_NO_CBB")
 local use_cblitbuffer, cblitbuffer
-if G_reader_settings:nilOrFalse("dev_no_c_blitter") then
+if not no_cbb_flag or no_cbb_flag == "false" then
     use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
 end
 -- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -140,8 +140,9 @@ void free(void *ptr);
 ]]
 
 -- NOTE: Try the C blitter, unless it was disabled by the user
+local use_cblitbuffer, cblitbuffer
 if G_reader_settings:nilOrFalse("dev_no_c_blitter") then
-    local use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
+    use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
 end
 -- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,
 --       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -956,7 +956,7 @@ function BBRGB32_mt.__index:blitToRGB32(dest, dest_x, dest_y, offs_x, offs_y, wi
         --print("BBRGB32 to BBRGB32 full copy")
         -- BBRGB32 is 4 bytes per pixel
         local srcp = ffi.cast(uint8pt, self.data) + self.pitch*offs_y
-        local dstp = ffi.cast(uint8pt, self.data) + dest.pitch*dest_y
+        local dstp = ffi.cast(uint8pt, dest.data) + dest.pitch*dest_y
         ffi.copy(dstp, srcp, lshift(width, 2)*height)
     else
         -- Scanline per scanline copy
@@ -965,7 +965,7 @@ function BBRGB32_mt.__index:blitToRGB32(dest, dest_x, dest_y, offs_x, offs_y, wi
         for y = dest_y, dest_y+height-1 do
             -- BBRGB32 is 4 bytes per pixel
             local srcp = ffi.cast(uint8pt, self.data) + self.pitch*o_y + lshift(offs_x, 2)
-            local dstp = ffi.cast(uint8pt, self.data) + dest.pitch*y + lshift(dest_x, 2)
+            local dstp = ffi.cast(uint8pt, dest.data) + dest.pitch*y + lshift(dest_x, 2)
             ffi.copy(dstp, srcp, lshift(width, 2))
             o_y = o_y + 1
         end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -139,7 +139,10 @@ void *malloc(int size);
 void free(void *ptr);
 ]]
 
-local use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
+-- NOTE: Try the C blitter, unless it was disabled by the user
+if G_reader_settings:nilOrFalse("dev_no_c_blitter") then
+    local use_cblitbuffer, cblitbuffer = pcall(ffi.load, 'blitbuffer')
+end
 -- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,
 --       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).
 --       c.f., #4137, #4752, #4782

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -44,9 +44,9 @@ function framebuffer:_updateWindow()
     if buffer[0].format == C.WINDOW_FORMAT_RGBA_8888
     or buffer[0].format == C.WINDOW_FORMAT_RGBX_8888
     then
-        bb = BB.new(buffer[0].width, buffer[0].height, BB.TYPE_BBRGB32, buffer[0].bits, buffer[0].stride*4)
+        bb = BB.new(buffer[0].width, buffer[0].height, BB.TYPE_BBRGB32, buffer[0].bits, buffer[0].stride*4, buffer[0].stride)
     elseif buffer[0].format == C.WINDOW_FORMAT_RGB_565 then
-        bb = BB.new(buffer[0].width, buffer[0].height, BB.TYPE_BBRGB16, buffer[0].bits, buffer[0].stride*2)
+        bb = BB.new(buffer[0].width, buffer[0].height, BB.TYPE_BBRGB16, buffer[0].bits, buffer[0].stride*2, buffer[0].stride)
     else
         android.LOGE("unsupported window format!")
     end

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -133,6 +133,7 @@ function framebuffer:init()
         --       (c.f., mxc_epdc_fb_check_var @ drivers/video/mxc/mxc_epdc_fb.c OR drivers/video/fbdev/mxc/mxc_epdc_v2_fb.c).
         --       On PB, not so much (possibly because they expect you to use InkView).
         --       So, do it ourselves, if need be...
+        local xres_virtual = vinfo.xres_virtual
         if not IS_ALIGNED(vinfo.xres_virtual, 32) then
             -- NOTE: As per Kindle/Kobo kernels, xres_virtual = ALIGN(xres, 32);
             vinfo.xres_virtual = ALIGN(vinfo.xres, 32)
@@ -177,6 +178,12 @@ function framebuffer:init()
                 -- And that means the original line_length should *probably* be honored, too...
                 finfo.line_length = line_length
                 io.write("PB FB: line_length <- ", finfo.line_length, "\n")
+                -- As well as both _virtual dimensions (c.f., #4851)...
+                vinfo.xres_virtual = xres_virtual
+                io.write("PB FB: xres_virtual <- ", vinfo.xres_virtual, "\n")
+                -- We probably don't care about yres as much ax xres, but, eh.
+                vinfo.yres_virtual = yres_virtual
+                io.write("PB FB: yres_virtual <- ", vinfo.yres_virtual, "\n")
             end
         end
     else

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -71,6 +71,7 @@ int fputc(int, struct _IO_FILE *);
 static const int FIONREAD = 21531;
 int fileno(struct _IO_FILE *) __attribute__((__nothrow__, __leaf__));
 char *strerror(int) __attribute__((__nothrow__, __leaf__));
-int putenv(char *) __attribute__((__nothrow__, __leaf__));
+int setenv(const char *, const char *, int) __attribute__((__nothrow__, __leaf__));
+int unsetenv(const char *) __attribute__((__nothrow__, __leaf__));
 int _putenv(const char *);
 ]]

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -71,4 +71,6 @@ int fputc(int, struct _IO_FILE *);
 static const int FIONREAD = 21531;
 int fileno(struct _IO_FILE *) __attribute__((__nothrow__, __leaf__));
 char *strerror(int) __attribute__((__nothrow__, __leaf__));
+int putenv(char *) __attribute__((__nothrow__, __leaf__));
+int _putenv(const char *);
 ]]

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    v1.12.2
+    v1.13.0
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Fix Android, because the framebuffer can also have a physical stride larger than the pixel width ;).
* Fix RGB32-to-RGB32 fast blitting w/ the Lua blitter, which I broke late in #878 because of a stupid typo.
* Allow disabling the C blitter, to make testing easier.
* Bump FBInk to v1.13.0 (unbreak legacy Kindle handling)
* Possibly unbreak some PB corner-cases (koreader/koreader#4851)