### PR TITLE
fix ANR by fixing a typo in the name

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -105,7 +105,7 @@ local function keyEventHandler(key_event)
     or code == C.AKEYCODE_MEDIA_REWIND
     or code == C.AKEYCODE_MEDIA_FAST_FORWARD then
         return 0 -- event not consumed
-    elseif code == C.AKEYCODE_MEDIA_MUTE
+    elseif code == C.AKEYCODE_MUTE
     or code == C.AKEYCODE_VOLUME_MUTE then
         if android.getVolumeKeysIgnored() then
             return 0


### PR DESCRIPTION
https://www.mobileread.com/forums/showpost.php?p=3881047&postcount=11

ANR while pressing the back button. I don't know why but it seems that I'm not a heavy back key user. It should be reproducible since https://github.com/koreader/koreader/commit/81ea5f6a7ebc7f0dff1bf31b46b4f76e1054f91f. Sorry for the mess.

```logcat

W/KOReader(21500):  got error waiting for events: ffi/input_android.lua:108: missing declaration for symbol 'AKEYCODE_MEDIA_MUTE'
E/ActivityManager( 1490): ANR in org.koreader.launcher (org.koreader.launcher/.MainActivity)
E/ActivityManager( 1490): Reason: keyDispatchingTimedOut
```