### PR TITLE
Update to KoboUSBMS v0.9.8

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v0.9.7
+    tags/v0.9.8
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Fix erratic status bar refresh on Mk. 7
* Attempt to abort early when connected to a wall charger instead of a USB host

In the spirit of that last change, split our own fake events in two, like on Cervantes, in order to prevent showing the USBMS popup when plugging into a wall charger.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1183)
<!-- Reviewable:end -->
