### PR TITLE
Tweak RTC alarm disable

### DIFF
--- a/ffi-cdecl/rtc_cdecl.c
+++ b/ffi-cdecl/rtc_cdecl.c
@@ -7,6 +7,8 @@
 cdecl_struct(rtc_time)
 cdecl_struct(rtc_wkalrm)
 
+cdecl_const(RTC_AIE_ON)
+cdecl_const(RTC_AIE_OFF)
 cdecl_const(RTC_WKALM_SET)
 cdecl_const(RTC_WKALM_RD)
 

--- a/ffi/rtc_h.lua
+++ b/ffi/rtc_h.lua
@@ -17,6 +17,8 @@ struct rtc_wkalrm {
   unsigned char pending;
   struct rtc_time time;
 };
+static const int RTC_AIE_ON = 28673;
+static const int RTC_AIE_OFF = 28674;
 static const int RTC_WKALM_SET = 1076391951;
 static const int RTC_WKALM_RD = 2150133776;
 typedef long int time_t;


### PR DESCRIPTION
Do it like busybox & Nickel

The other approach would be a WKALM_RD + WKALM_SET.
I'm not *quite* sure what the previous behavior was actually doing
(No idea what an epoch set to -1 actually does in practice?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1106)
<!-- Reviewable:end -->
