### PR TITLE
wip: desktop loader, working on osx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(ANDROID),$(LPEG_DYNLIB) $(LPEG_RE),) \
 		$(if $(WIN32),,$(ZMQ_LIB) $(CZMQ_LIB) $(FILEMQ_LIB) $(ZYRE_LIB)) \
 		$(if $(WIN32),,$(OUTPUT_DIR)/sdcv) \
+		$(if $(or $(APPIMAGE),$(DEBIAN),$(DEBIAN_CROSS),$(MACOS)),$(OUTPUT_DIR)/koreader,) \
 		$(if $(MACOS),$(SDL2_LIB),) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/dropbear,) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
@@ -209,6 +210,13 @@ ffi/lodepng_h.lua: ffi-cdecl/lodepng_decl.c $(LODEPNG_DIR)
 
 # include all third party libs
 include Makefile.third
+
+# ===========================================================================
+# entry point for the desktop application
+
+$(OUTPUT_DIR)/koreader: desktop_loader.c
+	$(CC) $(LOADER_FLAGS) \
+	-I$(LUAJIT_DIR)/src $(LUAJIT_STATIC) -o $@ $^
 
 # ===========================================================================
 # very simple "launcher" for koreader on the remarkable

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -188,9 +188,15 @@ ifdef DARWINHOST
 	endif
 endif
 
+ifdef DARWINHOST
+	LOADER_FLAGS=-pagezero_size 10000 -image_base 100000000 -framework CoreGraphics
+else
+	LOADER_FLAGS=-L/usr/X11/lib -L/usr/X11R6/lib -lX11
+endif
+
 USE_LUAJIT_LIB=$(or $(DARWIN),$(ANDROID),$(WIN32))
 
-SKIP_LUAJIT_BIN=$(or $(ANDROID),)
+SKIP_LUAJIT_BIN=$(or $(ANDROID),$(MACOS))
 
 # handle utility params on different host systems
 ifdef DARWINHOST
@@ -695,6 +701,7 @@ LUAJIT_DIR=$(CURDIR)/$(LUAJIT_BUILD_DIR)/luajit-prefix/src/luajit
 LUAJIT=$(OUTPUT_DIR)/$(if $(WIN32),luajit.exe,luajit)
 LUAJIT_JIT=$(OUTPUT_DIR)/jit
 LUAJIT_LIB=$(OUTPUT_DIR)/$(if $(WIN32),lua51.dll,libs/libluajit.so)
+LUAJIT_STATIC=$(LUAJIT_DIR)/src/libluajit.a
 
 POPEN_NOSHELL_BUILD_DIR=$(THIRDPARTY_DIR)/popen-noshell/build/$(MACHINE)
 POPEN_NOSHELL_DIR=$(CURDIR)/$(POPEN_NOSHELL_BUILD_DIR)/popen-noshell-prefix/src/popen-noshell

