### PR TITLE
thirdparty/djvulibre Bump to latest master

### DIFF
--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://gitlab.com/koreader/djvulibre.git
-    8cb2151866c1147ceb79348c666a81053bedcd11
+    32ff0948c5bc27c0b7507dba90e726fc941fcc42
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/djvulibre/android.patch
+++ b/thirdparty/djvulibre/android.patch
@@ -12,20 +12,3 @@ index f72a4c9..51b2ce3 100644
  
  #include "DjVuToPS.h"
  #include "IFFByteStream.h"
-diff --git a/libdjvu/GThreads.cpp b/libdjvu/GThreads.cpp
-index 0b0fe0a..afb28b0 100644
---- a/libdjvu/GThreads.cpp
-+++ b/libdjvu/GThreads.cpp
-@@ -446,10 +449,11 @@ GThread::create(void (*entry)(void*), void *arg)
- void 
- GThread::terminate()
- {
-+#ifndef __ANDROID__
-   if (xentry || xarg)
-     pthread_cancel(hthr);
-+#endif
- }
--
- int
- GThread::yield()
- {


### PR DESCRIPTION
Nothing of much importance besides perhaps a few ARM64 fixes, and [8e79901a927d7b20b629f5240e64f617d67f3dff](https://gitlab.com/koreader/djvulibre/-/commit/8e79901a927d7b20b629f5240e64f617d67f3dff) deprecates part of our Android patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1119)
<!-- Reviewable:end -->
