### PR TITLE
remove W>H startup rotation

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -78,19 +78,15 @@ function fb:init()
     -- asking the framebuffer for orientation is error prone,
     -- so we do this simple heuristic (for now)
     self.screen_size = self:getSize()
-    if self.screen_size.w > self.screen_size.h then
-        self.native_rotation_mode = self.ORIENTATION_LANDSCAPE
+    if self.screen_size.w > self.screen_size.h and self.device:isAlwaysPortrait() then
         self.screen_size.w, self.screen_size.h = self.screen_size.h, self.screen_size.w
-        if self.device:isAlwaysPortrait() then
-            -- some framebuffers need to be rotated counter-clockwise (they start in landscape mode)
-            self.debug("enforcing portrait mode by doing an initial rotation")
-            self.bb:rotate(-90)
-            self.blitbuffer_rotation_mode = self.bb:getRotation()
-            self.native_rotation_mode = self.ORIENTATION_PORTRAIT
-        end
-    else
+        -- some framebuffers need to be rotated counter-clockwise (they start in landscape mode)
+        self.debug("enforcing portrait mode by doing an initial rotation")
+        self.bb:rotate(-90)
+        self.blitbuffer_rotation_mode = self.bb:getRotation()
         self.native_rotation_mode = self.ORIENTATION_PORTRAIT
     end
+    self.native_rotation_mode = self.ORIENTATION_PORTRAIT
     self.cur_rotation_mode = self.native_rotation_mode
 end
 

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -84,7 +84,6 @@ function fb:init()
         self.debug("enforcing portrait mode by doing an initial rotation")
         self.bb:rotate(-90)
         self.blitbuffer_rotation_mode = self.bb:getRotation()
-        self.native_rotation_mode = self.ORIENTATION_PORTRAIT
     end
     self.native_rotation_mode = self.ORIENTATION_PORTRAIT
     self.cur_rotation_mode = self.native_rotation_mode

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -315,22 +315,6 @@ function fb:setRotationMode(mode)
     self.cur_rotation_mode = mode
 end
 
--- Handles orientation changes as requested...
--- All even orientations are Portrait (0 and 2), the larger one being the Inverted variant
--- All odd orientations are Landscape (1 and 3), the larger one being the Inverted variant
-function fb:setScreenMode(mode)
-    if mode == "portrait" and bit.band(self.cur_rotation_mode, 1) == 1 then
-        -- We were in a Landscape orientation (odd number), swap to Portrait (UR)
-        self:setRotationMode(self.ORIENTATION_PORTRAIT)
-    elseif mode == "landscape" and bit.band(self.cur_rotation_mode, 1) == 0 then
-        -- We were in a Portrait orientation (even number), swap to Landscape (CW or CCW, depending on user preference)
-        self:setRotationMode(
-            DLANDSCAPE_CLOCKWISE_ROTATION
-            and self.ORIENTATION_LANDSCAPE
-            or self.ORIENTATION_LANDSCAPE_ROTATED)
-    end
-end
-
 function fb:getWindowTitle()
     return self.window_title
 end

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -6,7 +6,6 @@ This will be extended by implementations of this API.
 @module ffi.framebuffer
 --]]
 
-local bit = require("bit")
 local Blitbuffer = require("ffi/blitbuffer")
 
 local fb = {

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -81,7 +81,9 @@ function fb:init()
     if self.screen_size.w > self.screen_size.h and self.device:isAlwaysPortrait() then
         self.screen_size.w, self.screen_size.h = self.screen_size.h, self.screen_size.w
         -- some framebuffers need to be rotated counter-clockwise (they start in landscape mode)
-        self.debug("enforcing portrait mode by doing an initial rotation")
+        io.write("FB: Enforcing portrait mode by doing an initial BB rotation")
+        io.flush()
+        self.debug("FB: This prevents the use of blitting optimizations. This should instead be fixed on the device's side on startup.")
         self.bb:rotate(-90)
         self.blitbuffer_rotation_mode = self.bb:getRotation()
     end


### PR DESCRIPTION
It was broken (only the FB was rotated not the touch) and prevents using a W>H device

this keeps `isAlwaysPortrait()` for devices that have a bad starting orientation (can be set in the emulator with EMULATE_READER_FORCE_PORTRAIT)

to test try `kodev run -h=600 -w=800`. Fixes: koreader/koreader#5910 may need koreader/koreader#6309 to be complete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1128)
<!-- Reviewable:end -->
