### PR TITLE
Fix LuaJIT patchset on Darwin

### DIFF
--- a/thirdparty/luajit/koreader-luajit-makefile-tweaks.patch
+++ b/thirdparty/luajit/koreader-luajit-makefile-tweaks.patch
@@ -1,18 +1,24 @@
 diff --git a/src/Makefile b/src/Makefile
-index d22eb73..6a74228 100644
+index d22eb73..be0b659 100644
 --- a/src/Makefile
 +++ b/src/Makefile
-@@ -214,7 +214,8 @@ TARGET_STCC= $(STATIC_CC)
+@@ -214,6 +214,7 @@ TARGET_STCC= $(STATIC_CC)
  TARGET_DYNCC= $(DYNAMIC_CC)
  TARGET_LD= $(CROSS)$(CC)
  TARGET_AR= $(CROSS)ar rcus
--TARGET_STRIP= $(CROSS)strip
 +TARGET_RANLIB= $(CROSS)ranlib
-+TARGET_STRIP= $(CROSS)strip --strip-unneeded
+ TARGET_STRIP= $(CROSS)strip
  
  TARGET_LIBPATH= $(or $(PREFIX),/usr/local)/$(or $(MULTILIB),lib)
- TARGET_SONAME= libluajit-$(ABIVER).so.$(MAJVER)
-@@ -634,7 +635,7 @@ depend:
+@@ -345,6 +346,7 @@ else
+   endif
+   ifeq (Linux,$(TARGET_SYS))
+     TARGET_XLIBS+= -ldl
++    TARGET_STRIP+= --strip-unneeded
+   endif
+   ifeq (GNU/kFreeBSD,$(TARGET_SYS))
+     TARGET_XLIBS+= -ldl
+@@ -634,7 +636,7 @@ depend:
  
  $(MINILUA_T): $(MINILUA_O)
  	$(E) "HOSTLINK  $@"
@@ -21,7 +27,7 @@ index d22eb73..6a74228 100644
  
  host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua
  	$(E) "DYNASM    $@"
-@@ -644,7 +645,7 @@ host/buildvm.o: $(DASM_DIR)/dasm_*.h
+@@ -644,7 +646,7 @@ host/buildvm.o: $(DASM_DIR)/dasm_*.h
  
  $(BUILDVM_T): $(BUILDVM_O)
  	$(E) "HOSTLINK  $@"
@@ -30,7 +36,7 @@ index d22eb73..6a74228 100644
  
  $(LJVM_BOUT): $(BUILDVM_T)
  	$(E) "BUILDVM   $@"
-@@ -705,16 +706,17 @@ include Makefile.dep
+@@ -705,16 +707,17 @@ include Makefile.dep
  $(LUAJIT_A): $(LJVMCORE_O)
  	$(E) "AR        $@"
  	$(Q)$(TARGET_AR) $@ $(LJVMCORE_O)

--- a/thirdparty/luajit/koreader-luajit-verbose-build.patch
+++ b/thirdparty/luajit/koreader-luajit-verbose-build.patch
@@ -1,0 +1,19 @@
+diff --git a/src/Makefile b/src/Makefile
+index be0b659..95b3297 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -592,10 +592,10 @@ endif
+ endif
+ endif
+ 
+-Q= @
+-E= @echo
+-#Q=
+-#E= @:
++#Q= @
++#E= @echo
++Q=
++E= @:
+ 
+ ##############################################################################
+ # Make targets.


### PR DESCRIPTION
strip arguments are target-sensitive, so enforcing GNU flags everywhere
was a bad call.