### PR TITLE
Unbreak MD5 on ARM

### DIFF
--- a/ffi/MD5.lua
+++ b/ffi/MD5.lua
@@ -128,10 +128,10 @@ local function MD5Transform(buf, input)
     c = MD5STEP(F4, c, d, a, b, input[2] + 0x2ad7d2bb, 15)
     b = MD5STEP(F4, b, c, d, a, input[9] + 0xeb86d391, 21)
 
-    buf[0] = buf[0] + a
-    buf[1] = buf[1] + b
-    buf[2] = buf[2] + c
-    buf[3] = buf[3] + d
+    buf[0] = band(buf[0] + a, 0xFFFFFFFF)
+    buf[1] = band(buf[1] + b, 0xFFFFFFFF)
+    buf[2] = band(buf[2] + c, 0xFFFFFFFF)
+    buf[3] = band(buf[3] + d, 0xFFFFFFFF)
 end
 
 local function MD5Update(ctx, buf, len)


### PR DESCRIPTION
Regression since #1065

Probably because of implicit type conversions to/from Lua
and the fact that Lua numbers are double internally?
Or something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1077)
<!-- Reviewable:end -->
