### PR TITLE
bump crengine: support display: inline-block, better text selection

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1372,6 +1372,16 @@ static int getTextFromPositions(lua_State *L) {
 	int y0 = luaL_checkint(L, 3);
 	int x1 = luaL_checkint(L, 4);
 	int y1 = luaL_checkint(L, 5);
+	// Default to have crengine do native highlight of selected text
+	// (segmented by line, for better results)
+	bool drawSelection = true;
+	if (lua_isboolean(L, 6)) {
+		drawSelection = lua_toboolean(L, 6);
+	}
+	bool drawSegmentedSelection = true;
+	if (lua_isboolean(L, 7)) {
+		drawSegmentedSelection = lua_toboolean(L, 7);
+	}
 
 	LVDocView *tv = doc->text_view;
 	lvRect margin = tv->getPageMargins();
@@ -1408,8 +1418,11 @@ static int getTextFromPositions(lua_State *L) {
 				r.getEnd().setOffset(offset + 1);
 		}
 
-		r.setFlags(1);
-		tv->selectRange(r);  // we let crengine do native highlight of selection
+		int rangeFlags = 0;
+		if (drawSelection) // have crengine do native highlight of selection
+			rangeFlags = drawSegmentedSelection ? 2 : 1;
+		r.setFlags(rangeFlags);
+		tv->selectRange(r);
 
 		/* We don't need these:
 		int page = tv->getBookmarkPage(startp);


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/325 :
- lvtinydom.cpp: fix Use-after-free
- lvtextfm: fix/cleanup lastnonspace code bits
- lvtextfm: fix vertical-align: top & bottom
- renderBlockElementEnhanced: minor fixes related to floats
- renderBlockElementEnhanced: compute baseline of block
- Add support for display: inline-block/inline-table
- Better selection highlighting by using getSegmentRects()
- getHtml(): add flag to get text soft-hyphenated

cre.cpp: toggable text selection highlighting method, default to the new one using segments.

If we need to revert to former method, we can add in credocument.lua `true, false` to the 2 occurences of:
```diff
-local text_range = self._document:getTextFromPositions(pos.x, pos.y, pos.x, pos.y)
+local text_range = self._document:getTextFromPositions(pos.x, pos.y, pos.x, pos.y, true, false)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1030)
<!-- Reviewable:end -->
