### PR TITLE
android input: do not error when the activity is destroyed

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -165,7 +165,6 @@ function input.waitForEvent(usecs)
             end
             if android.app.destroyRequested ~= 0 then
                 android.LOGI("Engine thread destroy requested!")
-                error("application forced to quit")
                 return
             end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then


### PR DESCRIPTION
 this is intended when killed by the system or by the program using `finish()` from kotlin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1224)
<!-- Reviewable:end -->
