### PR TITLE
[CI] New PocketBook Docker image with our own TC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
 
   emu: &EMU_TPL
     docker:
-      - image: koreader/kobase:0.1.5
+      - image: koreader/kobase:0.1.6
     environment: &EMU_ENV_LST
       BASH_ENV: "~/.bashrc"
       EMULATE_READER: "1"
@@ -163,7 +163,7 @@ jobs:
     <<: *XCOMPILE_TPL
     environment:
       TARGET: "pocketbook"
-      DOCKER_IMG: koreader/kopb:0.1.3
+      DOCKER_IMG: koreader/kopb:0.2.0
 
   sony-prstux:
     <<: *XCOMPILE_TPL


### PR DESCRIPTION
Without it the base CI is now failing to finish properly.

See https://github.com/koreader/virdevenv/pull/49 and https://github.com/koreader/koreader-base/pull/1049#issuecomment-587059804

Also includes a bump to the base image. See <https://github.com/koreader/virdevenv/pull/48>, closes <https://github.com/koreader/koreader-base/issues/956>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1050)
<!-- Reviewable:end -->
