### PR TITLE
bump crengine: ODT support, added/updated hyphenation

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -614,7 +614,9 @@ static int getHyphDictList(lua_State *L) {
 
 static int getSelectedHyphDict(lua_State *L) {
 	lua_pushstring(L, UnicodeToLocal(HyphMan::getSelectedDictionary()->getId()).c_str());
-	return 1;
+	lua_pushnumber(L, TextLangMan::getMainLangHyphMethod()->getLeftHyphenMin());
+	lua_pushnumber(L, TextLangMan::getMainLangHyphMethod()->getRightHyphenMin());
+	return 3;
 }
 
 static int setHyphDictionary(lua_State *L) {

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -140,6 +140,8 @@ set (CRENGINE_SOURCES
     ${CRE_DIR}/src/wordfmt.cpp
     ${CRE_DIR}/src/lvopc.cpp
     ${CRE_DIR}/src/docxfmt.cpp
+    ${CRE_DIR}/src/odtfmt.cpp
+    ${CRE_DIR}/src/odxutil.cpp
     ${CRE_DIR}/src/fb3fmt.cpp
     ${CRE_DIR}/src/lvstsheet.cpp
     ${CRE_DIR}/src/txtselector.cpp


### PR DESCRIPTION
Includes:
- Update German hyphenation patterns https://github.com/koreader/crengine/pull/375
- (Upstream) Adds ODT (ODF) format support https://github.com/koreader/crengine/pull/377
- TextLang, hyphenation: add Basque, Croatian, Esperanto, Estonian, Georgian, Latvian, Lithuanian, Macedonian, Occitan, Welsh; update Bulgarian, Irish, Portuguese, Slovak, Dutch, Norwegian, Spanish; update hyphen min for Czech, English, Greek; fix Romanian and Ukrainian pattern file names https://github.com/koreader/crengine/pull/378
- HyphMan: adds HyphMethod::getLeft/RightHyphenMin()
- epub.css: update HR default style https://github.com/koreader/crengine/pull/379
- fb2.css: keep <date> in main text left-aligned
- getRenderedWidths(): inline-block and table fixes
- CSS: avoid style hash mismatch when serializing content:''
- Tables: re-order row groups when necessary
- XML parsing: don't drop trailing text
- HTML parser: tweak implicit head/body insertion code
- Fix text search failure when blank at start or end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1190)
<!-- Reviewable:end -->
