### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -21,6 +21,11 @@ assert_var_defined(LEPTONICA_DIR)
 assert_var_defined(TESSERACT_DIR)
 assert_var_defined(STDCPPLIB)
 
+if ($ENV{DARWIN})
+    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
+    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+endif()
+
 ep_get_source_dir(SOURCE_DIR)
 
 set(BUILD_CMD sh -c "${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} BUILDMODE=shared HOST=${HOST} CC=\"${CC}\" CFLAGS=\"${CFLAGS} -O3\"")


### PR DESCRIPTION
Add a flag to compiles on macOS to allow implicit function declaration. Builds on XCode 12 seem to fail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1196)
<!-- Reviewable:end -->
