### PR TITLE
thirdparty/harfbuzz 2.6.8

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -44,7 +44,7 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
-set(HB_VER 2.6.7)
+set(HB_VER 2.6.8)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
> Meson build fixes, cmake port removal is postponed but please prepare for
it and give us feedback.
> Autotools is still our main build system however please consider
experimenting with meson also for packaging the library.

<https://github.com/harfbuzz/harfbuzz/releases/tag/2.6.8>

So, given that we don't use CMake, /shrug. ^_^

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1122)
<!-- Reviewable:end -->
