### PR TITLE
Forcibly disable docs when building giflib

### DIFF
--- a/thirdparty/giflib/CMakeLists.txt
+++ b/thirdparty/giflib/CMakeLists.txt
@@ -10,7 +10,7 @@ enable_language(C)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
-set(CFG_ENV_VAR "CC=\"${CC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\" ")
+set(CFG_ENV_VAR "ac_cv_prog_have_xmlto=no CC=\"${CC}\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\"")
 set(CFG_OPTS "-q --prefix=${BINARY_DIR} --disable-static --enable-shared --host=\"${CHOST}\"")
 set(CFG_CMD sh -c "${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS}")
 


### PR DESCRIPTION
Because everything is terrible, I guess?

Fix https://github.com/koreader/koreader/issues/6668

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1186)
<!-- Reviewable:end -->
