### PR TITLE
Minor Win32 cross-compile fix

### DIFF
--- a/thirdparty/cmake_modules/CMakeCross.cmake
+++ b/thirdparty/cmake_modules/CMakeCross.cmake
@@ -13,6 +13,10 @@ set(NO_POLICY_SCOPE NEW)
 set(CMAKE_SYSTEM_NAME Linux)
 # set target system processor, because we can't set CMAKE_SYSTEM_NAME without setting CMAKE_SYSTEM_PROCESSOR too...
 
+if($ENV{WIN32})
+    set(CMAKE_SYSTEM_NAME Windows)
+endif()
+
 # x86 Android
 if($ENV{CROSS_TC} MATCHES "^i686-.*")
 	set(CMAKE_SYSTEM_PROCESSOR i686)


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/4512#issuecomment-605433402

This is not intended to actually fix the build, just to make it so that an interested party won't have to start at 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1071)
<!-- Reviewable:end -->
