### PR TITLE
android: resize buffer

### DIFF
--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -54,13 +54,20 @@ function framebuffer:init()
     -- we present this buffer to the outside
     self.bb = BB.new(android.screen.width, android.screen.height, BB.TYPE_BBRGB32)
     self.invert_bb = BB.new(android.screen.width, android.screen.height, BB.TYPE_BBRGB32)
-    -- TODO: should we better use these?
-    -- android.lib.ANativeWindow_getWidth(window)
-    -- android.lib.ANativeWindow_getHeight(window)
     self.bb:fill(BB.COLOR_WHITE)
     self:_updateWindow()
-
     framebuffer.parent.init(self)
+end
+
+-- resize on rotation or split view.
+function framebuffer:resize()
+    android.screen.width = android.getScreenWidth()
+    android.screen.height = android.getScreenHeight()
+    self.bb:free()
+    self.bb = BB.new(android.screen.width, android.screen.height, BB.TYPE_BBRGB32)
+    self.invert_bb = BB.new(android.screen.width, android.screen.height, BB.TYPE_BBRGB32)
+    self.bb:fill(BB.COLOR_WHITE)
+    self:_updateWindow()
 end
 
 function framebuffer:_updateWindow()


### PR DESCRIPTION
As suggested by @Frenzie in https://github.com/koreader/android-luajit-launcher/pull/210#issuecomment-570514091

This unblocks a few things, namely:

- Native rotation on android
- Split view on android
- Platforms that require a resizable window: Chrome OS and Anbox

Also removed the (old) comments. It is not better to use NDK calls to get height and width, since our own sdk methods take care of oddities between APIs and fullscreen status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1130)
<!-- Reviewable:end -->
