### PR TITLE
Use LIB_SUFFIX to fix building on opensuse

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -20,7 +20,7 @@ $(FREETYPE_LIB) $(FREETYPE_DIR)/include: $(THIRDPARTY_DIR)/freetype2/CMakeLists.
 		-DCXXFLAGS="$(CXXFLAGS)" -DLDFLAGS="$(LDFLAGS)" -DCHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/freetype2 && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(FREETYPE_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(FREETYPE_LIB)) $@
+	cp -fL $(FREETYPE_DIR)/$(if $(WIN32),bin,lib$(LIB_SUFFIX))/$(notdir $(FREETYPE_LIB)) $@
 
 $(HARFBUZZ_LIB) $(HARFBUZZ_DIR)/include: $(THIRDPARTY_DIR)/harfbuzz/CMakeLists.txt
 	install -d $(HARFBUZZ_BUILD_DIR)
@@ -30,7 +30,7 @@ $(HARFBUZZ_LIB) $(HARFBUZZ_DIR)/include: $(THIRDPARTY_DIR)/harfbuzz/CMakeLists.t
 		-DFREETYPE_DIR="$(FREETYPE_DIR)" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/harfbuzz && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(HARFBUZZ_DIR)/lib/$(notdir $(HARFBUZZ_LIB)) $@
+	cp -fL $(HARFBUZZ_DIR)/lib$(LIB_SUFFIX)/$(notdir $(HARFBUZZ_LIB)) $@
 
 $(UTF8PROC_LIB) $(UTF8PROC_DIR): $(THIRDPARTY_DIR)/utf8proc/CMakeLists.txt
 	install -d $(UTF8PROC_BUILD_DIR)
@@ -49,7 +49,7 @@ $(FRIBIDI_LIB) $(FRIBIDI_DIR): $(THIRDPARTY_DIR)/fribidi/CMakeLists.txt
 		-DLDFLAGS="$(LDFLAGS)" -DCHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/fribidi && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(FRIBIDI_DIR)/lib/$(notdir $(FRIBIDI_LIB)) $@
+	cp -fL $(FRIBIDI_DIR)/lib$(LIB_SUFFIX)/$(notdir $(FRIBIDI_LIB)) $@
 	chmod 755 $@
 
 # libjpeg-turbo and libjepg
@@ -126,7 +126,7 @@ $(GIF_LIB): $(THIRDPARTY_DIR)/giflib/CMakeLists.txt
 		-DCFLAGS="$(CFLAGS)" -DLDFLAGS="$(LDFLAGS)" -DCHOST="$(CHOST)" \
 		$(CURDIR)/thirdparty/giflib && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(GIF_DIR)/lib/$(notdir $(GIF_LIB)) $@
+	cp -fL $(GIF_DIR)/lib$(LIB_SUFFIX)/$(notdir $(GIF_LIB)) $@
 
 $(DJVULIBRE_LIB): $(JPEG_LIB) $(THIRDPARTY_DIR)/djvulibre/CMakeLists.txt
 	install -d $(DJVULIBRE_BUILD_DIR)
