### PR TITLE
bump crengine: better linebreaks at em-dash, fb2 fixes

### DIFF
--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -18,6 +18,7 @@ ep_get_binary_dir(BINARY_DIR)
 set(CFG_ENV_VAR "CC=\"${CC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ")
 set(CFG_OPTS "--prefix=${BINARY_DIR} --disable-static --enable-shared --host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
+set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/add_lb_get_char_class.patch")
 
 if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|version_type=none|version_type=linux|' libtool")
@@ -38,7 +39,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND NOCONFIGURE=1 ./autogen.sh
+    PATCH_COMMAND ${PATCH_CMD1} COMMAND NOCONFIGURE=1 ./autogen.sh
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}
     INSTALL_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} install

--- a/thirdparty/libunibreak/add_lb_get_char_class.patch
+++ b/thirdparty/libunibreak/add_lb_get_char_class.patch
@@ -1,0 +1,28 @@
+diff --git a/src/linebreak.c b/src/linebreak.c
+index c2ccdda..45afba2 100644
+--- a/src/linebreak.c
++++ b/src/linebreak.c
+@@ -751,6 +751,12 @@ int lb_process_next_char(
+ 
+     return brk;
+ }
++enum LineBreakClass lb_get_char_class(
++        struct LineBreakContext *lbpCtx,
++        utf32_t ch)
++{
++    return get_char_lb_class_lang(ch, lbpCtx->lbpLang);
++}
+ 
+ /**
+  * Sets the line breaking information for a generic input string.
+diff --git a/src/linebreakdef.h b/src/linebreakdef.h
+index 5bb8838..8db80a6 100644
+--- a/src/linebreakdef.h
++++ b/src/linebreakdef.h
+@@ -169,3 +169,6 @@ void set_linebreaks(
+         const char *lang,
+         char *brks,
+         get_next_char_t get_next_char);
++enum LineBreakClass lb_get_char_class(
++        struct LineBreakContext *lbpCtx,
++        utf32_t ch);


### PR DESCRIPTION
Includes:
- (Upstream) LVBase64NodeStream: fix possible segfault https://github.com/koreader/crengine/pull/366
- (Upstream) Fix getting encoding from HTML META tags
- FB2: also look for cover in `<src-title-info>`
- FB2: fix cover image colors
- FB2: don't draw cover in scroll mode
- TextLang: better linebreaks at em-dash (EN/ES/FR) https://github.com/koreader/crengine/pull/365
- TextLang: increase _lb_props static array size https://github.com/koreader/crengine/pull/368

libunibreak: add patch to export internal function `get_char_lb_class_lang()` as `lb_get_char_class()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1160)
<!-- Reviewable:end -->
