### PR TITLE
thirdparty/lodepng 20190814

### DIFF
--- a/thirdparty/lodepng/CMakeLists.txt
+++ b/thirdparty/lodepng/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/lvandeve/lodepng.git
-    430268baa882a707c36b356402b94ab14dc08b69
+    34742d48e586bd9960bf0d494fb3180cca84520a
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Includes https://github.com/lvandeve/lodepng/commit/ed190f26daee126801c402690e26388554a9d93a

> Use huffman lookup tables and decode multiple bits at once instead
of bit per bit, giving 25% or more decoding speed increase.