@@ -293,7 +293,7 @@ $(GLIB): $(if $(DARWIN),$(LIBICONV) $(LIBGETTEXT),) $(LIBFFI_DIR)/include $(THIR
 		$(CURDIR)/$(THIRDPARTY_DIR)/glib && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 ifdef POCKETBOOK
-	cp -fL $(GLIB_DIR)/lib/$(notdir $(GLIB)) $(OUTPUT_DIR)/libs/$(notdir $(GLIB))
+	cp -fL $(GLIB_DIR)/lib$(LIB_SUFFIX)/$(notdir $(GLIB)) $(OUTPUT_DIR)/libs/$(notdir $(GLIB))
 endif
 
 $(GLIB_STATIC): $(LIBICONV) $(LIBGETTEXT) $(LIBFFI_DIR)/include $(THIRDPARTY_DIR)/glib/CMakeLists.txt
@@ -529,12 +529,12 @@ $(ZMQ_LIB): $(THIRDPARTY_DIR)/libzmq/CMakeLists.txt
 		$(if $(LEGACY),-DLEGACY:BOOL=ON,) -DCHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/libzmq && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(ZMQ_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(ZMQ_LIB)) $@
+	cp -fL $(ZMQ_DIR)/$(if $(WIN32),bin,lib$(LIB_SUFFIX))/$(notdir $(ZMQ_LIB)) $@
 ifdef POCKETBOOK
 	# when cross compiling libtool would find libstdc++.la in wrong location
 	# accoding to the GCC configuration
 	sed -i 's|^dependency_libs=.*|dependency_libs=" -lrt -lpthread -lstdc++"|g' \
-		$(ZMQ_DIR)/lib/libzmq.la
+		$(ZMQ_DIR)/lib$(LIB_SUFFIX)/libzmq.la
 	# and the libuuid.so is also missing in the PocketBook SDK, but libuuid.la
 	# may let the build system assume that libuuid is installed
 	rm -f $(POCKETBOOK_TOOLCHAIN)/arm-obreey-linux-gnueabi/sysroot/usr/lib/libuuid*
@@ -548,7 +548,7 @@ $(CZMQ_LIB): $(ZMQ_LIB) $(THIRDPARTY_DIR)/czmq/CMakeLists.txt
 		-DZMQ_DIR=$(ZMQ_DIR) -DHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/czmq && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(CZMQ_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(CZMQ_LIB)) $@
+	cp -fL $(CZMQ_DIR)/$(if $(WIN32),bin,lib$(LIB_SUFFIX))/$(notdir $(CZMQ_LIB)) $@
 
 $(FILEMQ_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(SSL_LIB) $(THIRDPARTY_DIR)/filemq/CMakeLists.txt
 	install -d $(FILEMQ_BUILD_DIR)
@@ -558,7 +558,7 @@ $(FILEMQ_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(SSL_LIB) $(THIRDPARTY_DIR)/filemq/CMakeL
 		-DZMQ_DIR=$(ZMQ_DIR) -DCZMQ_DIR=$(CZMQ_DIR) -DHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/filemq && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(FILEMQ_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(FILEMQ_LIB)) $@
+	cp -fL $(FILEMQ_DIR)/$(if $(WIN32),bin,lib$(LIB_SUFFIX))/$(notdir $(FILEMQ_LIB)) $@
 
 $(ZYRE_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(THIRDPARTY_DIR)/zyre/CMakeLists.txt
 	install -d $(ZYRE_BUILD_DIR)
@@ -568,7 +568,7 @@ $(ZYRE_LIB): $(ZMQ_LIB) $(CZMQ_LIB) $(THIRDPARTY_DIR)/zyre/CMakeLists.txt
 		-DZMQ_DIR=$(ZMQ_DIR) -DCZMQ_DIR=$(CZMQ_DIR) -DHOST=$(CHOST) \
 		$(CURDIR)/$(THIRDPARTY_DIR)/zyre && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -fL $(ZYRE_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(ZYRE_LIB)) $@
+	cp -fL $(ZYRE_DIR)/$(if $(WIN32),bin,lib$(LIB_SUFFIX))/$(notdir $(ZYRE_LIB)) $@
 
 # libtffi_wrap.so locates in koreader/common, but libssl.so and libcrypto.so
 # live in koreader/libs, so we need to set rpath accordingly
@@ -607,14 +607,14 @@ endif
 
 # override lpeg built by luarocks, this is only necessary for Android
 $(LPEG_DYNLIB) $(LPEG_RE): $(LUAJIT_LIB) $(THIRDPARTY_DIR)/lpeg/CMakeLists.txt
-	install -d $(OUTPUT_DIR)/rocks/lib/lua/5.1
+	install -d $(OUTPUT_DIR)/rocks/lib$(LIB_SUFFIX)/lua/5.1
 	install -d $(OUTPUT_DIR)/rocks/share/lua/5.1
 	install -d $(LPEG_BUILD_DIR)
 	cd $(LPEG_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" -DDYNLIB_CFLAGS="$(DYNLIB_CFLAGS)" \
 		-DLUA_DIR="$(LUAJIT_DIR)" $(CURDIR)/$(THIRDPARTY_DIR)/lpeg && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp -f $(LPEG_DIR)/lpeg.so $(OUTPUT_DIR)/rocks/lib/lua/5.1
+	cp -f $(LPEG_DIR)/lpeg.so $(OUTPUT_DIR)/rocks/lib$(LIB_SUFFIX)/lua/5.1
 	cp -f $(LPEG_DIR)/re.lua $(OUTPUT_DIR)/rocks/share/lua/5.1
 
 $(EVERNOTE_LIB): $(THIRDPARTY_DIR)/evernote-sdk-lua/CMakeLists.txt
@@ -642,7 +642,7 @@ $(SQLITE_LIB): $(THIRDPARTY_DIR)/sqlite/CMakeLists.txt
 			-DLDFLAGS="$(LDFLAGS)" \
 		$(CURDIR)/thirdparty/sqlite && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
-	cp $(SQLITE_DIR)/lib/$(notdir $(SQLITE_LIB)) $(OUTPUT_DIR)/libs
+	cp $(SQLITE_DIR)/lib$(LIB_SUFFIX)/$(notdir $(SQLITE_LIB)) $(OUTPUT_DIR)/libs
 
 $(LUA_LJ_SQLITE) $(OUTPUT_DIR)/common/xsys.lua: $(LUA_LJ_SQLITE_DIR)/init.lua $(LUA_LJ_SQLITE_DIR)/xsys.lua
 	install -d $(LUA_LJ_SQLITE_INSTALL_DIR)


### PR DESCRIPTION
[Why]
opensuse uses lib64 instead of lib. This causes the build to fail even
when using the docker images.

[How]
In Makefile.third use LIB_SUFFIX after `lib` so that the directory will
point to the correct place on opensuse or on other distros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/995)
<!-- Reviewable:end -->
