### PR TITLE
bump crengine: more than 64 styles, table layout fixes

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -5,6 +5,7 @@ std = "luajit"
 self = false
 
 read_globals = {
+    "DALPHA_SORT_CASE_INSENSITIVE",
     "DLANDSCAPE_CLOCKWISE_ROTATION",
     "lfs",
 }

--- a/cre.cpp
+++ b/cre.cpp
@@ -1308,6 +1308,29 @@ static int getFontFaces(lua_State *L) {
 	return 1;
 }
 
+static int getFontFaceFilenameAndFaceIndex(lua_State *L) {
+	const char *facename = luaL_checkstring(L, 1);
+	bool bold = false;
+	if (lua_isboolean(L, 2)) {
+		bold = lua_toboolean(L, 2);
+	}
+	bool italic = false;
+	if (lua_isboolean(L, 3)) {
+		italic = lua_toboolean(L, 3);
+	}
+
+	lString8 filename;
+	int faceindex = -1;
+	bool found = fontMan->getFontFileNameAndFaceIndex(lString16(facename), bold, italic, filename, faceindex);
+	if (found) {
+		lua_pushstring(L, filename.c_str());
+		lua_pushinteger(L, faceindex);
+		return 2;
+	}
+
+	return 0;
+}
+
 static int setViewMode(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	LVDocViewMode view_mode = (LVDocViewMode)luaL_checkint(L, 2);
@@ -3378,6 +3401,7 @@ static const struct luaL_Reg cre_func[] = {
     {"initHyphDict", initHyphDict},
     {"newDocView", newDocView},
     {"getFontFaces", getFontFaces},
+    {"getFontFaceFilenameAndFaceIndex", getFontFaceFilenameAndFaceIndex},
     {"getGammaLevel", getGammaLevel},
     {"getGammaIndex", getGammaIndex},
     {"setGammaIndex", setGammaIndex},

--- a/ffi/freetype.lua
+++ b/ffi/freetype.lua
@@ -132,12 +132,13 @@ FTFace_mt.__gc = FTFace_mt.__index.done;
 
 local FTFaceType = ffi.metatype("struct FT_FaceRec_", FTFace_mt) -- luacheck: ignore 211
 
-function FT.newFace(filename, pxsize)
+function FT.newFace(filename, pxsize, faceindex)
     if pxsize == nil then pxsize = 16*64 end
+    if faceindex == nil then faceindex = 0 end
 
     local facept = ffi.new("FT_Face[1]")
 
-    local err = ft2.FT_New_Face(freetypelib, filename, 0, facept)
+    local err = ft2.FT_New_Face(freetypelib, filename, faceindex, facept)
     if err ~= 0 then
         error("Failed to load font '"..filename.."', freetype error code: "..err)
     end


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/385 :
- TextLang: German: loosen quotation marks handling
- Fonts: add LVFontManager::getFontFileNameAndFaceIndex()
- fb2.css: avoid break before footnote links
- FlowState: fix possible wrong baseline with nested inline-table
- Tables: fix possible layout issues with rowspan
- Table cells: minor refactoring of baseline handling
- getRenderedWidths(): better estimate table width
- lvstyles: allow for more than 64 styles

cre.cpp: add getFontFaceFilenameAndFaceIndex().
ffi/freetype.lua: add optional 'faceindex" parameter to FT.newFace() so we can request a font other than the first one from font collections (.ttc).
Needed to show font names in the menu in their own font, see https://github.com/koreader/koreader/issues/6739#issuecomment-703131167 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1208)
<!-- Reviewable:end -->
