### PR TITLE
xtext: fix occasionally wrong measured width

### DIFF
--- a/xtext.cpp
+++ b/xtext.cpp
@@ -950,8 +950,6 @@ public:
                         if ( t_notdef_start < 0 ) {
                             t_notdef_start = t;
                         }
-                        // We'll remove it from final_width if we measure sucessfully with fallback font
-                        notdef_width += advance;
                     }
                     #ifdef DEBUG_MEASURE_TEXT
                         printf("c%d+%d ", hcl, advance);
@@ -978,6 +976,13 @@ public:
                 final_width += cur_width;
                 // It seems each soft-hyphen is in its own cluster, of length 1 and width 0,
                 // so HarfBuzz must already deal correctly with soft-hyphens.
+                if ( t_notdef_start >= 0 ) {
+                    // If we had one glyph not found, we'll measure the whole cluster with
+                    // a fallback font, so add the full cluster advance to notdef_width,
+                    // that we'll remove from final_width if we measure sucessfully with
+                    // a fallback font.
+                    notdef_width += cur_width;
+                }
             }
             if ( is_rtl )
                 m_charinfo[t].flags |= CHAR_IS_RTL;
@@ -1000,6 +1005,8 @@ public:
                 fb_hints &= ~HINT_BEGINS_PARAGRAPH;
             int fallback_width = measureSegment( font_num+1, t_notdef_start, t_notdef_end, fb_hints );
             if ( fallback_width != NOT_MEASURED ) {
+                // printf("%sMSHB ### final_width=%d - notdef_width=%d + fallback_width=%d > W= %d\n%s[...]",
+                //   indent, final_width, notdef_width, fallback_width, final_width - notdef_width + fallback_width, indent);
                 final_width = final_width - notdef_width + fallback_width;
             }
             #ifdef DEBUG_MEASURE_TEXT


### PR DESCRIPTION
When computing the accumulated width, we have a trick of keeping adding "tofu" widths, that we later remove when we add the correct width measured with a fallback font.
In a multi glyphs cluster, that notdef width was computed only from the first notdef glyph met, but it should include all the glyphs' widths, even if the first one is not notdef.

