### PR TITLE
Rebase MD5 module against upstream

### DIFF
--- a/ffi/MD5.lua
+++ b/ffi/MD5.lua
@@ -36,7 +36,7 @@ local function F4(x, y, z) return bxor(y, bor(x, bnot(z))) end
 
 local function MD5STEP(f, w, x, y, z, data, s)
     w = w + f(x, y, z) + data
-    w = bor(lshift(w,s), rshift(w,(32-s)))
+    w = bor(lshift(w, s), rshift(w, (32 - s)))
     w = w + x
 
     return w
@@ -136,7 +136,7 @@ end
 
 local function MD5Update(ctx, buf, len)
     local t = ctx.bits[0]
-    ctx.bits[0] = t + lshift( len, 3)
+    ctx.bits[0] = t + lshift(len, 3)
     if (ctx.bits[0] < t) then
         ctx.bits[1] = ctx.bits[1] + 1
     end
@@ -195,12 +195,14 @@ local function MD5Final(digest, ctx)
     ffi.cast("uint32_t *", ctx.input)[15] = ctx.bits[1]
 
     MD5Transform(ctx.buf, ffi.cast("uint32_t *", ctx.input))
-    byteReverse(ffi.cast("unsigned char *",ctx.buf), 4)
+    byteReverse(ffi.cast("unsigned char *", ctx.buf), 4)
     copy(digest, ctx.buf, 16)
     fill(ffi.cast("unsigned char *", ctx), ffi.sizeof(ctx), 0)
 end
 
 -- From https://github.com/Wiladams/LAPHLibs/blob/master/laphlibs/stringzutils.lua
+-- Output string hex representation requires two bytes per input byte,
+-- so output buffer needs to be twice as large as input, + 1 to accomodate a terminating NUL.
 local hex = ffi.new("const unsigned char[16]", "0123456789abcdef")
 
 local function bin2str(to, p, len)

--- a/ffi/MD5.lua
+++ b/ffi/MD5.lua
@@ -202,7 +202,6 @@ end
 
 -- From https://github.com/Wiladams/LAPHLibs/blob/master/laphlibs/stringzutils.lua
 local hex = ffi.new("const unsigned char[16]", "0123456789abcdef")
-local hex = strdup("0123456789abcdef")
 
 local function bin2str(to, p, len)
     while (len > 0) do

--- a/ffi/MD5.lua
+++ b/ffi/MD5.lua
@@ -226,7 +226,9 @@ md5_proto.__index = md5_proto
 --- Feed content to md5 hashing instance.
 ---- @string luastr stream to process
 function md5_proto:update(luastr)
-    MD5Update(self.ctx, ffi.cast("const unsigned char *", luastr), #luastr)
+    local len = #luastr
+    local p = ffi.cast("const unsigned char *", luastr)
+    MD5Update(self.ctx, p, len)
 end
 
 --- Calculate md5 sum with the state of a md5 hashing instance.


### PR DESCRIPTION
(Same upstream as luxl, which is why I fell into this rabbit hole).

My vague hope that this might fix the mysterious Clang bot issues have been crushed.
On the other hand, it doesn't seem to break anything, so, eh.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1065)
<!-- Reviewable:end -->
