### PR TITLE
thirdparty/harfbuzz 2.6.7

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -44,7 +44,7 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
-set(HB_VER 2.6.6)
+set(HB_VER 2.6.7)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
> As a part of our migration to meson, this release will be the last one
to provide cmake port files but autotools still is our main build system.
There is a possibility that the next version or the after be released
using meson.

<https://github.com/harfbuzz/harfbuzz/releases/tag/2.6.7>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1109)
<!-- Reviewable:end -->
