### PR TITLE
Bump evernote-lua-sdk(fix 印象笔记)

### DIFF
--- a/thirdparty/evernote-sdk-lua/CMakeLists.txt
+++ b/thirdparty/evernote-sdk-lua/CMakeLists.txt
@@ -17,7 +17,7 @@ set(BUILD_CMD sh -c "${KO_MAKE_RECURSIVE} -j1 -C thrift CC=\"${CC}\" LDFLAGS=\"$
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/evernote-sdk-lua
-    45d81cf11588e3c8f1c517395dde706ef5979313
+    b6d8bed1fecb95b062f719dcad3cd720048c623a
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Bump evernote-sdk-version to https://github.com/koreader/evernote-sdk-lua/commit/b6d8bed1fecb95b062f719dcad3cd720048c623a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1121)
<!-- Reviewable:end -->
