### PR TITLE
[fix] GitHub Actions set-env error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: setup-xcode
-        uses: maxim-lobanov/setup-xcode@1.0
+        uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: 11.3.1 # Use Xcode 11.3.1, because 11.4, 11.5, and 11.6 have a segfaulting clang.
 


### PR DESCRIPTION
```
Error: Unable to process command '::set-env name=MD_APPLE_SDK_ROOT::/Applications/Xcode_11.3.1.app' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Cf. https://github.com/maxim-lobanov/setup-xcode/issues/12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1232)
<!-- Reviewable:end -->
