### PR TITLE
lua-ljsqlite3: use sqlite3_close_v2()

### DIFF
--- a/thirdparty/lua-ljsqlite3/init.lua
+++ b/thirdparty/lua-ljsqlite3/init.lua
@@ -92,6 +92,7 @@ const char *sqlite3_errmsg(sqlite3*);
 int sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags,
   const char *zVfs);
 int sqlite3_close(sqlite3*);
+int sqlite3_close_v2(sqlite3*);
 int sqlite3_busy_timeout(sqlite3*, int ms);
 
 // Statement.
@@ -318,7 +319,7 @@ function conn_mt:close() T_open(self)
   for _,v in pairs(conncb[self].scalar) do v:free() end
   for _,v in pairs(conncb[self].step)   do v:free() end
   for _,v in pairs(conncb[self].final)  do v:free() end
-  local code = sql.sqlite3_close(self._ptr)
+  local code = sql.sqlite3_close_v2(self._ptr)
   T_okcode(self._ptr, code)
   connstmt[self] = nil -- Table connstmt is not weak, need to clear manually.
   conncb[self] = nil


### PR DESCRIPTION
`sqlite3_close()` may occasionally return SQLITE_BUSY, which is not expected by frontend code and can cause some crash.
`sqlite3_close_v2()` always returns SQLITE_OK and has SQLite deal itself with properly closing it later.
Ref: https://github.com/koreader/koreader/issues/5563#issuecomment-682980942

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1174)
<!-- Reviewable:end -->
