### PR TITLE
Better nightmode handling on the KOA2 & PW4

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -27,6 +27,7 @@ local framebuffer = {
     waveform_fast = nil,
     waveform_reagl = nil,
     waveform_night = nil,
+    waveform_flashnight = nil,
     mech_refresh = nil,
     -- start with an out of bound marker value to avoid doing something stupid on our first update
     marker = MARKER_MIN - 1,
@@ -45,37 +46,49 @@ function framebuffer:_get_next_marker()
     return marker
 end
 
--- Returns true if waveform_mode arg matches the UI waveform mode for current device
+-- Returns true if waveform_mode arg matches the UI waveform mode for the current device
 -- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
 --       Here, it's because of the Kindle-specific WAVEFORM_MODE_GC16_FAST
 function framebuffer:_isUIWaveFormMode(waveform_mode)
     return waveform_mode == self.waveform_ui
 end
 
--- Returns true if waveform_mode arg matches the FlashUI waveform mode for current device
+-- Returns true if waveform_mode arg matches the FlashUI waveform mode for the current device
 -- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
 --       Here, it's because of the Kindle-specific WAVEFORM_MODE_GC16_FAST
 function framebuffer:_isFlashUIWaveFormMode(waveform_mode)
     return waveform_mode == self.waveform_flashui
 end
 
--- Returns true if waveform_mode arg matches the REAGL waveform mode for current device
+-- Returns true if waveform_mode arg matches the REAGL waveform mode for the current device
 -- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
 --       Here, it's Kindle's various WAVEFORM_MODE_REAGL vs. Kobo's NTX_WFM_MODE_GLD16
 function framebuffer:_isREAGLWaveFormMode(waveform_mode)
     return waveform_mode == self.waveform_reagl
 end
 
--- Returns true if waveform_mode arg matches the fast waveform mode for current device
+-- Returns true if waveform_mode arg matches the fast waveform mode for the current device
 -- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
 --       Here, it's because some devices use A2, while other prefer DU
 function framebuffer:_isFastWaveFormMode(waveform_mode)
     return waveform_mode == self.waveform_fast
 end
 
+-- Returns true if waveform_mode arg matches the partial waveform mode for the current device
+-- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
+--       Here, because REAGL or device-specific quirks.
+function framebuffer:_isPartialWaveFormMode(waveform_mode)
+    return waveform_mode == self.waveform_partial
+end
+
 -- Returns the device-specific nightmode waveform mode
 function framebuffer:_getNightWaveFormMode()
     return self.waveform_night
+end
+
+-- Returns the device-specific flashing nightmode waveform mode
+function framebuffer:_getFlashNightWaveFormMode()
+    return self.waveform_flashnight
 end
 
 -- Returns true if w & h are equal or larger than our visible screen estate (i.e., we asked for a full-screen update)
@@ -261,11 +274,15 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
             refarea[0].flags = bor(refarea[0].flags, C.EPDC_FLAG_ENABLE_INVERSION)
         end
 
-        -- If the waveform is not fast or GC16, enforce a nightmode-specific mode (usually, GC16), to limit ghosting.
+
+        -- Enforce a nightmode-specific mode (usually, GC16), to limit ghosting, where appropriate (i.e., partial & flashes).
         -- There's nothing much we can do about crappy flashing behavior on some devices, though (c.f., base/#884),
         -- that's in the hands of the EPDC. Kindle PW2+ behave sanely, for instance, even when flashing on AUTO or GC16 ;).
-        if not fb:_isFastWaveFormMode(waveform_mode) and waveform_mode ~= C.WAVEFORM_MODE_GC16 then
+        if fb:_isPartialWaveFormMode(waveform_mode) then
             waveform_mode = fb:_getNightWaveFormMode()
+            refarea[0].waveform_mode = waveform_mode
+        elseif waveform_mode == C.WAVEFORM_MODE_GC16 then
+            waveform_mode = fb:_getFlashNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
         end
     end
@@ -506,6 +523,7 @@ function framebuffer:init()
         self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_night = C.WAVEFORM_MODE_GC16
+        self.waveform_flashnight = self.waveform_night
 
         -- New devices are REAGL-aware, default to REAGL
         local isREAGL = true
@@ -547,6 +565,7 @@ function framebuffer:init()
             -- NOTE: GL16_INV is available since FW >= 5.6.x only, but it'll safely fall-back to AUTO on older FWs.
             --       Most people with those devices should be running at least FW 5.9.7 by now, though ;).
             self.waveform_night = C.WAVEFORM_MODE_GL16_INV
+            -- NOTE: Might be worth using GL16_INV for flashnight, too?
         else
             self.waveform_fast = C.WAVEFORM_MODE_DU -- NOTE: DU, because A2 looks terrible on the Touch, and ghosts horribly. Framework is actually using AUTO for UI feedback inverts.
             self.waveform_partial = C.WAVEFORM_MODE_GL16_FAST -- NOTE: Depending on FW, might instead be AUTO w/ hist_gray_waveform_mode set to GL16_FAST
@@ -571,8 +590,9 @@ function framebuffer:init()
             self.waveform_flashui = C.WAVEFORM_MODE_GC16
             self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl
-            -- NOTE: There's also KOA2_GLKW16... One might be more suited to UI or text than the other?
-            self.waveform_night = C.WAVEFORM_MODE_KOA2_GCK16
+            -- NOTE: Apparently, the KT4 doesn't support one or both of those. Consider swapping night to GL16 and flashnight to GC16, or both to GC16.
+            self.waveform_night = C.WAVEFORM_MODE_KOA2_GLKW16
+            self.waveform_flashnight = C.WAVEFORM_MODE_KOA2_GCK16
         end
     elseif self.device:isKobo() then
         require("ffi/mxcfb_kobo_h")
