### PR TITLE
thirdparty/harfbuzz 2.7.1

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -44,7 +44,7 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
-set(HB_VER 2.7.0)
+set(HB_VER 2.7.1)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
<https://github.com/harfbuzz/harfbuzz/releases/tag/2.7.1>

    ot-funcs now handles variable empty glyphs better when hvar/vvar isn't present.
    Reverted a GDEF processing regression.
    A couple of fixes to handle OOM better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1161)
<!-- Reviewable:end -->