--- a/desktop_loader.c
+++ b/desktop_loader.c
@@ -1,0 +1,181 @@
+/* Entry point for the desktop application */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/syslimits.h>
+
+#include "lua.h"
+#include "lualib.h"
+#include "lauxlib.h"
+
+#include "desktop_platform.h"
+
+#define PLATFORM "KO_MULTIUSER"
+#define LANGUAGE "en_US.UTF-8"
+#define USER_CONFIG ".config/koreader/settings/desktop.lua"
+
+#define ENV_TOP "KOREADER_WINDOW_POS_Y"
+#define ENV_LEFT "KOREADER_WINDOW_POS_X"
+#define ENV_WIDTH "EMULATE_READER_W"
+#define ENV_HEIGHT "EMULATE_READER_H"
+
+#define ERROR_ARGS "failed setting arguments: %s\n"
+#define ERROR_FILE "failed running lua script: %s\n"
+
+struct Window {
+    int top, left, width, height;
+};
+
+const char* getConfigFile(void) {
+    static char path[PATH_MAX];
+    char *homedir = getenv("HOME");
+    if (homedir != NULL) {
+        sprintf(path, "%s/%s", homedir, USER_CONFIG);
+        return (const char*)path;
+    }
+    return NULL;
+}
+
+void setEnv(const char *name, int n) {
+    if (n > 0) {
+        char value[8];
+        sprintf(value, "%d", n);
+        setenv(name, value, 1);
+    }
+}
+
+int getInt(lua_State *L, const char *key) {
+    int value = 0;
+    if (lua_istable(L, -1)) {
+        lua_pushstring(L, key);
+        lua_gettable(L, -2);
+        value = lua_tonumber(L, -1);
+        lua_pop(L, 1);
+    }
+    return value;
+}
+
+struct Window loadWindow(lua_State *L, const char *file) {
+    struct Window w = { 0, 0, 0, 0 };
+    int err = luaL_dofile(L, file);
+    if (!err) {
+        w.top = getInt(L, "top");
+        w.left = getInt(L, "left");
+        w.width = getInt(L, "width");
+        w.height = getInt(L, "height");
+    }
+    lua_pop(L, 1);
+    return w;
+
+}
+
+int fitsInScreen(struct Window w, struct ScreenSize s) {
+    if ((w.top + w.height <= s.height) && (w.left + w.width <= s.width)) {
+        return 1;
+    }
+    return 0;
+}
+
+void logAndDie(const char* msg) {
+    fprintf(stderr, "[%s]: %s\n", LOGNAME, msg);
+    exit(EXIT_FAILURE);
+}
+
+
+int main(int argc, const char * argv[]) {
+    int appImage = isAppImage();
+
+    if (!appImage) {
+        char *binary_dir = binaryPath();
+        if (binary_dir == NULL)
+            logAndDie("unable to get executable path");
+
+        char *assets_dir = assetsDir();
+        if (assets_dir == NULL)
+            logAndDie("unable to get assets path");
+
+        if (chdir(binary_dir) != 0)  
+            logAndDie("unable to chdir to executable path");
+        
+        if (chdir(assets_dir) != 0)
+            fprintf(stdout, "[%s]: unable to chdir to assets, using cwd\n", LOGNAME);
+
+        if (setenv(PLATFORM, "1", 1) != 0)
+            logAndDie("unable to set environment for desktop platforms");
+    }	
+   
+    if (setenv("LC_ALL", LANGUAGE, 1) != 0)
+        logAndDie("unable to set language, please check your locales");
+
+    lua_State *L = luaL_newstate();
+    luaL_openlibs(L);
+
+    int windowFits = 0;
+
+    const char* luaFile = getConfigFile();
+    if (luaFile != NULL) {
+
+        struct Window w;
+        struct ScreenSize s;
+
+        w = loadWindow(L, luaFile);
+        s = getScreenSize();
+
+        windowFits = fitsInScreen(w, s);
+
+        if (windowFits) {
+            setEnv(ENV_TOP, w.top);
+            setEnv(ENV_LEFT, w.left);
+            setEnv(ENV_WIDTH, w.width);
+            setEnv(ENV_HEIGHT, w.height);
+        }
+    }
+
+    int retval;
+    if (argc == 1) {
+        retval = luaL_dostring(L, "arg = { os.getenv('HOME') }");
+        if (retval) {
+            fprintf(stderr, ERROR_ARGS, lua_tostring(L, -1));
+            goto quit;
+        }
+
+    } else {
+        retval = luaL_dostring(L, "arg = {}");
+        if (retval) {
+            fprintf(stderr, ERROR_ARGS, lua_tostring(L, -1));
+            goto quit;
+        }
+        char buffer[PATH_MAX];
+        for (int i = 1; i < argc; ++i) {
+            if (snprintf(buffer, PATH_MAX, "table.insert(arg, '%s')", argv[i]) >= 0) {
+                retval = luaL_dostring(L, buffer);
+                if (retval) {
+                    fprintf(stderr, ERROR_ARGS, lua_tostring(L, -1));
+                    goto quit;
+                }
+            }
+        }
+    }
+
+    retval = luaL_dofile(L, "reader.lua");
+    if (retval)
+        fprintf(stderr, ERROR_FILE, lua_tostring(L, -1));
+
+    goto quit;
+
+quit:
+    lua_close(L);
+    unsetenv("LC_ALL");
+    if (!appImage)
+        unsetenv(PLATFORM);
+
+    if (windowFits) {
+        unsetenv(ENV_TOP);
+        unsetenv(ENV_LEFT);
+        unsetenv(ENV_WIDTH);
+        unsetenv(ENV_HEIGHT);
+    }
+
+    return retval;
+}

