### PR TITLE
blitbuffer: Some more refactoring + SDL FB debug tools     

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -116,13 +116,13 @@ static const char*
 #define BB_GET_PIXEL(bb, rotation, COLOR, x, y, pptr) \
 ({ \
     if (rotation == 0) { \
-        *pptr = (COLOR*)(bb->data + y * bb->pitch) + x; \
+        *pptr = (COLOR*)(bb->data + y * bb->stride) + x; \
     } else if (rotation == 1) { \
-        *pptr = (COLOR*)(bb->data + x * bb->pitch) + bb->w - y - 1; \
+        *pptr = (COLOR*)(bb->data + x * bb->stride) + bb->w - y - 1; \
     } else if (rotation == 2) { \
-        *pptr = (COLOR*)(bb->data + (bb->h - y - 1) * bb->pitch) + bb->w - x - 1; \
+        *pptr = (COLOR*)(bb->data + (bb->h - y - 1) * bb->stride) + bb->w - x - 1; \
     } else if (rotation == 3) { \
-        *pptr = (COLOR*)(bb->data + (bb->h - x - 1) * bb->pitch) + y; \
+        *pptr = (COLOR*)(bb->data + (bb->h - x - 1) * bb->stride) + y; \
     } \
 })
 
@@ -204,15 +204,15 @@ void BB_fill_rect(BlitBuffer *bb, int x, int y, int w, int h, uint8_t v) {
     if (rx == 0 && rw == bb->w) {
         // Single step for contiguous scanlines
         //fprintf(stdout, "%s: Single fill paintRect\n", __FUNCTION__);
-        uint8_t *p = bb->data + bb->pitch*ry;
-        memset(p, v, bpp*bb->phys_w*rh);
+        uint8_t *p = bb->data + bb->stride*ry;
+        memset(p, v, bb->stride*rh);
     } else {
         // Scanline per scanline fill
         //fprintf(stdout, "%s: Scanline fill paintRect\n", __FUNCTION__);
         uint8_t *p = bb->data;
         int j;
         for (j = ry; j < ry+rh; j++) {
-            p = bb->data + bb->pitch*j + bpp*rx;
+            p = bb->data + bb->stride*j + bpp*rx;
             memset(p, v, bpp*rw);
         }
     }
@@ -330,8 +330,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     //fprintf(stdout, "%s: Full BB8 invertRect\n", __FUNCTION__);
-                    uint8_t *p = bb->data + bb->pitch*ry;
-                    for (i = 0; i < bb->phys_w*rh; i++) {
+                    uint8_t *p = bb->data + bb->stride*ry;
+                    for (i = 0; i < bb->pixel_stride*rh; i++) {
                         p[i] ^= 0xFF;
                     }
                 } else {
@@ -339,7 +339,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     //fprintf(stdout, "%s: Pixel BB8 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
-                        p = bb->data + bb->pitch*j + rx;
+                        p = bb->data + bb->stride*j + rx;
                         for (i = 0; i < rw; i++) {
                             p[i] ^= 0xFF;
                         }
@@ -352,8 +352,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     //fprintf(stdout, "%s: Full BB8A invertRect\n", __FUNCTION__);
-                    uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < bb->phys_w*rh; i++) {
+                    uint16_t *p = (uint16_t*) (bb->data + bb->stride*ry);
+                    for (i = 0; i < bb->pixel_stride*rh; i++) {
                         p[i] ^= 0x00FF;
                     }
                 } else {
@@ -361,7 +361,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     //fprintf(stdout, "%s: Pixel BB8A invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
-                        p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
+                        p = (uint16_t*) (bb->data + bb->stride*j + (rx << 1));
                         for (i = 0; i < rw; i++) {
                             p[i] ^= 0x00FF;
                         }
@@ -374,8 +374,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     //fprintf(stdout, "%s: Full BBRGB16 invertRect\n", __FUNCTION__);
-                    uint16_t *p = (uint16_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < bb->phys_w*rh; i++) {
+                    uint16_t *p = (uint16_t*) (bb->data + bb->stride*ry);
+                    for (i = 0; i < bb->pixel_stride*rh; i++) {
                         p[i] ^= 0xFFFF;
                     }
                 } else {
@@ -383,7 +383,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     //fprintf(stdout, "%s: Pixel BBRGB16 invertRect\n", __FUNCTION__);
                     uint16_t *p;
                     for (j = ry; j < ry+rh; j++) {
-                        p = (uint16_t*) (bb->data + bb->pitch*j + (rx << 1));
+                        p = (uint16_t*) (bb->data + bb->stride*j + (rx << 1));
                         for (i = 0; i < rw; i++) {
                             p[i] ^= 0xFFFF;
                         }
@@ -396,8 +396,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     //fprintf(stdout, "%s: Full BBRGB24 invertRect\n", __FUNCTION__);
-                    uint8_t *p = bb->data + bb->pitch*ry;
-                    for (i = 0; i < bb->phys_w*rh; i+=3) {
+                    uint8_t *p = bb->data + bb->stride*ry;
+                    for (i = 0; i < bb->pixel_stride*rh; i+=3) {
                         p[i] ^= 0xFF;
                         p[i+1] ^= 0xFF;
                         p[i+2] ^= 0xFF;
@@ -407,7 +407,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     //fprintf(stdout, "%s: Pixel BBRGB24 invertRect\n", __FUNCTION__);
                     uint8_t *p;
                     for (j = ry; j < ry+rh; j++) {
-                        p = bb->data + bb->pitch*j + (rx * 3);
+                        p = bb->data + bb->stride*j + (rx * 3);
                         for (i = 0; i < rw; i+=3) {
                             p[i] ^= 0xFF;
                             p[i+1] ^= 0xFF;
@@ -422,8 +422,8 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                 if (rx == 0 && rw == bb->w) {
                     // Single step for contiguous scanlines
                     //fprintf(stdout, "%s: Full BBRGB32 invertRect\n", __FUNCTION__);
-                    uint32_t *p = (uint32_t*) (bb->data + bb->pitch*ry);
-                    for (i = 0; i < bb->phys_w*rh; i++) {
+                    uint32_t *p = (uint32_t*) (bb->data + bb->stride*ry);
+                    for (i = 0; i < bb->pixel_stride*rh; i++) {
                         p[i] ^= 0x00FFFFFF;
                     }
                 } else {
@@ -431,7 +431,7 @@ void BB_invert_rect(BlitBuffer *bb, int x, int y, int w, int h) {
                     //fprintf(stdout, "%s: Pixel BBRGB32 invertRect\n", __FUNCTION__);
                     uint32_t *p;
                     for (j = ry; j < ry+rh; j++) {
-                        p = (uint32_t*) (bb->data + bb->pitch*j + (rx << 2));
+                        p = (uint32_t*) (bb->data + bb->stride*j + (rx << 2));
                         for (i = 0; i < rw; i++) {
                             p[i] ^= 0x00FFFFFF;
                         }
@@ -456,12 +456,12 @@ void BB_blit_to_BB8(BlitBuffer *src, BlitBuffer *dst,
                 // (i.e., setPixel, no rota, no invert).
                 // The cbb codepath ensures setPixel & no invert, so we only check for rotation.
                 if (sbb_rotation == 0 && dbb_rotation == 0) {
-                    if (offs_x == 0 && dest_x == 0 && w == src->w && w == dst->w && src->pitch == dst->pitch) {
+                    if (offs_x == 0 && dest_x == 0 && w == src->w && w == dst->w && src->stride == dst->stride) {
                         // Single step for contiguous scanlines (on both sides)
                         //fprintf(stdout, "%s: full copy blit from BB8 to BB8\n", __FUNCTION__);
                         // BB8 is 1 byte per pixel
-                        const uint8_t *srcp = src->data + src->pitch*offs_y;
-                        uint8_t *dstp = dst->data + dst->pitch*dest_y;
+                        const uint8_t *srcp = src->data + src->stride*offs_y;
+                        uint8_t *dstp = dst->data + dst->stride*dest_y;
                         memcpy(dstp, srcp, w*h);
                     } else {
                         // Scanline per scanline copy
@@ -469,8 +469,8 @@ void BB_blit_to_BB8(BlitBuffer *src, BlitBuffer *dst,
                         o_y = offs_y;
                         for (d_y = dest_y; d_y < dest_y+h; d_y++, o_y++) {
                             // BB8 is 1 byte per pixel
-                            const uint8_t *srcp = src->data + src->pitch*o_y + offs_x;
-                            uint8_t *dstp = dst->data + dst->pitch*d_y + dest_x;
+                            const uint8_t *srcp = src->data + src->stride*o_y + offs_x;
+                            uint8_t *dstp = dst->data + dst->stride*d_y + dest_x;
                             memcpy(dstp, srcp, w);
                         }
                     }
@@ -1066,12 +1066,12 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                 // (i.e., setPixel, no rota, no invert).
                 // The cbb codepath ensures setPixel & no invert, so we only check for rotation.
                 if (sbb_rotation == 0 && dbb_rotation == 0) {
-                    if (offs_x == 0 && dest_x == 0 && w == src->w && w == dst->w && src->pitch == dst->pitch) {
+                    if (offs_x == 0 && dest_x == 0 && w == src->w && w == dst->w && src->stride == dst->stride) {
                         // Single step for contiguous scanlines (on both sides)
                         //fprintf(stdout, "%s: full copy blit from BBRGB32 to BBRGB32\n", __FUNCTION__);
                         // BBRGB32 is 4 bytes per pixel
-                        const uint8_t *srcp = src->data + src->pitch*offs_y;
-                        uint8_t *dstp = dst->data + dst->pitch*dest_y;
+                        const uint8_t *srcp = src->data + src->stride*offs_y;
+                        uint8_t *dstp = dst->data + dst->stride*dest_y;
                         memcpy(dstp, srcp, (w << 2)*h);
                     } else {
                         // Scanline per scanline copy
@@ -1079,8 +1079,8 @@ void BB_blit_to_BB32(BlitBuffer *src, BlitBuffer *dst,
                         o_y = offs_y;
                         for (d_y = dest_y; d_y < dest_y+h; d_y++, o_y++) {
                             // BBRGB32 is 4 bytes per pixel
-                            const uint8_t *srcp = src->data + src->pitch*o_y + (offs_x << 2);
-                            uint8_t *dstp = dst->data + dst->pitch*d_y + (dest_x << 2);
+                            const uint8_t *srcp = src->data + src->stride*o_y + (offs_x << 2);
+                            uint8_t *dstp = dst->data + dst->stride*d_y + (dest_x << 2);
                             memcpy(dstp, srcp, w << 2);
                         }
                     }

--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -49,60 +49,54 @@ typedef struct ColorRGB32 {
 
 typedef struct BlitBuffer {
     int w;
-    int phys_w;
+    int pixel_stride;   // nb of pixels from the start of a line to the start of next line
     int h;
-    int phys_h;
-    int pitch;
+    int stride;         // nb of bytes from the start of a line to the start of next line
     uint8_t *data;
     uint8_t config;
 } BlitBuffer;
 
 typedef struct BlitBuffer8 {
     int w;
-    int phys_w;
+    int pixel_stride;
     int h;
-    int phys_h;
-    int pitch;
+    int stride;
     Color8 *data;
     uint8_t config;
 } BlitBuffer8;
 
 typedef struct BlitBuffer8A {
     int w;
-    int phys_w;
+    int pixel_stride;
     int h;
-    int phys_h;
-    int pitch;
+    int stride;
     Color8A *data;
     uint8_t config;
 } BlitBuffer8A;
 
 typedef struct BlitBufferRGB16 {
     int w;
-    int phys_w;
+    int pixel_stride;
     int h;
-    int phys_h;
-    int pitch;
+    int stride;
     ColorRGB16 *data;
     uint8_t config;
 } BlitBufferRGB16;
 
 typedef struct BlitBufferRGB24 {
     int w;
-    int phys_w;
+    int pixel_stride;
     int h;
-    int phys_h;
-    int pitch;
+    int stride;
     ColorRGB24 *data;
     uint8_t config;
 } BlitBufferRGB24;
 
 typedef struct BlitBufferRGB32 {
     int w;
-    int phys_w;
+    int pixel_stride;
     int h;
-    int phys_h;
-    int pitch;
+    int stride;
     ColorRGB32 *data;
     uint8_t config;
 } BlitBufferRGB32;

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -419,7 +419,7 @@ function S.setWindowIcon(icon)
     local icon_bit_depth = 32
     local surface = SDL.SDL_CreateRGBSurfaceWithFormatFrom(icon_bb.data,
                                                            icon_bb:getWidth(), icon_bb:getHeight(),
-                                                           icon_bit_depth, icon_bb.pitch,
+                                                           icon_bit_depth, icon_bb.stride,
                                                            SDL.SDL_PIXELFORMAT_RGBA32)
     SDL.SDL_SetWindowIcon(S.screen, surface)
     SDL.SDL_FreeSurface(surface)

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -134,7 +134,7 @@ function framebuffer:reinit()
     self.debug("FB mapped at", self.data, "of", PAGE_ALIGN(self.fb_size), "bytes")
 
     -- @warning Don't ever cache self.bb, as we may replace it at any time later due to HW rotation causing fb reinit.
-    self.bb = BB.new(vinfo.xres, vinfo.yres, BB["TYPE_BB"..bpp] or BB["TYPE_BBRGB"..bpp], self.data, finfo.line_length, stride_pixels, vinfo.yres)
+    self.bb = BB.new(vinfo.xres, vinfo.yres, BB["TYPE_BB"..bpp] or BB["TYPE_BBRGB"..bpp], self.data, finfo.line_length, stride_pixels)
 
     -- Make accessing the bitdepth easier, because we might want to know we're running on Kobo's quirky 16bpp mode later...
     self.fb_bpp = bpp

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -735,18 +735,16 @@ function mupdf.scaleBlitBuffer(bb, width, height)
     local colorspace
     local converted_bb
     local alpha
-    local stride
+    local stride = bb.stride
     -- MuPDF should know how to handle *most* of our BB types,
     -- special snowflakes excluded (4bpp & RGB565),
     -- in which case we feed it a temporary copy in the closest format it'll understand.
     if bbtype == BlitBuffer.TYPE_BB8 then
         colorspace = M.fz_device_gray(context())
         alpha = 0
-        stride = orig_w
     elseif bbtype == BlitBuffer.TYPE_BB8A then
         colorspace = M.fz_device_gray(context())
         alpha = 1
-        stride = orig_w * 2
     elseif bbtype == BlitBuffer.TYPE_BBRGB24 then
         if mupdf.bgr then
             colorspace = M.fz_device_bgr(context())
@@ -754,7 +752,6 @@ function mupdf.scaleBlitBuffer(bb, width, height)
             colorspace = M.fz_device_rgb(context())
         end
         alpha = 0
-        stride = orig_w * 3
     elseif bbtype == BlitBuffer.TYPE_BBRGB32 then
         if mupdf.bgr then
             colorspace = M.fz_device_bgr(context())
@@ -762,7 +759,6 @@ function mupdf.scaleBlitBuffer(bb, width, height)
             colorspace = M.fz_device_rgb(context())
         end
         alpha = 1
-        stride = orig_w * 4
     elseif bbtype == BlitBuffer.TYPE_BB4 then
         converted_bb = BlitBuffer.new(orig_w, orig_h, BlitBuffer.TYPE_BB8)
         converted_bb:blitFrom(bb, 0, 0, 0, 0, orig_w, orig_h)
@@ -780,7 +776,6 @@ function mupdf.scaleBlitBuffer(bb, width, height)
             colorspace = M.fz_device_rgb(context())
         end
         alpha = 1
-        stride = orig_w * 4
     end
     -- We can now create a pixmap from this bb of correct type
     local pixmap = W.mupdf_new_pixmap_with_data(context(), colorspace,

--- a/ffi/pic.lua
+++ b/ffi/pic.lua
@@ -317,7 +317,7 @@ function Pic.openJPGDocument(filename)
 
     if turbojpeg.tjDecompress2(handle, ffi.cast("unsigned char*", data), #data,
         ffi.cast("unsigned char*", doc.image_bb.data),
-        width[0], doc.image_bb.pitch, height[0], format, 0) == -1 then
+        width[0], doc.image_bb.stride, height[0], format, 0) == -1 then
         error("decoding JPEG file")
     end
 
@@ -348,7 +348,7 @@ function Pic.openJPGDocumentFromMem(data)
 
     if turbojpeg.tjDecompress2(handle, ffi.cast("unsigned char*", data), #data,
         ffi.cast("unsigned char*", doc.image_bb.data),
-        width[0], doc.image_bb.pitch, height[0], format, 0) == -1 then
+        width[0], doc.image_bb.stride, height[0], format, 0) == -1 then
         return false
     end
 

--- a/spec/unit/common_spec.lua
+++ b/spec/unit/common_spec.lua
@@ -38,7 +38,7 @@ describe("Common modules", function()
         local ss = Blitbuffer.fromstring(serial.load("/tmp/bb.dump"))
         assert.are.same(bb.w, ss.w)
         assert.are.same(bb.h, ss.h)
-        assert.are.same(bb.pitch, ss.pitch)
+        assert.are.same(bb.stride, ss.stride)
         assert.are.same(bb:getType(), ss:getType())
         for i = 0, h - 1 do
             for j = 0, w - 1 do


### PR DESCRIPTION
More of an RFC/WIP for now, to agree on stuff etc.
TODO: This turned out to be fairly invasive in a lot of places, so need to do some daily use testing to see if things still hold together.

* phys_w/pitch renamed to pixel_stride/stride, phys_h removed
* Get rid of getPhys*() uses. stride is hardwired to rotation,
   so returning swapped coordinates from there doesn't work
* make proper distinctions in uses between stride/pixel_stride where such
   wasn't the case
* add some more getenv() options to SDL to emulate arbitrary bb formats
  and b&w device
* make BB.new() infer optional stride/pixel_stride parameters

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1201)
<!-- Reviewable:end -->
