### PR TITLE
On Kindle legacy, disable atomics in HB

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -21,6 +21,15 @@ set(CFG_ENV_VAR "${CFG_ENV_VAR} FREETYPE_LIBS=\"-L${FREETYPE_DIR} -lfreetype\"")
 set(CFG_OPTS "--prefix=\"${BINARY_DIR}\" --enable-shared --disable-static --with-freetype --with-ucdn --without-glib --without-gobject --without-cairo --without-fontconfig --without-icu --without-graphite2 --without-uniscribe --without-directwrite --without-coretext --host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 
+set(AUTOGEN_CMD sh -c "env NOCONFIGURE=1 ./autogen.sh")
+
+# We've apparently hit a weird corner-case w/ XText where GCC/STL atomics *sometimes* horribly blow up on an ARM1136JF-S CPU w/ GCC 7.5...
+# c.f., https://github.com/koreader/koreader/issues/5780
+# NOTE: Nerf PB, too, mostly because I don't trust the older GCC version used there...
+if(DEFINED ENV{LEGACY} OR DEFINED ENV{POCKETBOOK})
+	set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/hb-disable-atomics.patch")
+end()
+
 if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|version_type=none|version_type=linux|' libtool")
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|need_lib_prefix=no|need_lib_prefix=yes|' libtool")
@@ -43,7 +52,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND NOCONFIGURE=1 ./autogen.sh
+    PATCH_COMMAND COMMAND ${PATCH_CMD} COMMAND ${AUTOGEN_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}
     INSTALL_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} install

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -28,7 +28,7 @@ set(AUTOGEN_CMD sh -c "env NOCONFIGURE=1 ./autogen.sh")
 # NOTE: Nerf PB, too, mostly because I don't trust the older GCC version used there...
 if(DEFINED ENV{LEGACY} OR DEFINED ENV{POCKETBOOK})
 	set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/hb-disable-atomics.patch")
-end()
+endif()
 
 if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|version_type=none|version_type=linux|' libtool")

--- a/thirdparty/harfbuzz/hb-disable-atomics.patch
+++ b/thirdparty/harfbuzz/hb-disable-atomics.patch
@@ -1,0 +1,22 @@
+diff --git a/src/hb-atomic.hh b/src/hb-atomic.hh
+index f9afd4ff..783a4198 100644
+--- a/src/hb-atomic.hh
++++ b/src/hb-atomic.hh
+@@ -49,7 +49,7 @@
+ /* Defined externally, i.e. in config.h. */
+ 
+ 
+-#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE)
++#elif !defined(HB_NO_MT) && defined(__ATOMIC_ACQUIRE) && defined(__NOPEY_NOPE)
+ 
+ /* C++11-style GCC primitives. */
+ 
+@@ -72,7 +72,7 @@ _hb_atomic_ptr_impl_cmplexch (const void **P, const void *O_, const void *N)
+ }
+ #define hb_atomic_ptr_impl_cmpexch(P,O,N)	_hb_atomic_ptr_impl_cmplexch ((const void **) (P), (O), (N))
+ 
+-#elif !defined(HB_NO_MT) && __cplusplus >= 201103L
++#elif !defined(HB_NO_MT) && __cplusplus >= 201103L && defined(__NOPEY_NOPE)
+ 
+ /* C++11 atomics. */
+ 


### PR DESCRIPTION
Workaround for https://github.com/koreader/koreader/issues/5780

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1046)
<!-- Reviewable:end -->
