### PR TITLE
unbreak KT4 dithering (broken by #1034)

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -606,7 +606,9 @@ function framebuffer:init()
 
         -- NOTE: Devices on the Rex platform essentially use the same driver as the Zelda platform, they're just passing a slightly smaller mxcfb_update_data struct
         if isZelda or isRex then
-            self.device.canHWDither = yes
+            if not isNightModeChallenged then
+                self.device.canHWDither = yes
+            end
             if isZelda then
                 self.mech_refresh = refresh_zelda
             else


### PR DESCRIPTION
@NiLuJe 
KT4 doesnt support this HW dithering.
#1034 causes the display to be faded (i almost thought i damaged my screen by mistake)

if you think there is anything else that can be tried i am happy to help/test

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1039)
<!-- Reviewable:end -->
