### PR TITLE
bump crengine: sync with upstream, new hyphenation languages

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -535,12 +535,6 @@ static int getDomVersionWithNormalizedXPointers(lua_State *L) {
     return 1;
 }
 
-static int requestDomVersion(lua_State *L) {
-    int version = luaL_checkint(L, 1);
-    gDOMVersionRequested = version;
-    return 0;
-}
-
 static int getIntProperty(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *propName = luaL_checkstring(L, 2);
@@ -3394,7 +3388,6 @@ static const struct luaL_Reg cre_func[] = {
     {"getTextLangStatus", getTextLangStatus},
     {"getLatestDomVersion", getLatestDomVersion},
     {"getDomVersionWithNormalizedXPointers", getDomVersionWithNormalizedXPointers},
-    {"requestDomVersion", requestDomVersion},
     {NULL, NULL}
 };
 


### PR DESCRIPTION
Includes:
- (Upstream) various unimpacting changes to keep in sync https://github.com/koreader/crengine/pull/384
- (Upstream) Fix issues with legacy text rendering
- (Upstream) FB3/DocX/ODT: get lang and description metadata
- (Upstream) remove some global settings, make them per-doc
- TextLang, hyphenation: add Armenian, Friulian, Piedmontese, Romansh, Zulu and Brazilian Portuguese. https://github.com/koreader/crengine/pull/383

cre.cpp: remove update of removed global `gDOMVersionRequested`, which should now be done with:
`setIntProperty("crengine.render.requested_dom_version", version)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1204)
<!-- Reviewable:end -->
