### PR TITLE
The Dark (K)Night

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ ifdef DARWIN
 endif
 
 $(OUTPUT_DIR)/libs/libblitbuffer.so: blitbuffer.c
-	$(CC) $(DYNLIB_CFLAGS) -o $@ $^
+	$(CC) $(DYNLIB_CFLAGS) $(VECTO_CFLAGS) -o $@ $^
 
 $(OUTPUT_DIR)/libs/libwrap-mupdf.so: wrap-mupdf.c \
 			$(MUPDF_LIB)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -230,6 +230,8 @@ endif
 BASE_CFLAGS:=-O2 -ffast-math -pipe -fomit-frame-pointer
 # For ricers.
 #BASE_CFLAGS:=-O3 -ffast-math -pipe -fomit-frame-pointer -frename-registers -fweb
+# Used to enforce aggressive optimizations in some components
+VECTO_CFLAGS:=-O3 -ffast-math -fomit-frame-pointer -frename-registers -fweb -ftree-vectorize -funroll-loops
 # Use this for debugging:
 ifdef KODEBUG
 	BASE_CFLAGS:=-Og -g -pipe -fno-omit-frame-pointer
@@ -238,8 +240,6 @@ ifdef KODEBUG
 	# Don't enforce extra CFLAGS in debug builds
 	VECTO_CFLAGS:=
 endif
-# Used to enforce aggressive optimizations in some components
-VECTO_CFLAGS:=-O3 -ffast-math -fomit-frame-pointer -frename-registers -fweb -ftree-vectorize -funroll-loops
 
 # Misc GCC tricks to ensure backward compatibility with the K2,
 # even when using a fairly recent TC (Linaro/MG).

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -235,7 +235,11 @@ ifdef KODEBUG
 	BASE_CFLAGS:=-Og -g -pipe -fno-omit-frame-pointer
 	# Prevent runaway buildsystems from screwing with us and stripping stuff behind our backs...
 	STRIP:=true
+	# Don't enforce extra CFLAGS in debug builds
+	VECTO_CFLAGS:=
 endif
