### PR TITLE
thirdparty/libjpeg-turbo 2.0.6

### DIFF
--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/libjpeg-turbo/libjpeg-turbo.git
-    2.0.5
+    2.0.6
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Probably nothing relevant to us.

<https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.0.6>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1231)
<!-- Reviewable:end -->
