### PR TITLE
add lua-rapidjson

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(USE_LJ_WPACLIENT),$(LJ_WPACLIENT),) \
 		$(TURBO_FFI_WRAP_LIB) \
 		$(LUA_HTMLPARSER_ROCK) \
+		$(LUA_RAPIDJSON_ROCK) \
 		$(LUA_SPORE_ROCK) \
 		$(if $(ANDROID),$(LPEG_DYNLIB) $(LPEG_RE),) \
 		$(if $(WIN32),,$(ZMQ_LIB) $(CZMQ_LIB) $(FILEMQ_LIB) $(ZYRE_LIB)) \

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -847,6 +847,10 @@ LUA_HTMLPARSER_VER=scm-0
 LUA_HTMLPARSER_BUILD_DIR=$(THIRDPARTY_DIR)/lua-htmlparser/build/$(MACHINE)
 LUA_HTMLPARSER_ROCK=$(LUAROCKS_DIR)/lua-htmlparser/htmlparser-$(LUA_HTMLPARSER_VER).rockspec
 
+LUA_RAPIDJSON_VER=0.6.1-1
+LUA_RAPIDJSON_BUILD_DIR=$(THIRDPARTY_DIR)/lua-rapidjson/build/$(MACHINE)
+LUA_RAPIDJSON_ROCK=$(LUAROCKS_DIR)/lua-rapidjson/rapidjson-$(LUA_RAPIDJSON_VER).rockspec
+
 LUA_SPORE_BUILD_DIR=$(THIRDPARTY_DIR)/lua-Spore/build/$(MACHINE)
 LUA_SPORE_DIR=$(CURDIR)/$(LUA_SPORE_BUILD_DIR)/lua-Spore-prefix/src/lua-Spore
 SPORE_VER=0.3.1-1
@@ -920,7 +924,7 @@ CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),evernote-sdk-lua,luajit,lpeg,t
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),zyre,czmq,filemq,libzmq
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),libk2pdfopt,tesseract,leptonica
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),lj-wpaclient
-CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),lua-htmlparser,lua-Spore,luasec,luasocket,libffi,lua-serialize,glib,lodepng,minizip
+CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),lua-htmlparser,lua-rapidjson,lua-Spore,luasec,luasocket,libffi,lua-serialize,glib,lodepng,minizip
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),djvulibre,mupdf,freetype2,harfbuzz,giflib,libpng,zlib
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),tar,sdcv,libiconv,gettext,libjpeg-turbo,popen-noshell,sqlite
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),openssl,dropbear,openssh

