### PR TITLE
SDL + Android: Clean up inverse blit modes

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -403,7 +403,7 @@ function fb:toggleNightMode()
         self.bb:invert()
         if self.viewport then
             -- invert and blank out the full framebuffer when we are working on a viewport
-            self.full_bb:invert()
+            self.full_bb:setInverse(self.bb:getInverse())
             self.full_bb:fill(Blitbuffer.COLOR_WHITE)
         end
     end

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -55,7 +55,6 @@ function framebuffer:_newBB(w, h)
         inverse = self.bb:getInverse() == 1
         self.bb:free()
     end
-    if self.invert_bb then self.invert_bb:free() end
 
     -- we present this buffer to the outside
     local bb = BB.new(w, h, BB.TYPE_BBRGB32)
@@ -68,7 +67,6 @@ function framebuffer:_newBB(w, h)
     else
         self.bb = bb
     end
-    self.invert_bb = BB.new(w, h, BB.TYPE_BBRGB32)
 
     if rotation then
         self.bb:setRotation(rotation)
@@ -86,11 +84,6 @@ function framebuffer:_render(bb, x, y, w, h)
 
     -- x, y, w, h without rotation for SDL rectangle
     local px, py, pw, ph = bb:getPhysicalRect(x, y, w, h)
-
-    if bb:getInverse() == 1 then
-        self.invert_bb:invertblitFrom(bb)
-        bb = self.invert_bb
-    end
 
     -- A viewport is a Blitbuffer object that works on a rectangular
     -- subset of the underlying memory without allocating new memory.


### PR DESCRIPTION
Get rid of the triple/quad inversion mess.

Tested only on SDL, but the mechanism is now same on Android:
Inversion is done during writes to the shadow BB that is configured
to invert by noHWInvert from the base fb class, same way it works for
linuxfb eink that lacks inversion mode.

During the final update we then copy the shadow buffer 1:1 to the
backing texture.

Should fix

https://github.com/koreader/koreader/issues/6708
https://github.com/koreader/koreader/issues/6703

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1200)
<!-- Reviewable:end -->
