### PR TITLE
bump harfbuzz to 2.6.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/harfbuzz/harfbuzz.git
-    2.4.0
+    2.5.0
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -29,10 +29,19 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
+if($ENV{POCKETBOOK})
+    # The PocketBook toolchain is stuck with gcc 4.8, support of which was dropped in HB 2.5.
+    # In the short term we deal with this by keeping PB at a lower version.
+    # See https://github.com/koreader/koreader-base/pull/917#issuecomment-495940413
+    set(HB_VER 2.4.0)
+else()
+    set(HB_VER 2.6.0)
+endif()
+
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/harfbuzz/harfbuzz.git
-    2.5.0
+    ${HB_VER}
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
> This release does not include much functional changes, but includes major internal
code-base changes. We now require C++11. Support for gcc 4.8 and earlier has been
dropped.

https://github.com/harfbuzz/harfbuzz/releases/tag/2.5.0