--- a/Makefile.third
+++ b/Makefile.third
@@ -696,6 +696,26 @@ $(LUA_HTMLPARSER_ROCK): $(THIRDPARTY_DIR)/lua-htmlparser/*.*
 		$(CURDIR)/$(THIRDPARTY_DIR)/lua-htmlparser && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 
+$(LUA_RAPIDJSON_ROCK): $(THIRDPARTY_DIR)/lua-rapidjson/*.*
+	install -d $(LUA_RAPIDJSON_BUILD_DIR)
+	-rm -f $(LUA_RAPIDJSON_ROCK)
+	cd $(LUA_RAPIDJSON_BUILD_DIR) && \
+		$(CMAKE) $(CMAKE_FLAGS) -DOUTPUT_DIR="$(CURDIR)/$(OUTPUT_DIR)" \
+		-DLUA_RAPIDJSON_VER=$(LUA_RAPIDJSON_VER) \
+		-DCC="$(CC)" \
+		-DCXX="$(CXX)" \
+		-DCFLAGS="$(CFLAGS)"\
+		-DCXXFLAGS="$(CXXFLAGS)" \
+		-DLDFLAGS="$(LDFLAGS)" \
+		-I$(LUAJIT_DIR)/src \
+		-DLUAROCKS=$(if $(DARWINHOST),"luarocks --lua-dir=/usr/local/opt/lua@5.1",luarocks) \
+		-DLUA_INCDIR=$(if $(DARWINHOST),/usr/local/opt/lua@5.1/include/lua5.1,"$(LUAJIT_DIR)/src") \
+		-DLUA_LIBDIR=$(if $(DARWINHOST),/usr/local/opt/lua@5.1/lib,"$(abspath $(CURDIR)/$(dir $(LUAJIT_LIB)))") \
+		$(if $(ANDROID),-DLUALIB="$(notdir $(LUAJIT_LIB))",) \
+		$(if $(ANDROID),-DLIBFLAG="-lm $(CURDIR)/$(LUAJIT_LIB)",) \
+		$(CURDIR)/$(THIRDPARTY_DIR)/lua-rapidjson && \
+		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
+
 # override lpeg built by luarocks, this is only necessary for Android
 $(LPEG_DYNLIB) $(LPEG_RE): $(LUAJIT_LIB) $(THIRDPARTY_DIR)/lpeg/*.*
 	install -d $(OUTPUT_DIR)/rocks/lib/lua/5.1

--- a/thirdparty/lua-rapidjson/CMakeLists.txt
+++ b/thirdparty/lua-rapidjson/CMakeLists.txt
@@ -1,0 +1,54 @@
+project(lua-rapidjson)
+cmake_minimum_required(VERSION 3.5.1)
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
+include("koreader_thirdparty_common")
+include("koreader_thirdparty_git")
+
+enable_language(C CXX)
+
+assert_var_defined(CC)
+assert_var_defined(CFLAGS)
+assert_var_defined(CXX)
+assert_var_defined(CXXFLAGS)
+assert_var_defined(LDFLAGS)
+assert_var_defined(LUA_INCDIR)
+assert_var_defined(LUA_LIBDIR)
+assert_var_defined(LUA_RAPIDJSON_VER)
+assert_var_defined(OUTPUT_DIR)
+assert_var_defined(LUAROCKS)
+
+ep_get_source_dir(SOURCE_DIR)
+
+set(LUA_RAPIDJSON_ROCKSPEC rapidjson-${LUA_RAPIDJSON_VER}.rockspec)
+set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/lua-rapidjson-never-native.patch")
+if(DEFINED ENV{ANDROID})
+    set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/lua-rapidjson-android-link-to-lua.patch")
+endif()
+
+set(BUILD_CMD sh -c "${LUAROCKS} make --tree=${OUTPUT_DIR}/rocks ${LUA_RAPIDJSON_ROCKSPEC}")
+set(BUILD_CMD "${BUILD_CMD} CC=\"${CC}\" CXX=\"${CXX}\"")
+set(BUILD_CMD "${BUILD_CMD} CFLAGS=\"${CFLAGS}\" CXXFLAGS=\"${CXXFLAGS}\" LDFLAGS=\"${LDFLAGS} ${LIBFLAG}\"")
+set(BUILD_CMD "${BUILD_CMD} LUA_INCDIR=\"${LUA_INCDIR}\" LUA_LIBDIR=\"${LUA_LIBDIR}\" LUALIB=\"${LUALIB}\"")
+if(DEFINED LIBFLAG)
+    set(BUILD_CMD "${BUILD_CMD} LIBFLAG=\"${LIBFLAG}\"")
+endif()
+
+ko_write_gitclone_script(
+    GIT_CLONE_SCRIPT_FILENAME
+    https://github.com/xpol/lua-rapidjson
+    75bdc42fa822377ebc2acbeda6b2feaf35e8752b
+    ${SOURCE_DIR}
+)
+
+include(ExternalProject)
+ExternalProject_Add(
+    ${PROJECT_NAME}
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
+    PATCH_COMMAND COMMAND ${PATCH_CMD} COMMAND ${PATCH_CMD2}
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ${BUILD_CMD}
+    # skip install
+    INSTALL_COMMAND ""
+)

--- a/thirdparty/lua-rapidjson/lua-rapidjson-android-link-to-lua.patch
+++ b/thirdparty/lua-rapidjson/lua-rapidjson-android-link-to-lua.patch
@@ -1,0 +1,32 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d85260b..46dcfb1 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -79,9 +79,9 @@ endif()
+ 
+ source_group(src FILES ${SOURCES})
+ 
+-if (WIN32)
+-    target_link_libraries(lua-rapidjson ${LUA_LIBRARIES})
+-endif()
++target_link_libraries(lua-rapidjson m ${LUA_LIBRARIES})
++# NOTE: C++, that's a terrible idea (and will fail to build ;)).
++#target_link_options(lua-rapidjson PRIVATE -nostartfiles)
+ 
+ if (LINK_FLAGS)
+     set_target_properties(lua-rapidjson PROPERTIES
+diff --git a/rapidjson-0.6.1-1.rockspec b/rapidjson-0.6.1-1.rockspec
+index aebdc35..5329b39 100644
+--- a/rapidjson-0.6.1-1.rockspec
++++ b/rapidjson-0.6.1-1.rockspec
+@@ -20,9 +20,7 @@ build = {
+     BUILD_SHARED_LIBS = "ON",
+     CMAKE_INSTALL_PREFIX = "$(PREFIX)",
+     LUA_INCLUDE_DIR = "$(LUA_INCDIR)",
++    LUA_LIBRARIES = "$(LUA_LIBDIR)/$(LUALIB)",
+     LUA_RAPIDJSON_VERSION = v
+   },
+-  platforms = { windows = { variables = {
+-    LUA_LIBRARIES = "$(LUA_LIBDIR)/$(LUALIB)"
+-  }}}
+ }

--- a/thirdparty/lua-rapidjson/lua-rapidjson-never-native.patch
+++ b/thirdparty/lua-rapidjson/lua-rapidjson-never-native.patch
@@ -1,0 +1,15 @@
+diff -uNr a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2020-06-08 19:24:43.384755608 +0200
++++ b/CMakeLists.txt	2020-06-08 19:25:26.545655140 +0200
+@@ -32,11 +32,6 @@
+         set(LINK_FLAGS "-shared")
+     endif(APPLE)
+     add_compile_options(-g -Wall -fPIC)
+-    include(CheckCXXCompilerFlag)
+-    CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_ARCH_NATIVE)
+-    if (COMPILER_SUPPORTS_ARCH_NATIVE)
+-        add_compile_options(-march=native)
+-    endif()
+ else(UNIX)
+     if(WIN32)
+         set(PLAT "win32")


### PR DESCRIPTION
Decodes **2-10x** faster than current json lib (with minimal memory footprint), supports pretty print and has nice functions to load/dump tables from/to JSON files.

Mainly to use when speed could be an issue, like in https://github.com/koreader/koreader/pull/6177

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1113)
<!-- Reviewable:end -->
