### PR TITLE
Minor mxcfb refresh cleanups

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -107,19 +107,19 @@ end
 
 -- Kindle's MXCFB_WAIT_FOR_UPDATE_COMPLETE_PEARL == 0x4004462f
 local function kindle_pearl_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_COMPLETE_PEARL, ffi.new("uint32_t[1]", marker))
 end
 
 -- Kobo's MXCFB_WAIT_FOR_UPDATE_COMPLETE_V1 == 0x4004462f
 local function kobo_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_COMPLETE_V1, ffi.new("uint32_t[1]", marker))
 end
 
 -- Kobo's Mk7 MXCFB_WAIT_FOR_UPDATE_COMPLETE_V3
 local function kobo_mk7_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     local mk7_update_marker = ffi.new("struct mxcfb_update_marker_data[1]")
     mk7_update_marker[0].update_marker = marker
     -- NOTE: 0 seems to be a fairly safe assumption for "we don't care about collisions".
@@ -130,25 +130,25 @@ end
 
 -- Kindle's MXCFB_WAIT_FOR_UPDATE_COMPLETE == 0x4004462f
 local function pocketbook_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_COMPLETE, ffi.new("uint32_t[1]", marker))
 end
 
 -- Sony PRS MXCFB_WAIT_FOR_UPDATE_COMPLETE
 local function sony_prstux_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_COMPLETE, ffi.new("uint32_t[1]", marker))
 end
 
 -- BQ Cervantes MXCFB_WAIT_FOR_UPDATE_COMPLETE == 0x4004462f
 local function cervantes_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_COMPLETE, ffi.new("uint32_t[1]", marker))
 end
 
 -- Kindle's MXCFB_WAIT_FOR_UPDATE_COMPLETE == 0xc008462f
 local function kindle_carta_mxc_wait_for_update_complete(fb, marker)
-    -- Wait for the previous update to be completed
+    -- Wait for a specific update to be completed
     local carta_update_marker = ffi.new("struct mxcfb_update_marker_data[1]")
     carta_update_marker[0].update_marker = marker
     -- NOTE: 0 seems to be a fairly safe assumption for "we don't care about collisions".
@@ -159,7 +159,7 @@ end
 
 -- Kindle's MXCFB_WAIT_FOR_UPDATE_SUBMISSION == 0x40044637
 local function kindle_mxc_wait_for_update_submission(fb, marker)
-    -- Wait for the current (the one we just sent) update to be submitted
+    -- Wait for a specific update to be submitted
     return C.ioctl(fb.fd, C.MXCFB_WAIT_FOR_UPDATE_SUBMISSION, ffi.new("uint32_t[1]", marker))
 end
 
@@ -182,8 +182,8 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     end
 
     if w == 1 and h == 1 then
-        -- avoid system freeze when updating 1x1 pixel block on KPW2 and KV,
-        -- see koreader/koreader#1299 and koreader/koreader#1486
+        -- Avoid a kernel deadlock when updating 1x1 pixel block on KPW2 and KV,
+        -- c.f., koreader/koreader#1299 and koreader/koreader#1486
         fb.debug("got a 1x1 pixel refresh request, ignoring it.")
         return
     end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -34,7 +34,7 @@ local framebuffer = {
 
 -- Returns an incrementing marker value, w/ a sane wraparound.
 function framebuffer:_get_next_marker()
-    -- Wrap around at 128
+    -- Wrap around at 128 (via an optimized modulo of a power of two)
     self.marker = band(self.marker + 1, 127)
     return self.marker
 end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -28,6 +28,8 @@ local framebuffer = {
     mech_refresh = nil,
     -- start with an invalid marker value to avoid doing something stupid on our first update
     marker = 0,
+    -- remember a specific marker we'll want to wait for on the following refresh...
+    wait_for_marker = nil,
 }
 
 --[[ refresh list management: --]]
@@ -197,36 +199,53 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
        w = w*3
     end
 
-    -- NOTE: If we're trying to send a:
-    --         * true FULL update,
-    --         * GC16_FAST update (i.e., popping-up a menu),
-    --       then wait for submission of previous marker first.
-    local marker = fb.marker
-    -- NOTE: Technically, we might not always want to wait for *exactly* the previous marker
-    --       (we might actually want the one before that), but in the vast majority of cases, that's good enough,
-    --       and saves us a lot of annoying and hard-to-get-right heuristics anyway ;).
-    -- Make sure it's a valid marker, to avoid doing something stupid on our first update.
-    if fb.mech_wait_update_submission
-      and (refresh_type == C.UPDATE_MODE_FULL
-      or fb:_isUIWaveFormMode(waveform_mode))
-      and (marker ~= 0) then
-        fb.debug("refresh: wait for submission of (previous) marker", marker)
-        fb.mech_wait_update_submission(fb, marker)
-    end
+    -- NOTE: If we have a previous marker we need to wait for, do it now
+    --       Can never be set without fb.mech_wait_update_complete, so we don't need to check for that again.
+    if fb.wait_for_marker then
+        -- On Kindle, prefer wait_for_submission, unless we're queuing a REAGL update
+        if fb.mech_wait_update_submission and not fb:_isREAGLWaveFormMode(waveform_mode) then
+            fb.debug("refresh: wait for submission of (past) marker", fb.wait_for_marker)
+            fb.mech_wait_update_submission(fb, fb.wait_for_marker)
+        else
+            fb.debug("refresh: wait for completion of (past) marker", fb.wait_for_marker)
+            fb.mech_wait_update_complete(fb, fb.wait_for_marker)
+        end
+        -- Clear it
+        fb.wait_for_marker = nil
+    else
+        -- NOTE: Otherwise, wait for the previous marker right before any kind of FULL (or FULL-like) update.
+        --
+        -- NOTE: If we're trying to send a:
+        --         * true FULL update,
+        --         * GC16_FAST update (i.e., popping-up a menu),
+        --       then wait for submission of previous marker first.
+        local marker = fb.marker
+        -- NOTE: Technically, we might not always want to wait for *exactly* the previous marker
+        --       (we might actually want the one before that), but in the vast majority of cases, that's good enough,
+        --       and saves us a lot of annoying and hard-to-get-right heuristics anyway ;).
+        -- Make sure it's a valid marker, to avoid doing something stupid on our first update.
+        if fb.mech_wait_update_submission
+        and (refresh_type == C.UPDATE_MODE_FULL
+        or fb:_isUIWaveFormMode(waveform_mode))
+        and (marker ~= 0) then
+            fb.debug("refresh: wait for submission of (previous) marker", marker)
+            fb.mech_wait_update_submission(fb, marker)
+        end
 