+# Used to enforce aggressive optimizations in some components
+VECTO_CFLAGS:=-O3 -ffast-math -fomit-frame-pointer -frename-registers -fweb -ftree-vectorize -funroll-loops
 
 # Misc GCC tricks to ensure backward compatibility with the K2,
 # even when using a fairly recent TC (Linaro/MG).

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -322,14 +322,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    //fprintf(stdout, "%s: Single fill BB8 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Full BB8 invertRect\n", __FUNCTION__);
                     uint8_t *p = bb->data + bb->pitch*ry;
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0xFF;
                     }
                 } else {
-                    // Pixel per pixel fill
-                    //fprintf(stdout, "%s: Pixel fill BB8 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel
+                    //fprintf(stdout, "%s: Pixel BB8 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + rx;
@@ -344,14 +344,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    //fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Full BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FF;
                     }
                 } else {
-                    // Pixel per pixel fill
-                    //fprintf(stdout, "%s: Pixel fill BB8A invertRect\n", __FUNCTION__);
+                    // Pixel per pixel
+                    //fprintf(stdout, "%s: Pixel BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
@@ -366,14 +366,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    //fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Full BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0xFFFF;
                     }
                 } else {
-                    // Pixel per pixel fill
-                    //fprintf(stdout, "%s: Pixel fill BBRGB16 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel
+                    //fprintf(stdout, "%s: Pixel BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
@@ -388,7 +388,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    //fprintf(stdout, "%s: Single fill BBRGB24 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Full BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p = bb->data + bb->pitch*ry;
                     for (i = 0; i < bb->phys_w*rh; i+=3) {
                         p[i] ^= 0xFF;
@@ -396,8 +396,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                         p[i+2] ^= 0xFF;
                     }
                 } else {
-                    // Pixel per pixel fill
-                    //fprintf(stdout, "%s: Pixel fill BBRGB24 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel
+                    //fprintf(stdout, "%s: Pixel BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + (rx * 3);
@@ -414,14 +414,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    //fprintf(stdout, "%s: Single fill BBRGB32 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Full BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p = (uint32_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FFFFFF;
                     }
                 } else {
-                    // Pixel per pixel fill fill
-                    //fprintf(stdout, "%s: Pixel fill BBRGB32 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel
+                    //fprintf(stdout, "%s: Pixel BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -330,7 +330,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BB8 invertRect\n", __FUNCTION__);
-                    uint8_t *p = bb->data;
+                    uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + rx;
                         for (i = 0; i < rw; i++) {
@@ -352,7 +352,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BB8A invertRect\n", __FUNCTION__);
-                    uint16_t *p = (uint16_t*) bb->data;
+                    uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
                         for (i = 0; i < (rw << 1); i++) {
@@ -374,7 +374,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BBRGB16 invertRect\n", __FUNCTION__);
-                    uint16_t *p = (uint16_t*) bb->data;
+                    uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
                         for (i = 0; i < (rw << 1); i++) {
@@ -396,7 +396,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BBRGB24 invertRect\n", __FUNCTION__);
-                    uint8_t *p = bb->data;
+                    uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + (rx * 3);
                         for (i = 0; i < (rw * 3); i++) {
@@ -412,16 +412,19 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p = (uint32_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < (bb->phys_w << 2)*rh; i++) {
+                    for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FFFFFF;
                     }
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
-                    uint32_t *p = (uint32_t*) bb->data;
+                    uint32_t *p;
+                    //uint8_t *op;
                     for (j = ry; j < ry+rh; j++) {
+                        //op = (bb->data + bb->pitch*j) + (rx << 2);
+                        //p = (uint32_t*) op;
                         p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));
-                        for (i = 0; i < (rw << 2); i++) {
+                        for (i = 0; i < rw; i++) {
                             p[i] ^= 0x00FFFFFF;
                         }
                     }

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -346,7 +346,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
+                    for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FF;
                     }
                 } else {
@@ -355,7 +355,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
-                        for (i = 0; i < (rw << 1); i++) {
+                        for (i = 0; i < rw; i++) {
                             p[i] ^= 0x00FF;
                         }
                     }
@@ -368,7 +368,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
+                    for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0xFFFF;
                     }
                 } else {
@@ -377,7 +377,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
-                        for (i = 0; i < (rw << 1); i++) {
+                        for (i = 0; i < rw; i++) {
                             p[i] ^= 0xFFFF;
                         }
                     }
@@ -419,10 +419,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p;
-                    //uint8_t *op;
                     for (j = ry; j < ry+rh; j++) {
-                        //op = (bb->data + bb->pitch*j) + (rx << 2);
-                        //p = (uint32_t*) op;
                         p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));
                         for (i = 0; i < rw; i++) {
                             p[i] ^= 0x00FFFFFF;

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -284,6 +284,171 @@ void BB_blend_rect(BlitBuffer *bb, int x, int y, int w, int h, Color8A *color) {
     }
 }
 
+void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
+    int rotation = GET_BB_ROTATION(bb);
+    int rx, ry, rw, rh;
+    unsigned int i, j;
+    // Compute rotated rectangle coordinates & size
+    switch (rotation) {
+        case 0:
+                rx = x;
+                ry = y;
+                rw = w;
+                rh = h;
+                break;
+        case 1:
+                rx = bb->w - (y + h);
+                ry = x;
+                rw = h;
+                rh = w;
+                break;
+        case 2:
+                rx = bb->w - (x + w);
+                ry = bb->h - (y + h);
+                rw = w;
+                rh = h;
+                break;
+        case 3:
+                rx = y;
+                ry = bb->h - (x + w);
+                rw = h;
+                rh = w;
+                break;
+    }
+    // Handle any target pitch properly (i.e., fetch the amount of bytes taken per pixel)...
+    int bb_type = GET_BB_TYPE(bb);
+    uint8_t bpp = 1;
+    switch (bb_type) {
+        case TYPE_BB8:
+            bpp = 1;
+            break;
+        case TYPE_BB8A:
+            bpp = 2;
+            break;
+        case TYPE_BBRGB16:
+            bpp = 2;
+            break;
+        case TYPE_BBRGB24:
+            bpp = 3;
+            break;
+        case TYPE_BBRGB32:
+            bpp = 4;
+            break;
+    }
+    switch (bb_type) {
+        case TYPE_BB8:
+            {
+                if (rx == 0 && rw == bb->w) {
+                    // Single step for contiguous scanlines
+                    fprintf(stdout, "%s: Single fill BB8 invertRect\n", __FUNCTION__);
+                    uint8_t *p = bb->data + bb->pitch*ry;
+                    for (i = 0; i < bb->phys_w*rh; i++) {
+                        p[i] ^= 0xFF;
+                    }
+                } else {
+                    // Scanline per scanline fill
+                    fprintf(stdout, "%s: Scanline fill BB8 invertRect\n", __FUNCTION__);
+                    uint8_t *p = bb->data;
+                    for (j = ry; j < ry+rh; j++) {
+                        p = bb->data + bb->pitch*j + rx;
+                        for (i = 0; i < rw; i++) {
+                            p[i] ^= 0xFF;
+                        }
+                    }
+                }
+            }
+            break;
+        case TYPE_BB8A:
+            {
+                if (rx == 0 && rw == bb->w) {
+                    // Single step for contiguous scanlines
+                    fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
+                    uint16_t *p = bb->data + bb->pitch*ry;
+                    for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
+                        p[i] ^= 0x00FF;
+                    }
+                } else {
+                    // Scanline per scanline fill
+                    fprintf(stdout, "%s: Scanline fill BB8A invertRect\n", __FUNCTION__);
+                    uint16_t *p = bb->data;
+                    for (j = ry; j < ry+rh; j++) {
+                        p = bb->data + bb->pitch*j + (rx << 1);
+                        for (i = 0; i < (rw << 1); i++) {
+                            p[i] ^= 0x00FF;
+                        }
+                    }
+                }
+            }
+            break;
+        case TYPE_BBRGB16:
+            {
+                if (rx == 0 && rw == bb->w) {
+                    // Single step for contiguous scanlines
+                    fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
+                    uint16_t *p = bb->data + bb->pitch*ry;
+                    for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
+                        p[i] ^= 0xFFFF;
+                    }
+                } else {
+                    // Scanline per scanline fill
+                    fprintf(stdout, "%s: Scanline fill BBRGB16 invertRect\n", __FUNCTION__);
+                    uint16_t *p = bb->data;
+                    for (j = ry; j < ry+rh; j++) {
+                        p = bb->data + bb->pitch*j + (rx << 1);
+                        for (i = 0; i < (rw << 1); i++) {
+                            p[i] ^= 0xFFFF;
+                        }
+                    }
+                }
+            }
+            break;
+        case TYPE_BBRGB24:
+            {
+                if (rx == 0 && rw == bb->w) {
+                    // Single step for contiguous scanlines
+                    fprintf(stdout, "%s: Single fill BBRGB24 invertRect\n", __FUNCTION__);
+                    uint8_t *p = bb->data + bb->pitch*ry;
+                    for (i = 0; i < (bb->phys_w * 3)*rh; i++) {
+                        p[i] ^= 0xFFFF;
+                    }
+                } else {
+                    // Scanline per scanline fill
+                    fprintf(stdout, "%s: Scanline fill BBRGB24 invertRect\n", __FUNCTION__);
+                    uint8_t *p = bb->data;
+                    for (j = ry; j < ry+rh; j++) {
+                        p = bb->data + bb->pitch*j + (rx * 3);
+                        for (i = 0; i < (rw * 3); i++) {
+                            p[i] ^= 0xFFFF;
+                        }
+                    }
+                }
+            }
+            break;
+        case TYPE_BBRGB32:
+            {
+                if (rx == 0 && rw == bb->w) {
+                    // Single step for contiguous scanlines
+                    fprintf(stdout, "%s: Single fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
+                    uint32_t *p = bb->data + bb->pitch*ry;
+                    for (i = 0; i < (bb->phys_w << 2)*rh; i++) {
+                        p[i] ^= 0x00FFFFFF;
+                    }
+                } else {
+                    // Scanline per scanline fill
+                    fprintf(stdout, "%s: Scanline fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
+                    uint32_t *p = bb->data;
+                    for (j = ry; j < ry+rh; j++) {
+                        p = bb->data + bb->pitch*j + (rx << 2);
+                        for (i = 0; i < (rw << 2); i++) {
+                            p[i] ^= 0x00FFFFFF;
+                        }
+                    }
+                }
+            }
+            break;
+    }
+}
+
 void BB_blit_to_BB8(BlitBuffer *src, BlitBuffer *dst,
         int dest_x, int dest_y, int offs_x, int offs_y, int w, int h) {
     int d_x, d_y, o_x, o_y;

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -287,7 +287,7 @@ void BB_blend_rect(BlitBuffer *bb, int x, int y, int w, int h, Color8A *color) {
 void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
     int rotation = GET_BB_ROTATION(bb);
     int rx, ry, rw, rh;
-    unsigned int i, j;
+    int i, j;
     // Compute rotated rectangle coordinates & size
     switch (rotation) {
         case 0:
@@ -315,26 +315,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 rh = w;
                 break;
     }
-    // Handle any target pitch properly (i.e., fetch the amount of bytes taken per pixel)...
+    // Handle any target pitch properly
     int bb_type = GET_BB_TYPE(bb);
-    uint8_t bpp = 1;
-    switch (bb_type) {
-        case TYPE_BB8:
-            bpp = 1;
-            break;
-        case TYPE_BB8A:
-            bpp = 2;
-            break;
-        case TYPE_BBRGB16:
-            bpp = 2;
-            break;
-        case TYPE_BBRGB24:
-            bpp = 3;
-            break;
-        case TYPE_BBRGB32:
-            bpp = 4;
-            break;
-    }
     switch (bb_type) {
         case TYPE_BB8:
             {
@@ -363,16 +345,16 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
-                    uint16_t *p = bb->data + bb->pitch*ry;
+                    uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
                         p[i] ^= 0x00FF;
                     }
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BB8A invertRect\n", __FUNCTION__);
-                    uint16_t *p = bb->data;
+                    uint16_t *p = (uint16_t*) bb->data;
                     for (j = ry; j < ry+rh; j++) {
-                        p = bb->data + bb->pitch*j + (rx << 1);
+                        p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
                         for (i = 0; i < (rw << 1); i++) {
                             p[i] ^= 0x00FF;
                         }
@@ -385,16 +367,16 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
-                    uint16_t *p = bb->data + bb->pitch*ry;
+                    uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < (bb->phys_w << 1)*rh; i++) {
                         p[i] ^= 0xFFFF;
                     }
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill BBRGB16 invertRect\n", __FUNCTION__);
-                    uint16_t *p = bb->data;
+                    uint16_t *p = (uint16_t*) bb->data;
                     for (j = ry; j < ry+rh; j++) {
-                        p = bb->data + bb->pitch*j + (rx << 1);
+                        p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
                         for (i = 0; i < (rw << 1); i++) {
                             p[i] ^= 0xFFFF;
                         }
@@ -429,16 +411,16 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
-                    uint32_t *p = bb->data + bb->pitch*ry;
+                    uint32_t *p = (uint32_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < (bb->phys_w << 2)*rh; i++) {
                         p[i] ^= 0x00FFFFFF;
                     }
                 } else {
                     // Scanline per scanline fill
                     fprintf(stdout, "%s: Scanline fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
-                    uint32_t *p = bb->data;
+                    uint32_t *p = (uint32_t*) bb->data;
                     for (j = ry; j < ry+rh; j++) {
-                        p = bb->data + bb->pitch*j + (rx << 2);
+                        p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));
                         for (i = 0; i < (rw << 2); i++) {
                             p[i] ^= 0x00FFFFFF;
                         }

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -322,14 +322,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    fprintf(stdout, "%s: Single fill BB8 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Single fill BB8 invertRect\n", __FUNCTION__);
                     uint8_t *p = bb->data + bb->pitch*ry;
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0xFF;
                     }
                 } else {
-                    // Scanline per scanline fill
-                    fprintf(stdout, "%s: Scanline fill BB8 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel fill
+                    //fprintf(stdout, "%s: Pixel fill BB8 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + rx;
@@ -344,14 +344,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Single fill BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FF;
                     }
                 } else {
-                    // Scanline per scanline fill
-                    fprintf(stdout, "%s: Scanline fill BB8A invertRect\n", __FUNCTION__);
+                    // Pixel per pixel fill
+                    //fprintf(stdout, "%s: Pixel fill BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
@@ -366,14 +366,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Single fill BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0xFFFF;
                     }
                 } else {
-                    // Scanline per scanline fill
-                    fprintf(stdout, "%s: Scanline fill BBRGB16 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel fill
+                    //fprintf(stdout, "%s: Pixel fill BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
@@ -388,7 +388,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    fprintf(stdout, "%s: Single fill BBRGB24 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Single fill BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p = bb->data + bb->pitch*ry;
                     for (i = 0; i < bb->phys_w*rh; i+=3) {
                         p[i] ^= 0xFF;
@@ -396,8 +396,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                         p[i+2] ^= 0xFF;
                     }
                 } else {
-                    // Scanline per scanline fill
-                    fprintf(stdout, "%s: Scanline fill BBRGB24 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel fill
+                    //fprintf(stdout, "%s: Pixel fill BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + (rx * 3);
@@ -414,14 +414,14 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
             {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
-                    fprintf(stdout, "%s: Single fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
+                    //fprintf(stdout, "%s: Single fill BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p = (uint32_t*) (bb->data + bb->pitch*ry);
                     for (i = 0; i < bb->phys_w*rh; i++) {
                         p[i] ^= 0x00FFFFFF;
                     }
                 } else {
-                    // Scanline per scanline fill
-                    fprintf(stdout, "%s: Scanline fill TYPE_BBRGB32 invertRect\n", __FUNCTION__);
+                    // Pixel per pixel fill fill
+                    //fprintf(stdout, "%s: Pixel fill BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -390,8 +390,10 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     // Single step for contiguous scanlines
                     fprintf(stdout, "%s: Single fill BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p = bb->data + bb->pitch*ry;
-                    for (i = 0; i < (bb->phys_w * 3)*rh; i++) {
-                        p[i] ^= 0xFFFF;
+                    for (i = 0; i < bb->phys_w*rh; i+=3) {
+                        p[i] ^= 0xFF;
+                        p[i+1] ^= 0xFF;
+                        p[i+2] ^= 0xFF;
                     }
                 } else {
                     // Scanline per scanline fill
@@ -399,8 +401,10 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
                         p = bb->data + bb->pitch*j + (rx * 3);
-                        for (i = 0; i < (rw * 3); i++) {
-                            p[i] ^= 0xFFFF;
+                        for (i = 0; i < rw; i+=3) {
+                            p[i] ^= 0xFF;
+                            p[i+1] ^= 0xFF;
+                            p[i+2] ^= 0xFF;
                         }
                     }
                 }

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -1934,9 +1934,7 @@ void BB_invert_blit_from(BlitBuffer *dst, BlitBuffer *src,
                     for (d_x = dest_x; d_x < dest_x + w; d_x++) {
                         BB_GET_PIXEL(dst, dbb_rotation, ColorRGB32, d_x, d_y, &dstptr);
                         BB_GET_PIXEL(src, sbb_rotation, ColorRGB32, o_x, o_y, &srcptr);
-                        dstptr->r = srcptr->r ^ 0xFF;
-                        dstptr->g = srcptr->g ^ 0xFF;
-                        dstptr->b = srcptr->b ^ 0xFF;
+                        *(uint32_t*) dstptr = *(uint32_t*) srcptr ^ 0x00FFFFFF;
                         o_x += 1;
                     }
                     o_y += 1;

--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -109,6 +109,7 @@ typedef struct BlitBufferRGB32 {
 
 void BB_fill_rect(BlitBuffer *bb, int x, int y, int w, int h, uint8_t v);
 void BB_blend_rect(BlitBuffer *bb, int x, int y, int w, int h, Color8A *color);
+void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h);
 void BB_blit_to_BB8(BlitBuffer *src, BlitBuffer *dst,
                     int dest_x, int dest_y, int offs_x, int offs_y, int w, int h);
 void BB_blit_to_BB8A(BlitBuffer *src, BlitBuffer *dst,

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1176,21 +1176,21 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 local p = ffi.cast(uint32pt, self.data) + self.pitch*y
                 -- Account for potentially off-screen scanline bits by using self.phys_w instead of w,
                 -- as we've just assured ourselves that the requested w matches self.w ;).
-                for i = 0, self.phys_w*h do
+                for i = 1, self.phys_w*h do
                     p[0] = bxor(p[0], 0x00FFFFFF)
                     -- Pointer arithmetics magic: +1 on an uint32_t* means +4 bytes (i.e., next pixel) ;).
                     p = p+1
                 end
             elseif bbtype == TYPE_BBRGB16 then
                 local p = ffi.cast(uint16pt, self.data) + self.pitch*y
-                for i = 0, self.phys_w*h do
+                for i = 1, self.phys_w*h do
                     p[0] = bxor(p[0], 0xFFFF)
                     p = p+1
                 end
             else
                 -- Should only be BB8 left, but honor bpp for safety instead of relying purely on pointer arithmetics...
                 local p = ffi.cast(uint8pt, self.data) + self.pitch*y
-                for i = 0, bpp*self.phys_w*h do
+                for i = 1, bpp*self.phys_w*h do
                     p[0] = bxor(p[0], 0xFF)
                     p = p+1
                 end
@@ -1201,7 +1201,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
             if bbtype == TYPE_BBRGB32 then
                 for j = y, y+h-1 do
                     local p = ffi.cast(uint32pt, self.data) + self.pitch*j + x
-                    for i = 0, w do
+                    for i = 0, w-1 do
                         p[0] = bxor(p[0], 0x00FFFFFF)
                         p = p+1
                     end
@@ -1209,7 +1209,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
             elseif bbtype == TYPE_BBRGB16 then
                 for j = y, y+h-1 do
                     local p = ffi.cast(uint16pt, self.data) + self.pitch*j + x
-                    for i = 0, w do
+                    for i = 0, w-1 do
                         p[0] = bxor(p[0], 0xFFFF)
                         p = p+1
                     end
@@ -1218,7 +1218,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 -- Again, honor bpp for safety instead of relying purely on pointer arithmetics...
                 for j = y, y+h-1 do
                     local p = ffi.cast(uint8pt, self.data) + self.pitch*j + bpp*x
-                    for i = 0, bpp*w do
+                    for i = 0, bpp*(w-1) do
                         p[0] = bxor(p[0], 0xFF)
                         p = p+1
                     end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1174,7 +1174,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
             -- Single step for contiguous scanlines
             --print("Single fill invertRect")
             if bbtype == TYPE_BBRGB32 then
-                local p = ffi.cast(uint32pt, self.data) + self.pitch*y
+                local p = ffi.cast(uint32pt, ffi.cast(uint8pt, self.data) + self.pitch*y)
                 -- Account for potentially off-screen scanline bits by using self.phys_w instead of w,
                 -- as we've just assured ourselves that the requested w matches self.w ;).
                 for i = 1, self.phys_w*h do
@@ -1183,7 +1183,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
                     p = p+1
                 end
             elseif bbtype == TYPE_BBRGB16 then
-                local p = ffi.cast(uint16pt, self.data) + self.pitch*y
+                local p = ffi.cast(uint16pt, ffi.cast(uint8pt, self.data) + self.pitch*y)
                 for i = 1, self.phys_w*h do
                     p[0] = bxor(p[0], 0xFFFF)
                     p = p+1
@@ -1201,7 +1201,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
             --print("Scanline fill invertRect")
             if bbtype == TYPE_BBRGB32 then
                 for j = y, y+h-1 do
-                    local p = ffi.cast(uint32pt, self.data) + self.pitch*j + x
+                    local p = ffi.cast(uint32pt, ffi.cast(uint8pt, self.data) + self.pitch*j) + x
                     for i = 0, w-1 do
                         p[0] = bxor(p[0], 0x00FFFFFF)
                         p = p+1
@@ -1209,7 +1209,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 end
             elseif bbtype == TYPE_BBRGB16 then
                 for j = y, y+h-1 do
-                    local p = ffi.cast(uint16pt, self.data) + self.pitch*j + x
+                    local p = ffi.cast(uint16pt, ffi.cast(uint8pt, self.data) + self.pitch*j) + x
                     for i = 0, w-1 do
                         p[0] = bxor(p[0], 0xFFFF)
                         p = p+1

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1197,8 +1197,8 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 end
             end
         else
-            -- Scanline per scanline fill
-            --print("Scanline fill invertRect")
+            -- Pixel per pixel fill
+            --print("Pixel fill invertRect")
             if bbtype == TYPE_BBRGB32 then
                 for j = y, y+h-1 do
                     local p = ffi.cast(uint32pt, ffi.cast(uint8pt, self.data) + self.pitch*j) + x
@@ -1230,7 +1230,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
     end
 end
 
--- No fast paths @ 4bpp and BB8A
+-- No fast paths for BB4 & BB8A
 function BB4_mt.__index:invertRect(x, y, w, h)
     self:invertblitFrom(self, x, y, x, y, w, h)
 end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1172,7 +1172,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
         -- as our memory region has a fixed layout, too!
         if x == 0 and w == self.w then
             -- Single step for contiguous scanlines
-            --print("Single fill invertRect")
+            --print("Full invertRect")
             if bbtype == TYPE_BBRGB32 then
                 local p = ffi.cast(uint32pt, ffi.cast(uint8pt, self.data) + self.pitch*y)
                 -- Account for potentially off-screen scanline bits by using self.phys_w instead of w,
@@ -1197,8 +1197,8 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 end
             end
         else
-            -- Pixel per pixel fill
-            --print("Pixel fill invertRect")
+            -- Pixel per pixel
+            --print("Pixel invertRect")
             if bbtype == TYPE_BBRGB32 then
                 for j = y, y+h-1 do
                     local p = ffi.cast(uint32pt, ffi.cast(uint8pt, self.data) + self.pitch*j) + x

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -123,6 +123,7 @@ typedef struct BlitBufferRGB32 {
 
 void BB_fill_rect(BlitBuffer *bb, int x, int y, int w, int h, uint8_t v);
 void BB_blend_rect(BlitBuffer *bb, int x, int y, int w, int h, Color8A *color);
+void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h);
 void BB_blit_to(BlitBuffer *source, BlitBuffer *dest, int dest_x, int dest_y,
                 int offs_x, int offs_y, int w, int h);
 void BB_add_blit_from(BlitBuffer *dest, BlitBuffer *source, int dest_x, int dest_y,

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -20,6 +20,7 @@ local fb = {
     native_rotation_mode = nil,
     cur_rotation_mode = nil,
     blitbuffer_rotation_mode = nil,
+    night_mode = false,
 }
 
 --[[
@@ -362,6 +363,7 @@ function fb:setWindowTitle(new_title)
 end
 
 function fb:toggleNightMode()
+    self.night_mode = not self.night_mode
     self.bb:invert()
     if self.viewport then
         -- invert and blank out the full framebuffer when we are working on a viewport

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -364,11 +364,14 @@ end
 
 function fb:toggleNightMode()
     self.night_mode = not self.night_mode
-    self.bb:invert()
-    if self.viewport then
-        -- invert and blank out the full framebuffer when we are working on a viewport
-        self.full_bb:invert()
-        self.full_bb:fill(Blitbuffer.COLOR_WHITE)
+    -- Only do SW inversion if the HW can't...
+    if not (self.device and self.device:canHWInvert()) then
+        self.bb:invert()
+        if self.viewport then
+            -- invert and blank out the full framebuffer when we are working on a viewport
+            self.full_bb:invert()
+            self.full_bb:fill(Blitbuffer.COLOR_WHITE)
+        end
     end
 end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -254,7 +254,9 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
             refarea[0].flags = bor(refarea[0].flags, C.EPDC_FLAG_ENABLE_INVERSION)
         end
 
-        -- If the waveform is not fast or GC16, enforce a nightmode-specific mode (usually, GC16), to limit ghosting
+        -- If the waveform is not fast or GC16, enforce a nightmode-specific mode (usually, GC16), to limit ghosting.
+        -- There's nothing much we can do about crappy flashing behavior on some devices, though (c.f., base/#884),
+        -- that's in the hands of the EPDC. Kindle PW2+ behave sanely, for instance, even when flashing on AUTO or GC16 ;).
         if not fb:_isFastWaveFormMode(waveform_mode) and waveform_mode ~= C.WAVEFORM_MODE_GC16 then
             waveform_mode = fb:_getNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
@@ -539,8 +541,8 @@ function framebuffer:init()
             self.waveform_fast = C.WAVEFORM_MODE_DU -- NOTE: DU, because A2 looks terrible on REAGL devices. Older devices/FW may be using AUTO in this instance.
             self.waveform_reagl = C.WAVEFORM_MODE_REAGL
             self.waveform_partial = self.waveform_reagl
-            -- NOTE: We *might* be able to use GL16_INV in nightmode on devices running FW >= 5.6.x...
-            --       Should hopefully fall-back to AUTO on older FWs...
+            -- NOTE: GL16_INV is available since FW >= 5.6.x only, but it'll safely fall-back to AUTO on older FWs.
+            --       Most people with those devices should be running at least FW 5.9.7 by now, though ;).
             self.waveform_night = C.WAVEFORM_MODE_GL16_INV
         else
             self.waveform_fast = C.WAVEFORM_MODE_DU -- NOTE: DU, because A2 looks terrible on the Touch, and ghosts horribly. Framework is actually using AUTO for UI feedback inverts.
@@ -566,7 +568,7 @@ function framebuffer:init()
             self.waveform_flashui = C.WAVEFORM_MODE_GC16
             self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl
-            -- NOTE: Not quite sure this is the right one, as there's also KOA2_GLKW16... One might be more suited to UI or text than the other...
+            -- NOTE: There's also KOA2_GLKW16... One might be more suited to UI or text than the other?
             self.waveform_night = C.WAVEFORM_MODE_KOA2_GCK16
         end
     elseif self.device:isKobo() then

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -6,6 +6,7 @@ local C = ffi.C
 local dummy = require("ffi/posix_h")
 
 local band = bit.band
+local bor = bit.bor
 
 -- Valid marker bounds
 local MARKER_MIN = 42
@@ -257,7 +258,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     if fb.night_mode then
         -- We're in nightmode! If the device can do HW inversion safely, do that!
         if fb.device:canHWInvert() then
-            refarea[0].flags = band(refarea[0].flags, C.EPDC_FLAG_ENABLE_INVERSION)
+            refarea[0].flags = bor(refarea[0].flags, C.EPDC_FLAG_ENABLE_INVERSION)
         end
 
         -- If the waveform is not fast or GC16, enforce a nightmode-specific mode (usually, GC16), to limit ghosting

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -247,13 +247,6 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     refarea[0].alt_buffer_data.alt_update_region.width = 0
     refarea[0].alt_buffer_data.alt_update_region.height = 0
 
-    -- Handle REAGL promotion...
-    -- NOTE: We need to do this here, because we rely on the pre-promotion actual refresh_type in previous heuristics.
-    if fb:_isREAGLWaveFormMode(waveform_mode) then
-        -- NOTE: REAGL updates always need to be full.
-        refarea[0].update_mode = C.UPDATE_MODE_FULL
-    end
-
     -- Handle night mode shenanigans
     if fb.night_mode then
         -- We're in nightmode! If the device can do HW inversion safely, do that!
@@ -263,8 +256,16 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
 
         -- If the waveform is not fast or GC16, enforce a nightmode-specific mode (usually, GC16), to limit ghosting
         if not fb:_isFastWaveFormMode(waveform_mode) and waveform_mode ~= C.WAVEFORM_MODE_GC16 then
-            refarea[0].waveform_mode = fb:_getNightWaveFormMode()
+            waveform_mode = fb:_getNightWaveFormMode()
+            refarea[0].waveform_mode = waveform_mode
         end
+    end
+
+    -- Handle REAGL promotion...
+    -- NOTE: We need to do this here, because we rely on the pre-promotion actual refresh_type in previous heuristics.
+    if fb:_isREAGLWaveFormMode(waveform_mode) then
+        -- NOTE: REAGL updates always need to be full.
+        refarea[0].update_mode = C.UPDATE_MODE_FULL
     end
 
     -- Recap the actual details of the ioctl, vs. what UIManager asked for...

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -286,7 +286,7 @@ function util.runInSubProcess(func, with_pipe, double_fork)
     if pid < 0 then -- on failure, fork() returns -1
         return false
     end
-    -- If we double-fork, reap the outer fork
+    -- If we double-fork, reap the outer fork now, since its only purpose is fork -> _exit
     if double_fork then
         local status = ffi.new('int[1]')
         local ret = C.waitpid(pid, status, 0)

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -227,7 +227,9 @@ end
 -- if with_pipe: a fd for writting
 -- This function returns (to parent): the child pid, and,
 -- if with_pipe: a fd for reading what the child wrote
-function util.runInSubProcess(func, with_pipe)
+-- if double_fork: do a double fork so the child gets reparented to init,
+--                 ensuring automatic reaping of zombies.
+function util.runInSubProcess(func, with_pipe, double_fork)
     local parent_read_fd, child_write_fd
     if with_pipe then
         local pipe = ffi.new('int[2]', {-1, -1})
@@ -240,7 +242,17 @@ function util.runInSubProcess(func, with_pipe)
         end
     end
     local pid = C.fork()
+    -- If we double-fork, remember the first fork's pid so we can reap it.
+    local fpid = pid
     if pid == 0 then -- child process
+        if double_fork then
+            pid = C.fork()
+            if pid ~= 0 then
+                -- Exit the first fork (i.e., the parent of the nested child)
+                -- NOTE: Technically ought to be _exit, not exit.
+                os.exit((pid < 0) and 1 or 0)
+            end
+        end
         -- We need to wrap it with pcall: otherwise, if we were in a
         -- subroutine, the error would just abort the coroutine, bypassing
         -- our os.exit(0), and this subprocess would be a working 2nd instance
@@ -272,8 +284,17 @@ function util.runInSubProcess(func, with_pipe)
         os.exit(0)
     end
     -- parent/main process
-    if pid == -1 then -- on failure, fork() returns -1
+    if fpid < 0 then -- on failure, fork() returns -1
         return false
+    end
+    -- If we double-fork, reap the first child
+    if double_fork then
+        local status = ffi.new('int[1]')
+        local ret = C.waitpid(fpid, status, 0)
+        -- Returns fpid on success, -1 on failure
+        if ret < 0 then
+            return false
+        end
     end
     if child_write_fd then
         -- close our duplicate of child fd

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -229,6 +229,11 @@ end
 -- if with_pipe: a fd for reading what the child wrote
 -- if double_fork: do a double fork so the child gets reparented to init,
 --                 ensuring automatic reaping of zombies.
+--                 NOTE: In this case, the pid returned will *already*
+--                       have been reaped, making it fairly useless.
+--                       This means you do NOT have to call isSubProcessDone on it.
+--                       It is safe to do so, though, it'll just immediately return success,
+--                       as waitpid will return -1 w/ an ECHILD errno.
 function util.runInSubProcess(func, with_pipe, double_fork)
     local parent_read_fd, child_write_fd
     if with_pipe then

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -242,8 +242,6 @@ function util.runInSubProcess(func, with_pipe, double_fork)
         end
     end
     local pid = C.fork()
-    -- Remember the outer fork's pid so we can reap it when double-forking.
-    local opid = pid
     if pid == 0 then -- child process
         if double_fork then
             pid = C.fork()
@@ -285,14 +283,14 @@ function util.runInSubProcess(func, with_pipe, double_fork)
         os.exit(0)
     end
     -- parent/main process
-    if opid < 0 then -- on failure, fork() returns -1
+    if pid < 0 then -- on failure, fork() returns -1
         return false
     end
     -- If we double-fork, reap the outer fork
     if double_fork then
         local status = ffi.new('int[1]')
-        local ret = C.waitpid(opid, status, 0)
-        -- Returns opid on success, -1 on failure
+        local ret = C.waitpid(pid, status, 0)
+        -- Returns pid on success, -1 on failure
         if ret < 0 then
             return false
         end


### PR DESCRIPTION
Crappy puns aside:
* Faster SW inversion when done via invertRect (Lua/C, although the C version will be drastically faster on x64, because GCC vectorizes it properly).
* Speaking of, enforce aggressive optimizations when building the C bb, to ensure this will actually happen for real, and not just on my box ;p.
* Switch to HW PxP inversion on eInk devices where this is known to be stable (i.e., Kindles, Kobos aside from the Aura).
* When in NightMode, enforce a possibly less stupid waveform mode (fix the truly ancient https://github.com/koreader/koreader/issues/1375). On Kindle, where supported, this attempts to use the nightmode-optimized waveform modes. Needs testers on PW4/KOA2, because there's probably two of them.