@@ -586,6 +606,7 @@ function framebuffer:init()
         self.waveform_full = C.NTX_WFM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
         self.waveform_night = C.NTX_WFM_MODE_GC16
+        self.waveform_flashnight = self.waveform_night
 
         -- New devices *may* be REAGL-aware, but generally don't expect explicit REAGL requests, default to not.
         local isREAGL = false
@@ -641,6 +662,7 @@ function framebuffer:init()
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_GC16
         self.waveform_night = C.WAVEFORM_MODE_GC16
+        self.waveform_flashnight = self.waveform_night
     elseif self.device:isSonyPRSTUX() then
         require("ffi/mxcfb_sony_h")
 
@@ -653,6 +675,7 @@ function framebuffer:init()
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
         self.waveform_night = C.WAVEFORM_MODE_GC16
+        self.waveform_flashnight = self.waveform_night
     elseif self.device:isCervantes() then
         require("ffi/mxcfb_cervantes_h")
 
@@ -665,6 +688,7 @@ function framebuffer:init()
         self.waveform_full = C.WAVEFORM_MODE_GC16
         self.waveform_partial = C.WAVEFORM_MODE_AUTO
         self.waveform_night = C.WAVEFORM_MODE_GC16
+        self.waveform_flashnight = self.waveform_night
     else
         error("unknown device type")
     end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -247,6 +247,13 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     refarea[0].alt_buffer_data.alt_update_region.width = 0
     refarea[0].alt_buffer_data.alt_update_region.height = 0
 
+    -- Handle REAGL promotion...
+    -- NOTE: We need to do this here, because we rely on the pre-promotion actual refresh_type in previous heuristics.
+    if fb:_isREAGLWaveFormMode(waveform_mode) then
+        -- NOTE: REAGL updates always need to be full.
+        refarea[0].update_mode = C.UPDATE_MODE_FULL
+    end
+
     -- Handle night mode shenanigans
     if fb.night_mode then
         -- We're in nightmode! If the device can do HW inversion safely, do that!
@@ -261,13 +268,6 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
             waveform_mode = fb:_getNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
         end
-    end
-
-    -- Handle REAGL promotion...
-    -- NOTE: We need to do this here, because we rely on the pre-promotion actual refresh_type in previous heuristics.
-    if fb:_isREAGLWaveFormMode(waveform_mode) then
-        -- NOTE: REAGL updates always need to be full.
-        refarea[0].update_mode = C.UPDATE_MODE_FULL
     end
 
     -- Recap the actual details of the ioctl, vs. what UIManager asked for...

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -591,6 +591,7 @@ function framebuffer:init()
             self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl
             -- NOTE: Apparently, the KT4 doesn't support one or both of those. Consider swapping night to GL16 and flashnight to GC16, or both to GC16.
+            --       c.f., ko/#5076
             self.waveform_night = C.WAVEFORM_MODE_KOA2_GLKW16
             self.waveform_flashnight = C.WAVEFORM_MODE_KOA2_GCK16
         end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -600,7 +600,7 @@ function framebuffer:init()
             self.waveform_flashui = C.WAVEFORM_MODE_GC16
             self.waveform_reagl = C.WAVEFORM_MODE_KOA2_GLR16
             self.waveform_partial = self.waveform_reagl
-            -- NOTE: Apparently, the KT4 doesn't support one or both of those. Consider swapping night to GL16 and flashnight to GC16, or both to GC16.
+            -- NOTE: Apparently, the KT4 doesn't support one or both of those. Consider swapping night to GL16 and flashnight to GC16, or both to GC16 for the KT4 only.
             --       c.f., ko/#5076
             self.waveform_night = C.WAVEFORM_MODE_KOA2_GLKW16
             self.night_is_reagl = true

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -82,7 +82,7 @@ end
 
 -- Returns true if waveform_mode arg matches the partial waveform mode for the current device
 -- NOTE: This is to avoid explicit comparison against device-specific waveform constants in mxc_update()
---       Here, because REAGL or device-specific quirks.
+--       Here, because of REAGL or device-specific quirks.
 function framebuffer:_isPartialWaveFormMode(waveform_mode)
     return waveform_mode == self.waveform_partial
 end
@@ -279,7 +279,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
         if fb:_isPartialWaveFormMode(waveform_mode) then
             waveform_mode = fb:_getNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
-            -- And handle devices likes the KOA2/PW4, where night is a REAGL waveform that needs to be FULL...
+            -- And handle devices like the KOA2/PW4, where night is a REAGL waveform that needs to be FULL...
             if fb:_isNightREAGL() then
                 refarea[0].update_mode = C.UPDATE_MODE_FULL
             end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -281,7 +281,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
         if fb:_isPartialWaveFormMode(waveform_mode) then
             waveform_mode = fb:_getNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
-        elseif waveform_mode == C.WAVEFORM_MODE_GC16 then
+        elseif waveform_mode == C.WAVEFORM_MODE_GC16 or refresh_type == C.UPDATE_MODE_FULL then
             waveform_mode = fb:_getFlashNightWaveFormMode()
             refarea[0].waveform_mode = waveform_mode
         end


### PR DESCRIPTION
By utilizing *both* of the nightmode waveform modes, as they ought to, instead of blindly picking one ;).

Thanks to ilovejedd on MR for the strace logs ;).