### PR TITLE
Explicitly disable WOFF2 support in FT

### DIFF
--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -15,7 +15,7 @@ ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
 set(CFG_ENV_VAR "CC=\"${CC}\" CXX=\"${CXX}\" CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS}\"")
-set(CFG_OPTS "-q --prefix=${BINARY_DIR} --disable-static --enable-shared --with-zlib=no --with-bzip2=no --with-png=no --with-harfbuzz=no --host=\"${CHOST}\"")
+set(CFG_OPTS "-q --prefix=${BINARY_DIR} --disable-static --enable-shared --with-zlib=no --with-bzip2=no --with-brotli=no --with-png=no --with-harfbuzz=no --host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 
 if($ENV{ANDROID})


### PR DESCRIPTION
Apparently, Android sometimes likes to try to link against an inexistant
brotli otherwise...

Fix https://github.com/koreader/koreader/issues/6178 (thanks to @zwim)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1102)
<!-- Reviewable:end -->
