### PR TITLE
bump crengine: New HTML parser, libRu and FB2 tweaks

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -739,6 +739,13 @@ static int getUnknownEntities(lua_State *L) {
     return 3;
 }
 
+static int getDocumentFormat(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    lString16 docformat = getDocFormatName(doc->text_view->getDocFormat());
+    lua_pushstring(L, UnicodeToLocal(docformat).c_str());
+    return 1;
+}
+
 static int getDocumentProps(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 
@@ -3395,6 +3402,7 @@ static const struct luaL_Reg credocument_meth[] = {
     /*--- get methods ---*/
     {"getIntProperty", getIntProperty},
     {"getStringProperty", getStringProperty},
+    {"getDocumentFormat", getDocumentFormat},
     {"getDocumentProps", getDocumentProps},
     {"getPages", getNumberOfPages},
     {"getCurrentPage", getCurrentPage},

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -97,6 +97,15 @@ else
     util.usleep = C.usleep
 end
 
+function util.getTimestamp()
+    local secs, usecs = util.gettime()
+    return secs + usecs/1000000
+end
+
+function util.getDuration(from_timestamp)
+    return util.getTimestamp() - from_timestamp
+end
+
 local statvfs = ffi.new("struct statvfs")
 function util.df(path)
     C.statvfs(path, statvfs)


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/370 : 
- Revert "FB2: don't draw cover in scroll mode"
- (Upstream) FB2: fix coverpage drawing in scroll mode
- FB2 footnotes: only merge run-in when next is erm_final
- fb2.css: use OTF tabular-nums for footnote numbers
- Text: ignore ascii and unicode control chars
- Fix HR positionning when floats involved
- writeNodeEx(): minor tweaks
- OnTagClose(): add self_closing_tag parameter
- HTML format detection: accept HTML5 doctype
- HTML parser: rework Lib.ru specific handling
- HTML parser: new more conforming implementation
- HTML parser: ensure foster parenting inside tables

Also add getTimestamp() and getDuration() to ffi/util.lua.
To be used for timing loading and rendering times:
```diff
--- a/frontend/apps/reader/readerui.lua
+++ b/frontend/apps/reader/readerui.lua
         -- make sure we render document first before calling any callback
         self:registerPostInitCallback(function()
+            local start_ts = ffiUtil.getTimestamp()
             if not self.document:loadDocument() then
                 self:dealWithLoadDocumentFailure()
             end
+            logger.dbg(string.format("  loading took %.3f seconds", ffiUtil.getDuration(start_ts)))

             -- used to read additional settings after the document has been
             -- loaded (but not rendered yet)
             self:handleEvent(Event:new("PreRenderDocument", self.doc_settings))

+            start_ts = ffiUtil.getTimestamp()
             self.document:render()
+            logger.dbg(string.format("  rendering took %.3f seconds", ffiUtil.getDuration(start_ts)))
+
+            -- Uncomment to output the built DOM (for debugging)
+            -- logger.dbg(self.document:getHTMLFromXPointer(".0", 0x6830))
         end)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1166)
<!-- Reviewable:end -->
