### PR TITLE
[fix] Use correct time_t type

### DIFF
--- a/ffi/rtc.lua
+++ b/ffi/rtc.lua
@@ -53,7 +53,7 @@ you can process your value with @{secondsFromNowToEpoch}.
 function RTC:setWakeupAlarm(epoch, enabled)
     enabled = (enabled ~= nil) and enabled or true
 
-    local ptm = C.gmtime(ffi.new("int[1]", epoch))
+    local ptm = C.gmtime(ffi.new("time_t[1]", epoch))
     self._wakeup_scheduled_ptm = ptm
 
     local wake = ffi.new("struct rtc_wkalrm")


### PR DESCRIPTION
Cf. <https://github.com/koreader/koreader-base/pull/969#discussion_r322910027>.

Otherwise the interface won't work on… platforms where it doesn't matter,
but it's better to be correct. ;-)