### PR TITLE
[fix] Don't crash on SDL < 2.9

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -409,7 +409,7 @@ function S.gameControllerRumble(left_intensity, right_intensity, duration)
     right_intensity = right_intensity or 20000
     duration = duration or 200
 
-    return SDL.SDL_GameControllerRumble(S.controller, left_intensity, right_intensity, duration)
+    return pcall(SDL.SDL_GameControllerRumble, S.controller, left_intensity, right_intensity, duration)
 end
 
 return S


### PR DESCRIPTION
Otherwise we'll get an `undefined symbol` error, but this function is too convenient to bother with the old-fashioned way of rumbling.

Fixes <https://github.com/koreader/koreader/issues/5570>.