### PR TITLE
Fix build in macOS XCode 12

### DIFF
--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -21,10 +21,8 @@ assert_var_defined(LEPTONICA_DIR)
 assert_var_defined(TESSERACT_DIR)
 assert_var_defined(STDCPPLIB)
 
-if ($ENV{DARWIN})
-    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
-    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
-endif()
+#fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
+set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
 
 ep_get_source_dir(SOURCE_DIR)
 

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -21,6 +21,11 @@ assert_var_defined(LEPTONICA_DIR)
 assert_var_defined(TESSERACT_DIR)
 assert_var_defined(STDCPPLIB)
 
+if ($ENV{DARWIN})
+    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
+    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+endif()
+
 ep_get_source_dir(SOURCE_DIR)
 
 set(BUILD_CMD sh -c "${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS} BUILDMODE=shared HOST=${HOST} CC=\"${CC}\" CFLAGS=\"${CFLAGS} -O3\"")

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -21,8 +21,10 @@ assert_var_defined(LEPTONICA_DIR)
 assert_var_defined(TESSERACT_DIR)
 assert_var_defined(STDCPPLIB)
 
-#fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
-set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+if ($ENV{DARWIN})
+    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
+    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+endif()
 
 ep_get_source_dir(SOURCE_DIR)
 

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -10,14 +10,8 @@ enable_language(C ASM)
 
 assert_var_defined(CC)
 assert_var_defined(AR)
-#assert_var_defined(CFLAGS)
 assert_var_defined(LDFLAGS)
 assert_var_defined(RANLIB)
-
-if ($ENV{DARWIN})
-    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
-    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
-endif()
 
 ep_get_source_dir(SOURCE_DIR)
 
@@ -26,7 +20,10 @@ ep_get_source_dir(SOURCE_DIR)
 #set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/minizip-libaes-makefile.patch")
 
 set(PATCH_CMD sh -c "${ISED} \"s|^CC=|#CC=|g\" aes/Makefile && ${ISED} \"s|^CFLAGS=|#CFLAGS=|g\" aes/Makefile")
-set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
+
+#fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12 
+set(CC "${CC} -Wno-error=implicit-function-declaration")
+set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -13,6 +13,11 @@ assert_var_defined(AR)
 assert_var_defined(LDFLAGS)
 assert_var_defined(RANLIB)
 
+if ($ENV{DARWIN})
+    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
+    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+endif()
+
 ep_get_source_dir(SOURCE_DIR)
 
 # NOTE: 53a657318af1fccc4bac7ed230729302b2391d1d is the tip of the 1.2 branch. The fcrypt API we need is gone in master.
@@ -20,7 +25,11 @@ ep_get_source_dir(SOURCE_DIR)
 #set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/minizip-libaes-makefile.patch")
 
 set(PATCH_CMD sh -c "${ISED} \"s|^CC=|#CC=|g\" aes/Makefile && ${ISED} \"s|^CFLAGS=|#CFLAGS=|g\" aes/Makefile")
-set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
+if ($ENV{DARWIN})
+    set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
+else()
+    set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
+endif()
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -13,10 +13,8 @@ assert_var_defined(AR)
 assert_var_defined(LDFLAGS)
 assert_var_defined(RANLIB)
 
-if ($ENV{DARWIN})
-    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
-    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
-endif()
+#fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
+set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
 
 ep_get_source_dir(SOURCE_DIR)
 
@@ -25,11 +23,7 @@ ep_get_source_dir(SOURCE_DIR)
 #set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/minizip-libaes-makefile.patch")
 
 set(PATCH_CMD sh -c "${ISED} \"s|^CC=|#CC=|g\" aes/Makefile && ${ISED} \"s|^CFLAGS=|#CFLAGS=|g\" aes/Makefile")
-if ($ENV{DARWIN})
-    set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
-else()
-    set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
-endif()
+set(BUILD_CMD_STR -j${PARALLEL_JOBS} -C aes CC=${CC} CFLAGS=${CFLAGS} LDFLAGS=${LDFLAGS} AR=${AR} RANLIB=${RANLIB})
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -10,11 +10,14 @@ enable_language(C ASM)
 
 assert_var_defined(CC)
 assert_var_defined(AR)
+#assert_var_defined(CFLAGS)
 assert_var_defined(LDFLAGS)
 assert_var_defined(RANLIB)
 
-#fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
-set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+if ($ENV{DARWIN})
+    #fix build error due to implicit declarations of function being invalid in C99 under macOS/XCode 12
+    set(CFLAGS "${CFLAGS} -Wno-error=implicit-function-declaration")
+endif()
 
 ep_get_source_dir(SOURCE_DIR)
 


### PR DESCRIPTION
Add compile flags to allow implicit function declarations in libk2pdfopt and minizip

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1198)
<!-- Reviewable:end -->
