### PR TITLE
[CI] Switch to Clang 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,11 +117,11 @@ jobs:
   emu_clang_ninja:
     <<: *EMU_TPL
     docker:
-      - image: koreader/kobase-clang:0.1.1
+      - image: koreader/kobase-clang:0.1.2
     environment:
       <<: *EMU_ENV_LST
-      CC: "clang-7"
-      CXX: "clang++-7"
+      CC: "clang-8"
+      CXX: "clang++-8"
 
 
 


### PR DESCRIPTION
With any luck the odd MD5 problem will go away…

See <https://github.com/koreader/virdevenv/pull/42>.