### PR TITLE
Drop unused variable

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -973,7 +973,7 @@ end
 
 function BB_mt.__index:blitDefault(dest, dest_x, dest_y, offs_x, offs_y, width, height, setter, set_param)
     -- slow default variant:
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
     local o_y = offs_y
     for y = dest_y, dest_y+height-1 do
@@ -984,7 +984,7 @@ function BB_mt.__index:blitDefault(dest, dest_x, dest_y, offs_x, offs_y, width, 
         end
         o_y = o_y + 1
     end
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 -- no optimized blitting by default:
 BB_mt.__index.blitTo4 = BB_mt.__index.blitDefault
@@ -1259,7 +1259,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
         cblitbuffer.BB_invert_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h)
     else
-        local hook, mask, _ = debug.gethook()
+        local hook, hmask, _ = debug.gethook()
         debug.sethook()
         -- Handle rotation...
         x, y, w, h = self:getPhysicalRect(x, y, w, h)
@@ -1326,7 +1326,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
                 end
             end
         end
-        debug.sethook(hook, mask)
+        debug.sethook(hook, hmask)
     end
 end
 
@@ -1359,7 +1359,7 @@ function BB_mt.__index:paintRect(x, y, w, h, value, setter)
         cblitbuffer.BB_fill_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h, value:getColor8().a)
     else
-        local hook, mask, _ = debug.gethook()
+        local hook, hmask, _ = debug.gethook()
         debug.sethook()
         -- We can only do fast filling when there's no complex processing involved (i.e., simple setPixel only)
         -- NOTE: We cheat a bit when targeting non-grayscale BBs,
@@ -1399,7 +1399,7 @@ function BB_mt.__index:paintRect(x, y, w, h, value, setter)
                 end
             end
         end
-        debug.sethook(hook, mask)
+        debug.sethook(hook, hmask)
     end
 end
 
@@ -1411,14 +1411,14 @@ function BB4_mt.__index:paintRect(x, y, w, h, value, setter)
     w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
     h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
     if w <= 0 or h <= 0 then return end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
     for tmp_y = y, y+h-1 do
         for tmp_x = x, x+w-1 do
             setter(self, tmp_x, tmp_y, value)
         end
     end
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 --[[
@@ -1739,7 +1739,7 @@ local Png  -- lazy load ffi/png
 
 function BB4_mt.__index:writePNG(filename)
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1749,12 +1749,12 @@ function BB4_mt.__index:writePNG(filename)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 1)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 function BB8_mt.__index:writePNG(filename)
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1766,12 +1766,12 @@ function BB8_mt.__index:writePNG(filename)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 1)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 function BB8A_mt.__index:writePNG(filename)
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1781,12 +1781,12 @@ function BB8A_mt.__index:writePNG(filename)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 2)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 function BBRGB16_mt.__index:writePNG(filename)
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1796,7 +1796,7 @@ function BBRGB16_mt.__index:writePNG(filename)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 3)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 function BBRGB24_mt.__index:writePNG(filename, bgr)
@@ -1804,7 +1804,7 @@ function BBRGB24_mt.__index:writePNG(filename, bgr)
     if bgr then return self:writePNGFromBGR(filename) end
 
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1814,7 +1814,7 @@ function BBRGB24_mt.__index:writePNG(filename, bgr)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 3)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 function BBRGB32_mt.__index:writePNG(filename, bgr)
@@ -1822,7 +1822,7 @@ function BBRGB32_mt.__index:writePNG(filename, bgr)
     if bgr then return self:writePNGFromBGR(filename) end
 
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
 
     local w, h = self:getWidth(), self:getHeight()
@@ -1832,13 +1832,13 @@ function BBRGB32_mt.__index:writePNG(filename, bgr)
 
     Png.encodeToFile(filename, ffi.cast("const unsigned char*", bbdump.data), w, h, 4)
     bbdump:free()
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 -- Crap manual fallback when a have a BGR <-> RGB swap to handle...
 function BB_mt.__index:writePNGFromBGR(filename)
     if not Png then Png = require("ffi/png") end
-    local hook, mask, _ = debug.gethook()
+    local hook, hmask, _ = debug.gethook()
     debug.sethook()
     local w, h = self:getWidth(), self:getHeight()
     local stride = w * 3
@@ -1857,7 +1857,7 @@ function BB_mt.__index:writePNGFromBGR(filename)
     end
     Png.encodeToFile(filename, mem, w, h, 3)
     C.free(cdata)
-    debug.sethook(hook, mask)
+    debug.sethook(hook, hmask)
 end
 
 -- if no special case in BB???_mt exists, use function from BB_mt

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -973,7 +973,7 @@ end
 
 function BB_mt.__index:blitDefault(dest, dest_x, dest_y, offs_x, offs_y, width, height, setter, set_param)
     -- slow default variant:
-    local hook, mask, count = debug.gethook()
+    local hook, mask, _ = debug.gethook()
     debug.sethook()
     local o_y = offs_y
     for y = dest_y, dest_y+height-1 do
@@ -1259,7 +1259,7 @@ function BB_mt.__index:invertRect(x, y, w, h)
         cblitbuffer.BB_invert_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h)
     else
-        local hook, mask, count = debug.gethook()
+        local hook, mask, _ = debug.gethook()
         debug.sethook()
         -- Handle rotation...
         x, y, w, h = self:getPhysicalRect(x, y, w, h)
@@ -1359,7 +1359,7 @@ function BB_mt.__index:paintRect(x, y, w, h, value, setter)
         cblitbuffer.BB_fill_rect(ffi.cast("struct BlitBuffer *", self),
             x, y, w, h, value:getColor8().a)
     else
-        local hook, mask, count = debug.gethook()
+        local hook, mask, _ = debug.gethook()
         debug.sethook()
         -- We can only do fast filling when there's no complex processing involved (i.e., simple setPixel only)
         -- NOTE: We cheat a bit when targeting non-grayscale BBs,
@@ -1411,7 +1411,7 @@ function BB4_mt.__index:paintRect(x, y, w, h, value, setter)
     w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
     h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
     if w <= 0 or h <= 0 then return end
-    local hook, mask, count = debug.gethook()
+    local hook, mask, _ = debug.gethook()
     debug.sethook()
     for tmp_y = y, y+h-1 do
         for tmp_x = x, x+w-1 do


### PR DESCRIPTION
The rest of them were already doing that ;).

I don't *rightly* recall *why* we're killing debug hooks in there in the first place (performance?), but, oh, well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1210)
<!-- Reviewable:end -->
