### PR TITLE
Use awk instead of bc for version comparisons

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -20,7 +20,7 @@ NDKABI?=14
 
 # Detect LuaRocks 3
 LR_VER_NUM = $(shell luarocks --version | grep -o [0-9].[0-9])
-LR_GT_3_0 = $(shell echo $(LR_VER_NUM)\>=3.0 | bc )
+LR_GT_3_0 = $(shell awk -v LR_VER_NUM=$(LR_VER_NUM) 'BEGIN { print LR_VER_NUM >= 3.0; }')
 
 # Some CMake flags
 CMAKE_BUILD_TYPE?=Release


### PR DESCRIPTION
The Docke rimages don't ship w/ bc.

As discussed on gitter ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1053)
<!-- Reviewable:end -->
