### PR TITLE
[CI] Mac OS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: test
+
+on: push
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Cache for ccache
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-ccache
+        with:
+          path: ~/.ccache # ccache cache files are stored in `~/.ccache` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Homebrew install dependencies
+        # Compared to the README, adds ccache for faster compilation times and removes sh5sum to prevent some conflict with coreutils
+        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend sdl2 lua@5.1 luarocks gettext pkg-config wget && echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> "$HOME"/.bash_profile
+
+      - name: Building in progress…
+        run: export MACOSX_DEPLOYMENT_TARGET=10.14 && make fetchthirdparty && make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Homebrew install dependencies
         # Compared to the README, adds ccache for faster compilation times and removes sh5sum to prevent some conflict with coreutils
-        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend sdl2 lua@5.1 luarocks gettext pkg-config wget && echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> "$HOME"/.bash_profile
+        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend sdl2 lua@5.1 luarocks gettext pkg-config wget
 
       - name: Building in progress…
-        run: export MACOSX_DEPLOYMENT_TARGET=10.14 && make fetchthirdparty && make
+        run: export MACOSX_DEPLOYMENT_TARGET=10.14 PATH="/usr/local/opt/gettext/bin:$PATH" && make fetchthirdparty && make


### PR DESCRIPTION
GitHub Actions provides readily available Mac OS (and Windows) builds, so we should prevent the habitual Mac OS breakage from here on out.

Differences from README:
* ccache for obvious reasons (faster builds)
* md5sha1sum caused some conflict with coreutils

<hr>

Hopefully @NiLuJe will be able to help resolve the gettext/glib issue because I have no idea what's going on there.

GH Actions docs: https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1052)
<!-- Reviewable:end -->
