### PR TITLE
Add util.fsyncOpenedFile() and util.fsyncDirectory()

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -87,6 +87,8 @@ cdecl_func(fputc)
 cdecl_const(FIONREAD)
 cdecl_func(fileno)
 cdecl_func(strerror)
+cdecl_func(fsync)
+cdecl_func(fdatasync)
 
 cdecl_func(setenv)
 cdecl_func(unsetenv)

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -74,6 +74,8 @@ int fputc(int, struct _IO_FILE *);
 static const int FIONREAD = 21531;
 int fileno(struct _IO_FILE *) __attribute__((nothrow, leaf));
 char *strerror(int) __attribute__((nothrow, leaf));
+int fsync(int);
+int fdatasync(int);
 int setenv(const char *, const char *, int) __attribute__((nothrow, leaf));
 int unsetenv(const char *) __attribute__((nothrow, leaf));
 int _putenv(const char *);


### PR DESCRIPTION
To have some tools to try to do better with our config files getting corrupted in case of device hang/crash.
More details in https://github.com/koreader/koreader/pull/3625#issuecomment-561838044.
Of interest:
http://blog.httrack.com/blog/2013/11/15/everything-you-always-wanted-to-know-about-fsync/
https://stackoverflow.com/questions/37288453/calling-fsync2-after-close2

Also bump crengine:
-  Open (as text) small or empty files https://github.com/koreader/crengine/pull/322

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1021)
<!-- Reviewable:end -->
