### PR TITLE
bump crengine & fribidi, tweak xtext.makeLine()

### DIFF
--- a/thirdparty/fribidi/CMakeLists.txt
+++ b/thirdparty/fribidi/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/fribidi/fribidi.git
-    tags/v1.0.7
+    tags/v1.0.8
     ${SOURCE_DIR}
 )
 

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -482,6 +482,11 @@ public:
                 FriBidiLevel *       bidi_levels = (FriBidiLevel *)      (m_bidi_levels + s_start);
                 int this_max_level = fribidi_get_par_embedding_levels_ex(bidi_ctypes, bidi_btypes,
                                                             s_length, &para_bidi_type, bidi_levels);
+                /* To see resulting bidi levels:
+                printf("par_type %d , max_level %d\n", para_bidi_type, this_max_level);
+                for (int j=s_start; j<i; j++)
+                    printf("%x %c %d\n", m_text[j], m_text[j], m_bidi_levels[j]);
+                */
                 if ( this_max_level > max_level )
                     max_level = this_max_level;
                 // we set a flag on all chars part of this segment so we can know what
@@ -1087,6 +1092,7 @@ public:
             // printf("%d < %d && %d <= %d ?\n", i, m_length, line_width, targeted_width);
         }
         bool can_be_justified = true;
+        bool no_allowed_break_met = false;
         if ( forced_break ) {
             can_be_justified = false;
             if ( i==start ) { // \n at start: empty line with no glyph
@@ -1101,6 +1107,9 @@ public:
             next_line_start_offset = i;
             if ( i == m_length ) {
                 can_be_justified = false; // no justification on last line
+            }
+            else {
+                no_allowed_break_met = true;
             }
         }
         // We could have used some indirection to make that more
@@ -1127,6 +1136,12 @@ public:
         lua_pushstring(m_L, "targeted_width");
         lua_pushinteger(m_L, targeted_width);
         lua_settable(m_L, -3);
+
+        if ( no_allowed_break_met ) {
+            lua_pushstring(m_L, "no_allowed_break_met");
+            lua_pushboolean(m_L, true);
+            lua_settable(m_L, -3);
+        }
 
         if ( next_line_start_offset >= 0 && next_line_start_offset < m_length ) {
             // next_start_offset is to be nil if end of text


### PR DESCRIPTION
- bump crengine: (Upstream) DocX: fix paragraphs with single hyperlink https://github.com/koreader/crengine/pull/323
- bump fribidi to 1.0.8 (for nested isolates fix, https://github.com/koreader/koreader/issues/5359#issuecomment-565001148)
- xtext.makeLine(): return `no_allowed_break_met=true` when that happens, so we know the line breaks inside a word. https://github.com/koreader/koreader/pull/5598#issuecomment-565836669

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1022)
<!-- Reviewable:end -->
