### PR TITLE
bump crengine: various text and CSS fixes

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1420,7 +1420,7 @@ static int getTextFromPositions(lua_State *L) {
 
 		int rangeFlags = 0;
 		if (drawSelection) // have crengine do native highlight of selection
-			rangeFlags = drawSegmentedSelection ? 2 : 1;
+			rangeFlags = drawSegmentedSelection ? 0x11 : 0x01;
 		r.setFlags(rangeFlags);
 		tv->selectRange(r);
 
@@ -2631,7 +2631,9 @@ static int highlightXPointer(lua_State *L) {
         ldomNode * node = nodep.getNode();
         if (node->isNull())
             return 0;
-        sel.add( new ldomXRange(node, true) ); // highlight
+        ldomXRange * fullNodeRange = new ldomXRange(node, true);
+        fullNodeRange->setFlags(0x11); // draw segmented adjusted selection
+        sel.add( fullNodeRange ); // highlight it
         lua_pushboolean(L, true);
         return 1;
     }

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -56,6 +56,7 @@ add_definitions(
     -DUSE_HARFBUZZ=1
     -DUSE_FRIBIDI=1
     -DUSE_UTF8PROC=1
+    -DUSE_NANOSVG=1
     -DALLOW_KERNING=1
     -DCR3_PATCH=1
 )

--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -43,7 +43,7 @@ index e197fa1b..03bfbb34 100644
  		if (data)
  			ctx->font->symbol = fz_new_font_from_memory(ctx, NULL, data, size, 0, 0);
 +#else
-+		char *filename = get_font_file("freefont/FreeSans.ttf");
++		char *filename = get_font_file("freefont/FreeSerif.ttf");
 +		ctx->font->symbol = fz_new_font_from_file(ctx, NULL, filename, 0, 1);
 +		free(filename);
 +#endif


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/326 :
- ldomXRange/ldomMarkedRange: update enhanced drawing flag
- Hardcoded elements list: add <script>
- CSS: ensure selectors are applied in the order met
- elementFromPoint(): fix some floats not being visited
- Fix getPageDocumentRange() on bidi text
- Text: fix: allow wrap on space around images
- CSS/Text: adds "-cr-hint: strut-confined"
- Rename mispelled 'ident' and field 'margin' to 'indent"
- text-indent: some fixes, handle negative & hanging indent
- (Upstream) Minor cleanup and ifdef wraps
- lvtextfm: avoid possible segfault when hyphenating
- lvtextfm: avoid spurious spaces when hyphenating
- lvtextfm: dont adjust space after initial quotation mark/dash
- lvtextfm: ensure page-break:avoid on inline-block and images
- (Upstream) lvtinydom.cpp: fix old minor typo
- Fix internal/footnote links not working on some books

cre.cpp: also use enhanced selection drawing when highlighting the footnote link with footnote popups.

`MuPDF: switch fallback font from FreeSans to FreeSerif`
FreeSerif has more coverage than FreeSans. This will allow footnote popups and HTML dictionary results in Arabic and Hebrew to be correctly displayed. See https://github.com/koreader/koreader-base/pull/585#issuecomment-577049515

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1033)
<!-- Reviewable:end -->
