### PR TITLE
[fix] Prevent undefined symbol error on SDL < 2.0.9

### DIFF
--- a/ffi-cdecl/SDL2_0_decl.c
+++ b/ffi-cdecl/SDL2_0_decl.c
@@ -231,3 +231,5 @@ cdecl_const(SDL_PIXELFORMAT_ARGB32)
 cdecl_const(SDL_PIXELFORMAT_BGRA32)
 cdecl_const(SDL_PIXELFORMAT_ABGR32)
 
+cdecl_struct(SDL_version)
+cdecl_func(SDL_GetVersion)

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -863,4 +863,10 @@ static const int SDL_PIXELFORMAT_RGBA32 = 376840196;
 static const int SDL_PIXELFORMAT_ARGB32 = 377888772;
 static const int SDL_PIXELFORMAT_BGRA32 = 372645892;
 static const int SDL_PIXELFORMAT_ABGR32 = 373694468;
+struct SDL_version {
+  Uint8 major;
+  Uint8 minor;
+  Uint8 patch;
+};
+void SDL_GetVersion(struct SDL_version *) __attribute__((visibility("default")));
 ]]


### PR DESCRIPTION
I accidentally tested <https://github.com/koreader/koreader-base/pull/1008>
with SDL 2.0.9, so of course it seemed to be working…