--- a/desktop_platform.h
+++ b/desktop_platform.h
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+#include <libgen.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#include <sys/errno.h>
+#include <sys/syslimits.h>
+#include <CoreGraphics/CGDirectDisplay.h>
+
+#elif __linux__
+#include <errno.h>
+#include <limits.h>
+#include <X11/Xlib.h>
+
+#endif
+
+#define LOGNAME "Desktop loader"
+
+struct ScreenSize {
+    int width, height;
+};
+
+struct ScreenSize getScreenSize(void) {
+    struct ScreenSize screenSize = { 0 , 0 };
+#ifdef __APPLE__
+    CGDirectDisplayID id = CGMainDisplayID();
+    screenSize.width = CGDisplayPixelsWide(id);
+    screenSize.height = CGDisplayPixelsHigh(id);
+#elif __LINUX
+    Display *display = XOpenDisplay(NULL);
+    if (display != NULL) {
+        Screen *screen = XDefaultScreenOfDisplay(display);
+        if (screen != NULL {
+            screenSize.width = screen->width;
+            screenSize.height = screen->height;
+        }
+        XCloseDisplay(display);
+    }
+#endif
+    return screenSize;
+}
+
+
+int isAppImage(void) {
+#ifdef __linux__
+    if (getenv("APPIMAGE") != NULL)
+        return 1;
+    else
+        return 0;
+#else
+    return 0;
+#endif
+}
+
+char* assetsDir(void) {
+#ifdef __APPLE__
+    /* KOReader.app/Contents/MacOS -> KOReader.app/Contents/koreader */
+    return "../koreader";
+#elif __linux__
+    /* /usr/bin -> /usr/lib/koreader
+       /usr/local/bin -> /usr/local/lib/koreader
+    */
+    return "../lib/koreader";
+#else
+    return NULL;
+#endif
+}
+
+char* binaryPath(void) {
+    static char path[PATH_MAX];
+#ifdef __APPLE__
+    char buffer[PATH_MAX];
+    uint32_t size = sizeof(buffer);
+    if (_NSGetExecutablePath(buffer, &size) != 0) {
+        return NULL;
+    }
+    int len = readlink(buffer, path, sizeof(path));
+    if (len == -1) {
+        if (errno != EINVAL) {
+            fprintf(stderr, "[%s]: %s\n", LOGNAME, strerror(errno));
+            return NULL;
+        } else {
+            strncpy(path, buffer, sizeof(buffer));
+            return dirname(path);
+        }
+    } else {
+        path[len] = '\0';
+        fprintf(stderr, "[%s]: symbolic links not allowed\n", LOGNAME);
+        fprintf(stderr, "[%s]: please append %s to your PATH\n", LOGNAME, dirname(path));
+        return NULL;
+    }
+#elif __linux__
+    int len = readlink("/proc/self/exe", path, sizeof(path));
+    if (len == -1) {
+        fprintf(stderr, "[%s]: %s\n", LOGNAME, strerror(errno));
+        return NULL;
+    } else {
+        path[len] = '\0';
+        return dirname(path);
+    }
+#else
+    return NULL;
+#endif
+}

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -167,7 +167,8 @@ local function handleWindowEvent(event_window)
         SDL.SDL_RenderCopy(S.renderer, S.texture, nil, nil)
         SDL.SDL_RenderPresent(S.renderer)
     elseif (event_window.event == SDL.SDL_WINDOWEVENT_RESIZED
-             or event_window.event == SDL.SDL_WINDOWEVENT_SIZE_CHANGED) then
+             or event_window.event == SDL.SDL_WINDOWEVENT_SIZE_CHANGED
+             or event_window.event == SDL.SDL_WINDOWEVENT_MOVED) then
         genEmuEvent(EV_SDL, event_window.event, event_window)
     end
 end

--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -10,7 +10,9 @@ enable_language(C)
 
 ep_get_source_dir(SOURCE_DIR)
 
-# override process name, remove workarounds for standalone applications
+# remove workarounds for standalone applications and add a couple of actions
+# to be used from the osx main menu.
+
 set(PATCH_CMD "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/cocoa.patch")
 
 set(SDL2_VER "2.0.12")

--- a/thirdparty/sdl2/cocoa.patch
+++ b/thirdparty/sdl2/cocoa.patch
@@ -1,7 +1,50 @@
-diff -uNr a/src/video/cocoa/SDL_cocoaevents.m b/src/video/cocoa/SDL_cocoaevents.m
+diff -uNr a/src/video/cocoa/SDL_cocoaevents.m e/src/video/cocoa/SDL_cocoaevents.m
 --- a/src/video/cocoa/SDL_cocoaevents.m	2020-03-11 02:36:18.000000000 +0100
