### PR TITLE
Unify open flags for ioctl-only fds

### DIFF
--- a/ffi/kobolight.lua
+++ b/ffi/kobolight.lua
@@ -1,5 +1,7 @@
 local ffi = require("ffi")
+local bor = bit.bor
 local C = ffi.C
+
 -- for closing on garbage collection, we need a pointer or aggregate
 -- cdata object (not a plain "int"). So we encapsulate in a struct.
 ffi.cdef[[
@@ -35,7 +37,7 @@ function kobolight.open(device)
 		light_fd = nil,
 	}
 
-	local ld = C.open(device or "/dev/ntx_io", C.O_RDWR)
+	local ld = C.open(device or "/dev/ntx_io", bor(bor(C.O_RDONLY, C.O_NONBLOCK), C.O_CLOEXEC))
 	assert(ld ~= -1, "cannot open light device")
 	light.light_fd = ffi.gc(
 		ffi.new("light_fd", ld),

--- a/ffi/rtc.lua
+++ b/ffi/rtc.lua
@@ -71,7 +71,7 @@ function RTC:setWakeupAlarm(epoch, enabled)
     wake.enabled = enabled and 1 or 0
 
     local err
-    local rtc0 = C.open("/dev/rtc0", bor(C.O_RDONLY, C.O_NONBLOCK))
+    local rtc0 = C.open("/dev/rtc0", bor(bor(C.O_RDONLY, C.O_NONBLOCK), C.O_CLOEXEC))
     if rtc0 == -1 then
         err = ffi.string(C.strerror(ffi.errno()))
         print("setWakeupAlarm open /dev/rtc0", rtc0, err)
@@ -128,7 +128,7 @@ function RTC:getWakeupAlarmSys()
     local wake = ffi.new("struct rtc_wkalrm")
 
     local err, re
-    local rtc0 = C.open("/dev/rtc0", C.O_RDONLY)
+    local rtc0 = C.open("/dev/rtc0", bor(bor(C.O_RDONLY, C.O_NONBLOCK), C.O_CLOEXEC))
     if rtc0 == -1 then
         err = ffi.string(C.strerror(ffi.errno()))
         print("getWakeupAlarm open /dev/rtc0", rtc0, err)


### PR DESCRIPTION
Shouldn't have any visible effect, except for no longer leaking fds on
exec ;).

(c.f., man 3 open for the rationale behind this set of flags for ioctl handles).