### PR TITLE
bump crengine: adds DOCX and FB3 support

### DIFF
--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -131,6 +131,9 @@ set (CRENGINE_SOURCES
     ${CRE_DIR}/src/epubfmt.cpp
     ${CRE_DIR}/src/pdbfmt.cpp
     ${CRE_DIR}/src/wordfmt.cpp
+    ${CRE_DIR}/src/lvopc.cpp
+    ${CRE_DIR}/src/docxfmt.cpp
+    ${CRE_DIR}/src/fb3fmt.cpp
     ${CRE_DIR}/src/lvstsheet.cpp
     ${CRE_DIR}/src/txtselector.cpp
     ${CRE_DIR}/src/crtest.cpp


### PR DESCRIPTION
Includes:
- (Upstream) Unified cache for chars and glyph's indexes https://github.com/koreader/crengine/pull/314
- (Upstream) Glyph caching: optional use of hash table instead of a linked list
- (Upstream) Adds docx and fb3 support
- Update hardcoded elements list and stylesheets
- DocX: build a HTML DOM instead of a FB2 DOM
- Text: allow wrap after '/' and '-' https://github.com/koreader/crengine/pull/316
- Text: with Harfbuzz, split measurement on text node change
- Clear fonts on load and re-rendering