-+++ b/src/video/cocoa/SDL_cocoaevents.m	2020-07-19 14:50:50.000000000 +0200
-@@ -233,47 +233,12 @@
++++ e/src/video/cocoa/SDL_cocoaevents.m	2020-07-28 21:40:49.000000000 +0200
+@@ -34,6 +34,18 @@
+ #define kIOPMAssertPreventUserIdleDisplaySleep kIOPMAssertionTypePreventUserIdleDisplaySleep
+ #endif
+ 
++static void _openUrl(NSString *url) {
++    [[NSWorkspace sharedWorkspace] openURL:[NSURL URLWithString:url]];
++}
++
++static void _openFile(NSString *file, NSString *app) {
++    NSString *path = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:file];
++    if (path) {
++        if (!app) app = @"TextEdit";
++        [[NSWorkspace sharedWorkspace] openFile:path withApplication:app];
++    }
++}
++
+ @interface SDLApplication : NSApplication
+ 
+ - (void)terminate:(id)sender;
+@@ -45,6 +57,23 @@
+ 
+ @implementation SDLApplication
+ 
++/* KOReader specific actions */
++- (IBAction) openWeb: (NSMenuItem*) sender {
++    _openUrl(@"https://koreader.rocks");
++}
++
++- (IBAction) openWiki: (NSMenuItem*) sender {
++    _openUrl(@"https://github.com/koreader/koreader/wiki");
++}
++
++- (IBAction) openForum: (NSMenuItem*) sender {
++    _openUrl(@"https://www.mobileread.com/forums/forumdisplay.php?f=276");
++}
++
++- (IBAction) openLicense: (NSMenuItem*) sender {
++    _openFile(@"COPYING", nil);
++}
++
+ // Override terminate to handle Quit and System Shutdown smoothly.
+ - (void)terminate:(id)sender
+ {
+@@ -233,20 +262,7 @@
  
  - (void)applicationDidFinishLaunching:(NSNotification *)notification
  {
@@ -19,132 +62,20 @@ diff -uNr a/src/video/cocoa/SDL_cocoaevents.m b/src/video/cocoa/SDL_cocoaevents.
 -        SDL_Delay(300);  /* !!! FIXME: this isn't right. */
 -        [NSApp activateIgnoringOtherApps:YES];
 -    }
--
--    /* If we call this before NSApp activation, macOS might print a complaint
--     * about ApplePersistenceIgnoreState. */
-     [SDLApplication registerUserDefaults];
- }
- @end
++    [NSApp activateIgnoringOtherApps:YES];
  