-    -- NOTE: If we're trying to send a:
-    --         * REAGL update,
-    --         * GC16 update,
-    --         * Full-screen, flashing GC16_FAST update,
-    --       then wait for completion of previous marker first.
-    -- Again, make sure the marker is valid, too.
-    if (fb:_isREAGLWaveFormMode(waveform_mode)
-      or waveform_mode == C.WAVEFORM_MODE_GC16
-      or (refresh_type == C.UPDATE_MODE_FULL and fb:_isFlashUIWaveFormMode(waveform_mode) and fb:_isFullScreen(w, h)))
-      and fb.mech_wait_update_complete
-      and (marker ~= 0) then
-        fb.debug("refresh: wait for completion of (previous) marker", marker)
-        fb.mech_wait_update_complete(fb, marker)
+        -- NOTE: If we're trying to send a:
+        --         * REAGL update,
+        --         * GC16 update,
+        --         * Full-screen, flashing GC16_FAST update,
+        --       then wait for completion of previous marker first.
+        -- Again, make sure the marker is valid, too.
+        if (fb:_isREAGLWaveFormMode(waveform_mode)
+        or waveform_mode == C.WAVEFORM_MODE_GC16
+        or (refresh_type == C.UPDATE_MODE_FULL and fb:_isFlashUIWaveFormMode(waveform_mode) and fb:_isFullScreen(w, h)))
+        and fb.mech_wait_update_complete
+        and (marker ~= 0) then
+            fb.debug("refresh: wait for completion of (previous) marker", marker)
+            fb.mech_wait_update_complete(fb, marker)
+        end
     end
 
     refarea[0].update_mode = refresh_type or C.UPDATE_MODE_PARTIAL
@@ -285,11 +304,10 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
         fb.debug("MXCFB_SEND_UPDATE ioctl failed:", ffi.string(C.strerror(err)))
     end
 
-    -- NOTE: We wait for completion after *any kind* of full (i.e., flashing) update.
+    -- NOTE: Remember every flashing update, so we can wait for their completion before the next refresh...
     if refarea[0].update_mode == C.UPDATE_MODE_FULL
       and fb.mech_wait_update_complete then
-        fb.debug("refresh: wait for completion of marker", marker)
-        fb.mech_wait_update_complete(fb, marker)
+        fb.wait_for_marker = marker
     end
 end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -297,8 +297,8 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     --       ensuring the wait would potentially be shorter, or even null.
     --       In practice, we won't actually be busy for a bit after most (if not all) flashing refresh calls,
     --       so we can instead afford to wait for it right now, which *will* block for a while,
-    --       but will save us an ioctl before the next refresh, something which, even if it doesn't block at all,
-    --       may end up being more detrimental to interactivity.
+    --       but will save us an ioctl before the next refresh, something which, even if it didn't block at all,
+    --       would possibly end up being more detrimental to latency/reactivity.
     if refarea[0].update_mode == C.UPDATE_MODE_FULL
       and fb.mech_wait_update_complete then
         fb.debug("refresh: wait for completion of marker", marker)

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -177,7 +177,7 @@ local function mxc_update(fb, update_ioctl, refarea, refresh_type, waveform_mode
     x, y, w, h = bb:getPhysicalRect(x, y, w, h)
 
     if w == 0 or h == 0 then
-        fb.debug("got a 0 size (height and/or width) refresh request, ignoring it.")
+        fb.debug("got an empty (no height and/or width) refresh request, ignoring it.")
         return
     end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -34,9 +34,13 @@ local framebuffer = {
 
 -- Returns an incrementing marker value, w/ a sane wraparound.
 function framebuffer:_get_next_marker()
-    -- Wrap around at 128 (via an optimized modulo of a power of two)
-    self.marker = band(self.marker + 1, 127)
-    return self.marker
+    local marker = self.marker + 1
+    if marker > 128 then
+        marker = 1
+    end
+
+    self.marker = marker
+    return marker
 end
 
 -- Returns true if waveform_mode arg matches the UI waveform mode for the current device


### PR DESCRIPTION
* Get rid of the commented out collision stuff, as it's unlikely we'll ever be able to get it right anyway, so ti's just confusing noise.
* Use a slightly less cute marker range to skip a comparison.
* Add some more comments about our wait_for_update_complete usage, after having tried a few things (with essentially similar results, hence the slightly functionally smaller diff than I originally anticipated ;p).
* Avoid waiting for completion of the same marker twice (could probably only happen on REAGL Kindles).