### PR TITLE
xtext: link against stdc++, fix some clang-tidy warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ $(OUTPUT_DIR)/libs/libkoreader-xtext.so: xtext.cpp \
 	-I$(HARFBUZZ_DIR)/include/harfbuzz \
 	-I$(FRIBIDI_DIR)/include \
 	-I$(LIBUNIBREAK_DIR)/include \
-	$(DYNLIB_CXXFLAGS) -Wall -o $@ $^
+	$(DYNLIB_CXXFLAGS) -static-libstdc++ -Wall -o $@ $^
 ifdef DARWIN
 	install_name_tool -change \
 		`otool -L "$@" | grep "libluajit" | awk '{print $$1}'` \

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -408,6 +408,7 @@ function S.setWindowIcon(icon)
 
     local BB = require("ffi/blitbuffer")
     local icon_bb = BB.new(re.width, re.height, BB.TYPE_BBRGB32, re.data)
+    icon_bb:setAllocated(1) -- free re.data when bb is freed
     local icon_bit_depth = 32
     local surface = SDL.SDL_CreateRGBSurfaceWithFormatFrom(icon_bb.data,
                                                            icon_bb:getWidth(), icon_bb:getHeight(),


### PR DESCRIPTION
Linking with -static-libstdc++ might be needed on Kindle and Pocketbook to load (the simple fact of linking against the STL implies ABI compat checks). https://github.com/koreader/koreader/pull/5598#issuecomment-554764338

Also fix some clang-tidy warning about malloc'ing 0 bytes by handling the empty input case apart. https://github.com/koreader/koreader/pull/5598#issuecomment-554753824 - even if that's not really an issue:

```
$ man malloc
       The malloc() function allocates size bytes and returns a pointer to the
       allocated memory.  The memory is not initialized.  If size is  0,  then
       malloc()  returns either NULL, or a unique pointer value that can later
       be successfully passed to free().
```

Let's wait a bit for broken on Kindle reports to validate it's really needed - and in case we find the solution for https://github.com/koreader/koreader/issues/5602 ?
Or merge and bump in case it magically solves it? :)