### PR TITLE
Resync orderedPairs w/ upstream

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -582,53 +582,49 @@ function util.idiv(a, b)
     return (q > 0) and math.floor(q) or math.ceil(q)
 end
 
---- Equivalent of the pairs() function on tables. Allows to iterate in order.
-function util.orderedPairs(t) return end
-do -- limits scope
-    local function __genOrderedIndex( t )
-    -- this function is taken from http://lua-users.org/wiki/SortedIteration
-        local orderedIndex = {}
-        for key in pairs(t) do
-            table.insert( orderedIndex, key )
-        end
-        table.sort( orderedIndex )
-        return orderedIndex
+-- pairs(), but with *keys* sorted alphabetically.
+-- c.f., http://lua-users.org/wiki/SortedIteration
+-- See also http://lua-users.org/wiki/SortedIterationSimple
+local function __genOrderedIndex( t )
+    local orderedIndex = {}
+    for key in pairs(t) do
+        table.insert( orderedIndex, key )
     end
+    table.sort( orderedIndex )
+    return orderedIndex
+end
 
-    local function orderedNext(t, state)
-        -- this function is taken from http://lua-users.org/wiki/SortedIteration
-        -- Equivalent of the next function, but returns the keys in the alphabetic
-        -- order. We use a temporary ordered key table that is stored in the
-        -- table being iterated.
-        local key
-        if state == nil then
-            -- the first time, generate the index
-            t.__orderedIndex = __genOrderedIndex( t )
-            key = t.__orderedIndex[1]
-            return key, t[key]
-        end
+local function orderedNext(t, state)
+    -- Equivalent of the next function, but returns the keys in the alphabetic order.
+    -- We use a temporary ordered key table that is stored in the table being iterated.
+
+    local key = nil
+    --print("orderedNext: state = "..tostring(state) )
+    if state == nil then
+        -- the first time, generate the index
+        t.__orderedIndex = __genOrderedIndex( t )
+        key = t.__orderedIndex[1]
+    else
         -- fetch the next value
         for i = 1,table.getn(t.__orderedIndex) do
             if t.__orderedIndex[i] == state then
                 key = t.__orderedIndex[i+1]
             end
         end
-
-        if key then
-            return key, t[key]
-        end
-
-        -- no more value to return, cleanup
-        t.__orderedIndex = nil
-        return
     end
 
-    function util.orderedPairs(t)
-        -- this function is taken from http://lua-users.org/wiki/SortedIteration
-        -- Equivalent of the pairs() function on tables. Allows to iterate
-        -- in order
-        return orderedNext, t, nil
+    if key then
+        return key, t[key]
     end
+
+    -- no more value to return, cleanup
+    t.__orderedIndex = nil
+    return
+end
+
+function util.orderedPairs(t)
+    -- Equivalent of the pairs() function on tables. Allows to iterate in order
+    return orderedNext, t, nil
 end
 
 --[[--


### PR DESCRIPTION
(There was an early potentially bogus return).

Also, that do block for scoping was funky as hell.
We're already in a dedicated module, using local functions for the
private ones and a namespace ffor the public ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1140)
<!-- Reviewable:end -->
