### PR TITLE
bump crengine: tunable use of letter spacing for justification

### DIFF
--- a/xtext.cpp
+++ b/xtext.cpp
@@ -922,7 +922,12 @@ public:
                         #ifdef DEBUG_MEASURE_TEXT
                             printf("(found cp=%x) ", glyph_info[hg].codepoint);
                         #endif
-                        if ( t_notdef_start >= 0 ) { // But we have a segment of previous ".notdef"
+                        // Note: in crengine, we needed to add the following additional condition
+                        // to only process past notdef when the first glyph of a cluster is found.
+                        // This strangely seems not needed here (the thai sample that caused issues
+                        // with crengine displays fine in xtext), but let's add it for consistency.
+                        if ( t_notdef_start >= 0 && hcl > cur_cluster ) {
+                            // We have a segment of previous ".notdef", and this glyph starts a new cluster
                             t_notdef_end = t;
 
                             // Let a fallback font replace the wrong values in widths and flags


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/341 :
- Text: fix occasional BiDi bad word splitting
- Font: fix HB fallback measurement/drawing mismatches
- Font: do not add letter spacing on diacritics
- Text: tunable use of letter spacing for justification
- Text: dont adjust space after initial quotation mark/dash (rework)

xtext.cpp: pick crengine fix with HB fallback measurement/drawing mismatches

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1094)
<!-- Reviewable:end -->
