### PR TITLE
[fix] MuPDF: backport fix for upstream 698877

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -77,6 +77,9 @@ set(PATCH_CMD3 sh -c "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/libjpeg_shared.pat
 set(PATCH_CMD4 sh -c "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/no_arm_asm.patch")
 # Honor CFLAGS
 set(PATCH_CMD5 sh -c "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/honor_cflags.patch")
+# Patch for https://bugs.ghostscript.com/show_bug.cgi?id=698877; should be in upstream from 1.15
+# cf. https://github.com/koreader/koreader/issues/5182
+set(PATCH_CMD6 sh -c "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/upstream-698877.patch")
 
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
@@ -93,7 +96,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/upstream-698877.patch
+++ b/thirdparty/mupdf/upstream-698877.patch
@@ -1,0 +1,162 @@
+--- a/source/fitz/colorspace.c
++++ b/source/fitz/colorspace.c
+@@ -953,11 +953,10 @@ static void fast_gray_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* If copying spots, they must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1088,11 +1087,10 @@ static void fast_gray_to_cmyk(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, f
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* If copying spots, they must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1228,11 +1226,10 @@ static void fast_rgb_to_gray(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* If copying spots, they must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1353,11 +1350,10 @@ static void fast_bgr_to_gray(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* If copying spots, they must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1481,11 +1477,10 @@ static void fast_rgb_to_cmyk(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* Spots must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots || ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1641,11 +1636,10 @@ static void fast_bgr_to_cmyk(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* Spots must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1801,11 +1795,10 @@ static void fast_cmyk_to_gray(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, f
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* Spots must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -1943,11 +1936,10 @@ static void fast_cmyk_to_rgb(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	unsigned char r,g,b;
+ 
+ 	/* Spots must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -2089,11 +2081,10 @@ static void fast_cmyk_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz
+ 	unsigned char r,g,b;
+ 
+ 	/* Spots must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;
+@@ -2236,11 +2227,10 @@ static void fast_rgb_to_bgr(fz_context *ctx, fz_pixmap *dst, fz_pixmap *src, fz_
+ 	ptrdiff_t s_line_inc = src->stride - w * sn;
+ 
+ 	/* If copying spots, they must match, and we can never drop alpha (but we can invent it) */
+-	if ((copy_spots && ss != ds) || (!da && sa))
+-	{
+-		assert("This should never happen" == NULL);
+-		fz_throw(ctx, FZ_ERROR_GENERIC, "Cannot convert between incompatible pixmaps");
+-	}
++	if (copy_spots && ss != ds)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "incompatible number of spots when converting pixmap");
++	if (!da && sa)
++		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot drop alpha when converting pixmap");
+ 
+ 	if ((int)w < 0 || h < 0)
+ 		return;


### PR DESCRIPTION
Fixes <https://github.com/koreader/koreader/issues/5182>.