### PR TITLE
remarkable: fix button-listen when resuming from suspend

### DIFF
--- a/button-listen.c
+++ b/button-listen.c
@@ -2,12 +2,13 @@
 #include <stdio.h>
 #include <time.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
-static double timeval_diff(struct timeval const* start, struct timeval const* end)
+static double timespec_diff(struct timespec const* start, struct timespec const* end)
 {
-    double s = (double)end->tv_sec - (double)start->tv_sec;
-    double us = (double)end->tv_usec - (double)start->tv_usec;
-    return s + (us / 1e6);
+    double s = difftime(end->tv_sec, (double)start->tv_sec);
+    double ns = (double)end->tv_nsec - (double)start->tv_nsec;
+    return s + (ns / 1e9);
 }
 
 int main(int argc, char** argv)
@@ -19,22 +20,28 @@ int main(int argc, char** argv)
     }
 
     struct input_event ev;
-    struct timeval press_stamp = {0};
+    struct timespec press_time = {0};
+    bool pressed = false;
     while(1) {
         size_t sz = fread(&ev, sizeof(ev), 1, evf);
         if(sz == 0) {
             return 1;
         }
         if(ev.type == EV_KEY && ev.code == KEY_HOME) {
-            if(ev.value == 0) { /* keyrelease */
-                double t = timeval_diff(&press_stamp, &ev.time);
+            if(ev.value == 0 && pressed) { /* keyrelease */
+                struct timespec now;
+                clock_gettime(CLOCK_BOOTTIME, &now);
+                double t = timespec_diff(&press_time, &now);
+                /* Require a press event before processing another release */
+                pressed = false;
                 /* hold home (middle) button for 3 seconds to start koreader */
                 if(t >= 3.0) {
                     system("systemctl start koreader");
                 }
             }
             else if(ev.value == 1) { /* keypress */
-                press_stamp = ev.time;
+                clock_gettime(CLOCK_BOOTTIME, &press_time);
+                pressed = true;
             }
         }
     }


### PR DESCRIPTION
When the home button is used to wake the device from suspend the evdev
events have surprising time stamps. There is a pair of press & release
events, but the press has a timestamp from when the device went into
suspend and the release has a timestamp from after. This means that the
wake keypress will launch koreader as button-listen thinks the key was
held down for the whole time the device was suspended!

Instead, just record CLOCK_BOOTTIME timestamps for the events and use
those instead of the event timestamps. CLOCK_BOOTTIME is monotonic but
includes time spend in suspend.

Also keep track of whether button-listen saw a key press before each key
release. Probably not strictly required but seemed sensible to add.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1145)
<!-- Reviewable:end -->
