### PR TITLE
[fix] ffi/SDL2: crash with `SDL_FULLSCREEN`

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -77,7 +77,7 @@ function S.open()
 
     local full_screen = os.getenv("SDL_FULLSCREEN")
     if full_screen then
-        local mode = ffi.new("struct SDL_DisplayMode")
+        local mode = ffi.new("SDL_DisplayMode")
         if SDL.SDL_GetCurrentDisplayMode(0, mode) ~= 0 then
             error("SDL cannot get current display mode.")
         end


### PR DESCRIPTION
Only actively used on device ports (Ubuntu Touch, Sailfish), so it was silently broken.

Cf. https://github.com/koreader/koreader/issues/4960 and https://github.com/koreader/koreader-base/issues/899

```
---------------------------------------------
                launching...
  _  _____  ____                _
 | |/ / _ \|  _ \ ___  __ _  __| | ___ _ __
 | ' / | | | |_) / _ \/ _` |/ _` |/ _ \ '__|
 | . \ |_| |  _ <  __/ (_| | (_| |  __/ |
 |_|\_\___/|_| \_\___|\__,_|\__,_|\___|_|

 It's a scroll... It's a codex... It's KOReader!

 [*] Current time: 04/22/19-16:54:43
 [*] Version: v2019.03-129-g5c95597f_2019-04-22

ffi.load: SDL2
ffi.load: SDL2
ffi.load: blitbuffer
ffi.load (assisted searchpath): ./libs/libblitbuffer.so
./luajit: ./ffi/SDL2_0.lua:80: undeclared or implicit tag 'SDL_DisplayMode'
stack traceback:
	[C]: in function 'new'
	./ffi/SDL2_0.lua:80: in function 'open'
	./ffi/framebuffer_SDL2_0.lua:13: in function 'init'
	./ffi/framebuffer.lua:70: in function 'new'
	frontend/device/sdl/device.lua:72: in function 'init'
	frontend/device.lua:49: in main chunk
	[C]: in function 'require'
	./reader.lua:55: in main chunk
	[C]: at 0x5585698dc771
~/src/kobo/koreader
```