### PR TITLE
Revert "[fix] MuPDF Android font dir patch update (#971)"

### DIFF
--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -14,12 +14,11 @@ diff --git a/include/mupdf/fitz/font.h b/include/mupdf/fitz/font.h
 index ef4cd74d..6e6ea124 100644
 --- a/include/mupdf/fitz/font.h
 +++ b/include/mupdf/fitz/font.h
-@@ -624,4 +624,10 @@ void fz_hb_lock(fz_context *ctx);
+@@ -624,4 +624,9 @@ void fz_hb_lock(fz_context *ctx);
  */
  void fz_hb_unlock(fz_context *ctx);
  
 +char *get_font_file(char *name);
-+char *get_font_file_android(char *name);
 +char *fz_lookup_base14_font_from_file(fz_context *ctx, const char *name);
 +char *fz_lookup_cjk_font_from_file(fz_context *ctx, int registry, int serif, int wmode);
 +void fz_install_external_font_funcs(fz_context *ctx);
@@ -88,19 +87,6 @@ index f6951ba2..b1fdd981 100644
 +	len = strlen(fontdir) + strlen(name) + 2;
 +	filename = malloc(len);
 +	if(filename == NULL) {
-+		return NULL;
-+	}
-+	snprintf(filename, len, "%s/%s", fontdir, name);
-+	return filename;
-+}
-+
-+char *
-+get_font_file_android(char *name)
-+{
-+	const char fontdir[] = "/system/fonts";
-+	size_t len = sizeof(fontdir) + strlen(name) + 1;	// sizeof on a string literal includes the NUL
-+	char *filename = malloc(len);
-+	if (filename == NULL) {
 +		return NULL;
 +	}
 +	snprintf(filename, len, "%s/%s", fontdir, name);
@@ -191,11 +177,7 @@ index f6951ba2..b1fdd981 100644
 +char *
 +fz_lookup_cjk_font_from_file(fz_context *ctx, int registry, int serif, int wmode)
 +{
-+#ifdef __ANDROID__
-+	return get_font_file_android("Roboto-Regular.ttf");
-+#else
 +	return get_font_file("noto/NotoSansCJKsc-Regular.otf");
-+#endif
 +}
 +
 +const unsigned char *
@@ -225,11 +207,7 @@ index f6951ba2..b1fdd981 100644
 +	char *filename;
 +	fz_font *font;
 +
-+#ifdef __ANDROID__
-+	filename = get_font_file_android("Roboto-Regular.ttf");
-+#else
 +	filename = get_font_file("noto/NotoSansCJKsc-Regular.otf");
-+#endif
 +	font = fz_new_font_from_file(ctx, NULL, filename, 0, 1);
 +	free(filename);
 +	return font;

--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -67,7 +67,7 @@ index f6951ba2..b1fdd981 100644
  /*
  	Base 14 PDF fonts from URW.
  	Noto fonts from Google.
-@@ -367,3 +371,173 @@ fz_lookup_noto_emoji_font(fz_context *ctx, int *size)
+@@ -367,3 +371,152 @@ fz_lookup_noto_emoji_font(fz_context *ctx, int *size)
  	return *size = 0, NULL;
  #endif
  }


### PR DESCRIPTION
This reverts commit b7dd4c16b06c22fc1d1b85544f9c767f8d4b2995.

Closes <https://github.com/koreader/koreader/issues/5617>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1013)
<!-- Reviewable:end -->
