### PR TITLE
Move CMake's staging directory outside OUTPUT_DIR

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -501,6 +501,8 @@ else
 	MACHINE=$(TARGET_MARCHINE)
 endif
 OUTPUT_DIR=build/$(MACHINE)
+# We'll want a machine-specific staging directory *outside* of OUTPUT_DIR, so we don't pickup random build artifacts in packages...
+CMAKE_STAGING_DIR=build/staging-$(MACHINE)
 
 # you can configure an emulation for the (eink) framebuffer here.
 # the application won't use the framebuffer (and the special e-ink ioctls)
@@ -533,7 +535,7 @@ else
 	ifndef SYSROOT
 		export SYSROOT:=$(shell PATH='$(PATH)' $(CC) -print-sysroot)
 	endif
-	export CROSS_STAGING:=$(CURDIR)/$(OUTPUT_DIR)
+	export CROSS_STAGING:=$(CMAKE_STAGING_DIR)
 	export CMAKE_TCF:=-DCMAKE_TOOLCHAIN_FILE=$(CURDIR)/thirdparty/cmake_modules/CMakeCross.cmake
 	CMAKE+=$(CMAKE_TCF)
 	ifdef CCACHE


### PR DESCRIPTION
Otherwise, we're picking it up in the final packages

We've been shipping extra bits of jpeg-turbo & zsync2 because of that,
which explains why the tarball's size has suddenly ballooned...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1044)
<!-- Reviewable:end -->
