### PR TITLE
luarocks_dir compatibility with luarocks 3.x

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -796,7 +796,7 @@ LUA_SPORE_BUILD_DIR=$(THIRDPARTY_DIR)/lua-Spore/build/$(MACHINE)
 LUA_SPORE_DIR=$(CURDIR)/$(LUA_SPORE_BUILD_DIR)/lua-Spore-prefix/src/lua-Spore
 SPORE_VER=0.3.1-1
 LUA_SPORE_VER=lua-spore-$(SPORE_VER)
-LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks
+LUAROCKS_DIR=$(OUTPUT_DIR)/rocks/lib/luarocks/rocks-5.1
 LUA_SPORE_ROCK=$(LUAROCKS_DIR)/lua-spore/$(SPORE_VER)/$(LUA_SPORE_VER).rockspec
 
 SQLITE_BUILD_DIR=$(THIRDPARTY_DIR)/sqlite/build/$(MACHINE)


### PR DESCRIPTION
luarocks 3.x supports one luarocks install with multiple lua versions.
archlinux already uses 3.x, debian and friends still use 2.x

this will change the directory structure in the release (not sure if that is important)

as documented in:
https://github.com/luarocks/luarocks/blob/master/CHANGELOG.md

> Breaking change: The support for deprecated unversioned paths (e.g. /usr/local/lib/luarocks/rocks/ and /etc/luarocks/config.lua) was removed, LuaRocks will now only create and use paths versioned to the specific Lua version in use (e.g. /usr/local/lib/luarocks/rocks-5.3/ and /etc/luarocks/config-5.3.lua).