### PR TITLE
[chore] Fix implicit declaration of strcmp warning

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/prctl.h>
 
 #include <linux/input.h>


### PR DESCRIPTION
On line 80.