### PR TITLE
[chore, CI] Fix MD5 spec expected/result order

### DIFF
--- a/ffi/MD5.lua
+++ b/ffi/MD5.lua
@@ -223,7 +223,7 @@ function md5_proto:update(luastr)
     MD5Update(self.ctx, ffi.cast("const char*", luastr), #luastr)
 end
 
---- Calcualte md5 sum with the state of a md5 hashing instance.
+--- Calculate md5 sum with the state of a md5 hashing instance.
 ---- @string luastr stream to process
 ---- @treturn string md5 sum in Lua string
 function md5_proto:sum(luastr)
@@ -251,14 +251,14 @@ function md5.new()
     return o
 end
 
---- Calcualte md5 sum.
+--- Calculate md5 sum.
 ---- @string luastr stream to process
 ---- @treturn string md5 sum in Lua string
 function md5.sum(luastr)
     return md5:new():sum(luastr)
 end
 
---- Calcualte md5 sum for a file.
+--- Calculate md5 sum for a file.
 ---- @string filename
 ---- @treturn string md5 sum in Lua string
 function md5.sumFile(filename)

--- a/spec/unit/md5_spec.lua
+++ b/spec/unit/md5_spec.lua
@@ -8,22 +8,22 @@ describe("MD5 module", function()
     end)
 
     it("should calculate correct MD5 hashes", function()
-        assert.is_equal(md5.sum(""), "d41d8cd98f00b204e9800998ecf8427e")
-        assert.is_equal(md5.new():sum("\0"), "93b885adfe0da089cdf634904fd59f71")
-        assert.is_equal(md5.new():sum("0123456789abcdefX"), "1b05aba914a8b12315c7ee52b42f3d35")
+        assert.is_equal("d41d8cd98f00b204e9800998ecf8427e", md5.sum(""))
+        assert.is_equal("93b885adfe0da089cdf634904fd59f71", md5.new():sum("\0"))
+        assert.is_equal("1b05aba914a8b12315c7ee52b42f3d35", md5.new():sum("0123456789abcdefX"))
     end)
 
     it("should calculate MD5 sum by updating", function()
         local m = md5.new()
         m:update("0123456789")
         m:update("abcdefghij")
-        assert.is_equal(m:sum(), md5.sum("0123456789abcdefghij"))
+        assert.is_equal(md5.sum("0123456789abcdefghij"), m:sum())
     end)
 
     it("should calculate MD5 sum of a file", function()
         assert.is_equal(
-            md5.sumFile("spec/base/unit/data/2col.jbig2.pdf"),
-            "ee53c8f032c3d047cb3d1999c8ff5e09")
+            "ee53c8f032c3d047cb3d1999c8ff5e09",
+            md5.sumFile("spec/base/unit/data/2col.jbig2.pdf"))
     end)
 
     it("should error out on non-exist file", function()


### PR DESCRIPTION
It's `expected, object`, not the other way around. Not the most important thing because it'll error out as intended either way, but the error messages are confusing otherwise.