### PR TITLE
Update zsync2

### DIFF
--- a/thirdparty/zsync2/CMakeLists.txt
+++ b/thirdparty/zsync2/CMakeLists.txt
@@ -72,7 +72,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/zsync2.git
-    7565c081d581706c6a7859cf41eec976811180b6
+    e618d18f6a7cbf350cededa17ddfe8f76bdf0b5c
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Resync w/ upstream
Properly handle filesystems that don't support hard-links, like legacy
zsync used to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1108)
<!-- Reviewable:end -->