- static SDLAppDelegate *appDelegate = nil;
- 
--static NSString *
--GetApplicationName(void)
--{
--    NSString *appName;
--
--    /* Determine the application name */
--    appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
--    if (!appName) {
--        appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"];
--    }
--
--    if (![appName length]) {
--        appName = [[NSProcessInfo processInfo] processName];
--    }
--
--    return appName;
--}
--
- static bool
- LoadMainMenuNibIfAvailable(void)
- {
-@@ -296,11 +261,9 @@
- static void
- CreateApplicationMenus(void)
- {
--    NSString *appName;
-+    NSString *appName = @"KOReader";
-     NSString *title;
-     NSMenu *appleMenu;
--    NSMenu *serviceMenu;
--    NSMenu *windowMenu;
-     NSMenuItem *menuItem;
-     NSMenu *mainMenu;
- 
-@@ -317,27 +280,18 @@
-     mainMenu = nil;
- 
-     /* Create the application menu */
--    appName = GetApplicationName();
-     appleMenu = [[NSMenu alloc] initWithTitle:@""];
- 
--    /* Add menu items */
--    title = [@"About " stringByAppendingString:appName];
--    [appleMenu addItemWithTitle:title action:@selector(orderFrontStandardAboutPanel:) keyEquivalent:@""];
--
--    [appleMenu addItem:[NSMenuItem separatorItem]];
--
--    [appleMenu addItemWithTitle:@"Preferences…" action:nil keyEquivalent:@","];
--
--    [appleMenu addItem:[NSMenuItem separatorItem]];
--
--    serviceMenu = [[NSMenu alloc] initWithTitle:@""];
--    menuItem = (NSMenuItem *)[appleMenu addItemWithTitle:@"Services" action:nil keyEquivalent:@""];
--    [menuItem setSubmenu:serviceMenu];
--
--    [NSApp setServicesMenu:serviceMenu];
--    [serviceMenu release];
--
--    [appleMenu addItem:[NSMenuItem separatorItem]];
-+    /* Add the fullscreen toggle menu option, if supported */
-+    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
-+        /* Cocoa should update the title to Enter or Exit Full Screen automatically.
-+         * But if not, then just fallback to Toggle Full Screen.
-+         */
-+        menuItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
-+        [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagControl | NSEventModifierFlagCommand];
-+        [appleMenu addItem:menuItem];
-+        [menuItem release];
-+    }
- 
-     title = [@"Hide " stringByAppendingString:appName];
-     [appleMenu addItemWithTitle:title action:@selector(hide:) keyEquivalent:@"h"];
-@@ -361,38 +315,6 @@
-     /* Tell the application object that this is now the application menu */
-     [NSApp setAppleMenu:appleMenu];
-     [appleMenu release];
--
--
--    /* Create the window menu */
--    windowMenu = [[NSMenu alloc] initWithTitle:@"Window"];
--
--    /* Add menu items */
--    [windowMenu addItemWithTitle:@"Close" action:@selector(performClose:) keyEquivalent:@"w"];
--
--    [windowMenu addItemWithTitle:@"Minimize" action:@selector(performMiniaturize:) keyEquivalent:@"m"];
--
--    [windowMenu addItemWithTitle:@"Zoom" action:@selector(performZoom:) keyEquivalent:@""];
--    
--    /* Add the fullscreen toggle menu option, if supported */
--    if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_6) {
--        /* Cocoa should update the title to Enter or Exit Full Screen automatically.
--         * But if not, then just fallback to Toggle Full Screen.
--         */
--        menuItem = [[NSMenuItem alloc] initWithTitle:@"Toggle Full Screen" action:@selector(toggleFullScreen:) keyEquivalent:@"f"];
--        [menuItem setKeyEquivalentModifierMask:NSEventModifierFlagControl | NSEventModifierFlagCommand];
--        [windowMenu addItem:menuItem];
--        [menuItem release];
--    }
--
--    /* Put menu into the menubar */
--    menuItem = [[NSMenuItem alloc] initWithTitle:@"Window" action:nil keyEquivalent:@""];
--    [menuItem setSubmenu:windowMenu];
--    [[NSApp mainMenu] addItem:menuItem];
--    [menuItem release];
--
--    /* Tell the application object that this is now the window menu */
--    [NSApp setWindowsMenu:windowMenu];
--    [windowMenu release];
- }
- 
- void
-@@ -498,7 +420,7 @@
-          * seen by OS X power users. there's an additional optional human-readable
-          * (localized) reason parameter which we don't set.
-          */
--        NSString *name = [GetApplicationName() stringByAppendingString:@" using SDL_DisableScreenSaver"];
-+        NSString *name = [@"luajit" stringByAppendingString:@" using SDL_DisableScreenSaver"];
-         IOPMAssertionCreateWithDescription(kIOPMAssertPreventUserIdleDisplaySleep,
-                                            (CFStringRef) name,
-                                            NULL, NULL, NULL, 0, NULL,
+     /* If we call this before NSApp activation, macOS might print a complaint
+      * about ApplePersistenceIgnoreState. */
+@@ -424,12 +440,6 @@
+             }
+         }
+         [NSApp finishLaunching];
+-        if ([NSApp delegate]) {
+-            /* The SDL app delegate calls this in didFinishLaunching if it's
+-             * attached to the NSApp, otherwise we need to call it manually.
+-             */
+-            [SDLApplication registerUserDefaults];
+-        }
+     }
+     if (NSApp && !appDelegate) {
+         appDelegate = [[SDLAppDelegate alloc] init];


### PR DESCRIPTION
the same thing as #1151 but working on desktop linux / appImage too.

Barely tested on ~= OSX. Just a proof of concept. It handles SDL window size and position using env variables.

It can be used when the assets are in a different path than the binary but fallbacks to the same path if is unable to chdir to assets path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1155)
<!-- Reviewable:end -->
