### PR TITLE
Minor third-party bumps

### DIFF
--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -55,7 +55,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    26bc1ecac12391a307e393296f0d8386d2642c50
+    0c705d5bb36707959d90607618dd1f7d3c1271d0
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v0.9.10
+    tags/v0.9.11
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v0.9.11
+    tags/v0.9.12
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* KoboUSBMS 0.9.11 (the FL is now off during the session; fix a bug on fully-charged Mk. 7 devices).
* KoboUSBMS 0.9.12 (Make it work on Mk. 6 devices [fix https://github.com/koreader/koreader/issues/6582])
* FBInk (minor PB tweaks)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1225)
<!-- Reviewable:end -->