Fix the issue noticed in https://github.com/koreader/koreader/issues/5615#issuecomment-561734969.
Before, the glyph was off key because the computed width was too large (77):
<kbd>![too_large_wrong_width](https://user-images.githubusercontent.com/24273478/70189545-e00c7c00-16f3-11ea-8a96-85c4cd4fa7ff.png)</kbd>
After (correct width of 16):
<kbd>![fixed_width](https://user-images.githubusercontent.com/24273478/70189550-e1d63f80-16f3-11ea-9da0-7663fe7631ea.png)</kbd>

I just discovered that when Harfbuzz sees a diacritic at start of line, it prefixes it itself with a [DOTTED CIRCLE](https://www.compart.com/en/unicode/U+25CC), but we can reproduce the issue by adding it explicitely:
(my latin1 garbage is actually [U+25CC](https://www.compart.com/en/unicode/U+25CC) (Dotted circle)+ [U+0E37](https://www.compart.com/en/unicode/U+0E37) (Thai Character Sara Uee))
```lua
require("libs/libkoreader-xtext")
_xtext = xtext.new("â~W~Là¸·", require("ui/font"):getFace("infont"))
_xtext:measure()
require("logger").warn(_xtext:getWidth())
require("logger").warn(_xtext:shapeLine(1, #_xtext))
```
The Dotted circle can be found in an earlier font, but not the thai character - but they make all a single cluster, so the full cluster is tried with the fallback font.

Logs before:
```
MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#0]
MSHB g0 c0(=t:25cc) [0 ]        advance=(12,0)
MSHB g1 c0(=t:25cc) [0 ]        advance=(0,0)   offset=(-12,0)
MSHB ---
MSHB t0 (=25cc) (glyph not found) c0+12 (glyph not found) c0+0 => 12 (flags=256) => W=12
MSHB t1 (=e37) => 0 (flags=544) => W=12
[...]
MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSans-Regular.ttf in ./fonts/noto/NotoSans-Regular.ttf
  MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#1]
  MSHB g0 c0(=t:25cc) [74f uni25CC]     advance=(12,0)
  MSHB g1 c0(=t:25cc) [0 .notdef]       advance=(12,0)
  MSHB ---
  MSHB t0 (=25cc) (found cp=74f) c0+12 (glyph not found) c0+12 => 24 (flags=256) => W=24
  MSHB t1 (=e37) => 0 (flags=544) => W=24
  [...]
  MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSansCJKsc-Regular.otf in ./fonts/noto/NotoSansCJKsc-Regular.otf
    MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#2]
    MSHB g0 c0(=t:25cc) [4f1 ]  advance=(20,0)
    MSHB g1 c0(=t:25cc) [0 ]    advance=(20,0)
    MSHB ---
    MSHB t0 (=25cc) (found cp=4f1) c0+20 (glyph not found) c0+20 => 40 (flags=256) => W=40
    MSHB t1 (=e37) => 0 (flags=544) => W=40
    [...]
    MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSansArabicUI-Regular.ttf in ./fonts/noto/NotoSansArabicUI-Regular.ttf
      MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#3]
      MSHB g0 c0(=t:25cc) [534 uni25CC] advance=(13,0)
      MSHB g1 c0(=t:25cc) [0 .notdef]   advance=(12,0)
      MSHB ---
      MSHB t0 (=25cc) (found cp=534) c0+13 (glyph not found) c0+12 => 25 (flags=256) => W=25
      MSHB t1 (=e37) => 0 (flags=544) => W=25
      [...]
      MSHB ### measuring past failures at EOT with fallback font 0>2
        MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#4]
        MSHB g0 c0(=t:25cc) [0 .notdef] advance=(12,0)
        MSHB g1 c0(=t:25cc) [0 .notdef] advance=(12,0)
        MSHB ---
        MSHB t0 (=25cc) (glyph not found) c0+12 (glyph not found) c0+12 => 24 (flags=256) => W=24
        MSHB t1 (=e37) => 0 (flags=544) => W=24
        [...]
        MSHB ### measuring past failures at EOT with fallback font 0>2
          MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#5]
          MSHB g0 c0(=t:25cc) [11c5 uni25CC]    advance=(16,0)
          MSHB g1 c0(=t:25cc) [0 .notdef]       advance=(10,0)
          MSHB ---
          MSHB t0 (=25cc) (found cp=11c5) c0+16 (glyph not found) c0+10 => 26 (flags=256) => W=26
          MSHB t1 (=e37) => 0 (flags=544) => W=26
          [...]
          MSHB ### measuring past failures at EOT with fallback font 0>2
            MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#6]
            MSHB g0 c0(=t:25cc) [15ab uni25CC]  advance=(16,0)
            MSHB g1 c0(=t:25cc) [ac4 uni0E37]   advance=(0,0)
            MSHB ---
            MSHB t0 (=25cc) (found cp=15ab) c0+16 (found cp=ac4) c0+0 => 16 (flags=256) => W=16
            MSHB t1 (=e37) => 0 (flags=544) => W=16
            MSHB <<< W=16 [font#6]
            MSHB dwidths[]: 0:16 1:0
          MSHB ### final_width=26 - notdef_width=10 + fallback_width=16 > W= 32
          [...]          MSHB ### measured past failures at EOT > W= 32
          [...]          MSHB <<< W=32 [font#5]
          MSHB dwidths[]: 0:16 1:0
        MSHB ### final_width=24 - notdef_width=24 + fallback_width=32 > W= 32
        [...]        MSHB ### measured past failures at EOT > W= 32
        [...]        MSHB <<< W=32 [font#4]
        MSHB dwidths[]: 0:16 1:0
      MSHB ### final_width=25 - notdef_width=12 + fallback_width=32 > W= 45
      [...]      MSHB ### measured past failures at EOT > W= 45
      [...]      MSHB <<< W=45 [font#3]
      MSHB dwidths[]: 0:16 1:0
    MSHB ### final_width=40 - notdef_width=20 + fallback_width=45 > W= 65
    [...]    MSHB ### measured past failures at EOT > W= 65
    [...]    MSHB <<< W=65 [font#2]
    MSHB dwidths[]: 0:16 1:0
  MSHB ### final_width=24 - notdef_width=12 + fallback_width=65 > W= 77
  [...]  MSHB ### measured past failures at EOT > W= 77
  [...]  MSHB <<< W=77 [font#1]
  MSHB dwidths[]: 0:16 1:0
MSHB ### final_width=12 - notdef_width=12 + fallback_width=77 > W= 77
[...]MSHB ### measured past failures at EOT > W= 77
[...]MSHB <<< W=77 [font#0]
MSHB dwidths[]: 0:16 1:0
WARN  77       -- wrong, should be 16
WARN  {
    [1] = {
        ["y_offset"] = 0,
        ["x_advance"] = 16,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 1,
        ["glyph"] = 5547,
        ["font_num"] = 6,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 2
    },
    [2] = {
        ["y_offset"] = 0,
        ["x_advance"] = 0,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 1,
        ["glyph"] = 2756,
        ["font_num"] = 6,
        ["x_offset"] = 0,
        ["is_cluster_start"] = false,
        ["cluster_len"] = 2
    },
    ["nb_can_extend"] = 0,
    ["nb_can_extend_fallback"] = 0,
    ["width"] = 16
}
```
(It's just the width gathered when measuring that is wrong, the one we get after shaping is correct.)

Fixed:
```
MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#0]
MSHB g0 c0(=t:25cc) [0 ]        advance=(12,0)
MSHB g1 c0(=t:25cc) [0 ]        advance=(0,0)   offset=(-12,0)
MSHB ---
MSHB t0 (=25cc) (glyph not found) c0+12 (glyph not found) c0+0 => 12 (flags=256) => W=12
MSHB t1 (=e37) => 0 (flags=544) => W=12
[...]
MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSans-Regular.ttf in ./fonts/noto/NotoSans-Regular.ttf
  MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#1]
  MSHB g0 c0(=t:25cc) [74f uni25CC]     advance=(12,0)
  MSHB g1 c0(=t:25cc) [0 .notdef]       advance=(12,0)
  MSHB ---
  MSHB t0 (=25cc) (found cp=74f) c0+12 (glyph not found) c0+12 => 24 (flags=256) => W=24
  MSHB t1 (=e37) => 0 (flags=544) => W=24
  [...]
  MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSansCJKsc-Regular.otf in ./fonts/noto/NotoSansCJKsc-Regular.otf
    MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#2]
    MSHB g0 c0(=t:25cc) [4f1 ]  advance=(20,0)
    MSHB g1 c0(=t:25cc) [0 ]    advance=(20,0)
    MSHB ---
    MSHB t0 (=25cc) (found cp=4f1) c0+20 (glyph not found) c0+20 => 40 (flags=256) => W=40
    MSHB t1 (=e37) => 0 (flags=544) => W=40
    [...]
    MSHB ### measuring past failures at EOT with fallback font 0>2
DEBUG Found font: NotoSansArabicUI-Regular.ttf in ./fonts/noto/NotoSansArabicUI-Regular.ttf
      MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#3]
      MSHB g0 c0(=t:25cc) [534 uni25CC] advance=(13,0)
      MSHB g1 c0(=t:25cc) [0 .notdef]   advance=(12,0)
      MSHB ---
      MSHB t0 (=25cc) (found cp=534) c0+13 (glyph not found) c0+12 => 25 (flags=256) => W=25
      MSHB t1 (=e37) => 0 (flags=544) => W=25
      [...]
      MSHB ### measuring past failures at EOT with fallback font 0>2
        MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#4]
        MSHB g0 c0(=t:25cc) [0 .notdef] advance=(12,0)
        MSHB g1 c0(=t:25cc) [0 .notdef] advance=(12,0)
        MSHB ---
        MSHB t0 (=25cc) (glyph not found) c0+12 (glyph not found) c0+12 => 24 (flags=256) => W=24
        MSHB t1 (=e37) => 0 (flags=544) => W=24
        [...]
        MSHB ### measuring past failures at EOT with fallback font 0>2
          MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#5]
          MSHB g0 c0(=t:25cc) [11c5 uni25CC]    advance=(16,0)
          MSHB g1 c0(=t:25cc) [0 .notdef]       advance=(10,0)
          MSHB ---
          MSHB t0 (=25cc) (found cp=11c5) c0+16 (glyph not found) c0+10 => 26 (flags=256) => W=26
          MSHB t1 (=e37) => 0 (flags=544) => W=26
          [...]
          MSHB ### measuring past failures at EOT with fallback font 0>2
            MSHB >>> measureSegment start=0 len=2 is_rtl=0 [font#6]
            MSHB g0 c0(=t:25cc) [15ab uni25CC]  advance=(16,0)
            MSHB g1 c0(=t:25cc) [ac4 uni0E37]   advance=(0,0)
            MSHB ---
            MSHB t0 (=25cc) (found cp=15ab) c0+16 (found cp=ac4) c0+0 => 16 (flags=256) => W=16
            MSHB t1 (=e37) => 0 (flags=544) => W=16
            MSHB <<< W=16 [font#6]
            MSHB dwidths[]: 0:16 1:0
          MSHB ### final_width=26 - notdef_width=26 + fallback_width=16 > W= 16
          [...]          MSHB ### measured past failures at EOT > W= 16
          [...]          MSHB <<< W=16 [font#5]
          MSHB dwidths[]: 0:16 1:0
        MSHB ### final_width=24 - notdef_width=24 + fallback_width=16 > W= 16
        [...]        MSHB ### measured past failures at EOT > W= 16
        [...]        MSHB <<< W=16 [font#4]
        MSHB dwidths[]: 0:16 1:0
      MSHB ### final_width=25 - notdef_width=25 + fallback_width=16 > W= 16
      [...]      MSHB ### measured past failures at EOT > W= 16
      [...]      MSHB <<< W=16 [font#3]
      MSHB dwidths[]: 0:16 1:0
    MSHB ### final_width=40 - notdef_width=40 + fallback_width=16 > W= 16
    [...]    MSHB ### measured past failures at EOT > W= 16
    [...]    MSHB <<< W=16 [font#2]
    MSHB dwidths[]: 0:16 1:0
  MSHB ### final_width=24 - notdef_width=24 + fallback_width=16 > W= 16
  [...]  MSHB ### measured past failures at EOT > W= 16
  [...]  MSHB <<< W=16 [font#1]
  MSHB dwidths[]: 0:16 1:0
MSHB ### final_width=12 - notdef_width=12 + fallback_width=16 > W= 16
[...]MSHB ### measured past failures at EOT > W= 16
[...]MSHB <<< W=16 [font#0]
MSHB dwidths[]: 0:16 1:0
WARN  16
WARN  {
    [1] = {
        ["y_offset"] = 0,
        ["x_advance"] = 16,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 1,
        ["glyph"] = 5547,
        ["font_num"] = 6,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 2
    },
    [2] = {
        ["y_offset"] = 0,
        ["x_advance"] = 0,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 1,
        ["glyph"] = 2756,
        ["font_num"] = 6,
        ["x_offset"] = 0,
        ["is_cluster_start"] = false,
        ["cluster_len"] = 2
    },
    ["nb_can_extend"] = 0,
    ["nb_can_extend_fallback"] = 0,
    ["width"] = 16
}
```

Random note, about the limits of that algorithm.
If we surround these 2 chars with other stuff, like `zz` on each side, there may be some other clustering, and different things re-measured, and so drawn with different fonts (the dotted circles don't have the same size...).
Actually, I think this is less critical, and the split in measured segments is caused by the unicode script detection. `zzO` is actually latin script, the dotted circle is probably neutral script, so gathered with the preceeding latin script - then comes the Thai character, measured by itself as there are no other Thai char arround, then the `zz` latin again. In the original case, O+thai, the O, being neutral, went being measured with the Thai char as a segment of 2 Thai script chars.

<kbd>![mixed_notnice](https://user-images.githubusercontent.com/24273478/70190212-9cb30d00-16f5-11ea-87d9-70aa4bd49b57.png)</kbd>

```
MSHB >>> measureSegment start=0 len=3 is_rtl=0 [font#0]
MSHB g0 c0(=t:7a) [5b ] advance=(12,0)
MSHB g1 c1(=t:7a) [5b ] advance=(12,0)
MSHB g2 c2(=t:25cc) [0 ]        advance=(12,0)
MSHB ---
MSHB t0 (=7a) (found cp=5b) c0+12 => 12 (flags=256) => W=12
MSHB t1 (=7a) (found cp=5b) c1+12 => 12 (flags=0) => W=24
MSHB t2 (=25cc) (glyph not found) c2+12 => 12 (flags=0) => W=36
[...]
MSHB ### measuring past failures at EOT with fallback font 2>3
DEBUG Found font: NotoSans-Regular.ttf in ./fonts/noto/NotoSans-Regular.ttf
  MSHB >>> measureSegment start=2 len=1 is_rtl=0 [font#1]
  MSHB g0 c2(=t:25cc) [74f uni25CC]     advance=(12,0)
  MSHB ---
  MSHB t2 (=25cc) (found cp=74f) c2+12 => 12 (flags=0) => W=12
  MSHB <<< W=12 [font#1]
  MSHB dwidths[]: 2:12
MSHB ### final_width=36 - notdef_width=12 + fallback_width=12 > W= 36
[...]MSHB ### measured past failures at EOT > W= 36
[...]MSHB <<< W=36 [font#0]
MSHB dwidths[]: 0:12 1:12 2:12
MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#0]
MSHB g0 c3(=t:e37) [0 ] advance=(0,0)   offset=(-12,0)
MSHB ---
MSHB t3 (=e37) (glyph not found) c3+0 => 0 (flags=128) => W=0
[...]
MSHB ### measuring past failures at EOT with fallback font 3>4
  MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#1]
  MSHB g0 c3(=t:e37) [0 .notdef]        advance=(12,0)
  MSHB ---
  MSHB t3 (=e37) (glyph not found) c3+12 => 12 (flags=128) => W=12
  [...]
  MSHB ### measuring past failures at EOT with fallback font 3>4
DEBUG Found font: NotoSansCJKsc-Regular.otf in ./fonts/noto/NotoSansCJKsc-Regular.otf
    MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#2]
    MSHB g0 c3(=t:e37) [0 ]     advance=(20,0)
    MSHB ---
    MSHB t3 (=e37) (glyph not found) c3+20 => 20 (flags=128) => W=20
    [...]
    MSHB ### measuring past failures at EOT with fallback font 3>4
DEBUG Found font: NotoSansArabicUI-Regular.ttf in ./fonts/noto/NotoSansArabicUI-Regular.ttf
      MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#3]
      MSHB g0 c3(=t:e37) [0 .notdef]    advance=(12,0)
      MSHB ---
      MSHB t3 (=e37) (glyph not found) c3+12 => 12 (flags=128) => W=12
      [...]
      MSHB ### measuring past failures at EOT with fallback font 3>4
        MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#4]
        MSHB g0 c3(=t:e37) [0 .notdef]  advance=(12,0)
        MSHB ---
        MSHB t3 (=e37) (glyph not found) c3+12 => 12 (flags=128) => W=12
        [...]
        MSHB ### measuring past failures at EOT with fallback font 3>4
          MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#5]
          MSHB g0 c3(=t:e37) [0 .notdef]        advance=(10,0)
          MSHB ---
          MSHB t3 (=e37) (glyph not found) c3+10 => 10 (flags=128) => W=10
          [...]
          MSHB ### measuring past failures at EOT with fallback font 3>4
            MSHB >>> measureSegment start=3 len=1 is_rtl=0 [font#6]
            MSHB g0 c3(=t:e37) [ac4 uni0E37]    advance=(0,0)
            MSHB ---
            MSHB t3 (=e37) (found cp=ac4) c3+0 => 0 (flags=128) => W=0
            MSHB <<< W=0 [font#6]
            MSHB dwidths[]: 3:0
          MSHB ### final_width=10 - notdef_width=10 + fallback_width=0 > W= 0
          [...]          MSHB ### measured past failures at EOT > W= 0
          [...]          MSHB <<< W=0 [font#5]
          MSHB dwidths[]: 3:0
        MSHB ### final_width=12 - notdef_width=12 + fallback_width=0 > W= 0
        [...]        MSHB ### measured past failures at EOT > W= 0
        [...]        MSHB <<< W=0 [font#4]
        MSHB dwidths[]: 3:0
      MSHB ### final_width=12 - notdef_width=12 + fallback_width=0 > W= 0
      [...]      MSHB ### measured past failures at EOT > W= 0
      [...]      MSHB <<< W=0 [font#3]
      MSHB dwidths[]: 3:0
    MSHB ### final_width=20 - notdef_width=20 + fallback_width=0 > W= 0
    [...]    MSHB ### measured past failures at EOT > W= 0
    [...]    MSHB <<< W=0 [font#2]
    MSHB dwidths[]: 3:0
  MSHB ### final_width=12 - notdef_width=12 + fallback_width=0 > W= 0
  [...]  MSHB ### measured past failures at EOT > W= 0
  [...]  MSHB <<< W=0 [font#1]
  MSHB dwidths[]: 3:0
MSHB ### final_width=0 - notdef_width=0 + fallback_width=0 > W= 0
[...]MSHB ### measured past failures at EOT > W= 0
[...]MSHB <<< W=0 [font#0]
MSHB dwidths[]: 3:0
MSHB >>> measureSegment start=4 len=2 is_rtl=0 [font#0]
MSHB g0 c4(=t:7a) [5b ] advance=(12,0)
MSHB g1 c5(=t:7a) [5b ] advance=(12,0)
MSHB ---
MSHB t4 (=7a) (found cp=5b) c4+12 => 12 (flags=128) => W=12
MSHB t5 (=7a) (found cp=5b) c5+12 => 12 (flags=512) => W=24
MSHB <<< W=24 [font#0]
MSHB dwidths[]: 4:12 5:12
WARN  60
WARN  {
    [1] = {
        ["y_offset"] = 0,
        ["x_advance"] = 12,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 1,
        ["glyph"] = 91,
        ["font_num"] = 0,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    [2] = {
        ["y_offset"] = 0,
        ["x_advance"] = 12,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 2,
        ["glyph"] = 91,
        ["font_num"] = 0,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    [3] = {
        ["y_offset"] = 0,
        ["x_advance"] = 12,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 3,
        ["glyph"] = 1871,
        ["font_num"] = 1,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    [4] = {
        ["y_offset"] = 0,
        ["x_advance"] = 0,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 4,
        ["glyph"] = 2756,
        ["font_num"] = 6,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    [5] = {
        ["y_offset"] = 0,
        ["x_advance"] = 12,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 5,
        ["glyph"] = 91,
        ["font_num"] = 0,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    [6] = {
        ["y_offset"] = 0,
        ["x_advance"] = 12,
        ["can_extend"] = false,
        ["can_extend_fallback"] = false,
        ["is_rtl"] = false,
        ["text_index"] = 6,
        ["glyph"] = 91,
        ["font_num"] = 0,
        ["x_offset"] = 0,
        ["is_cluster_start"] = true,
        ["cluster_len"] = 1
    },
    ["nb_can_extend"] = 0,
    ["nb_can_extend_fallback"] = 0,
    ["width"] = 60
}
```

(Long explanation while I can just because it's still fresh - I might be happy reading this if I have to fix a bug in one year... :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1020)
<!-- Reviewable:end -->
