### PR TITLE
Revert "blitbuffer: Always enable JIT workaround (#1205)"

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1957,7 +1957,8 @@ function BB:enableCBB(enabled)
     if old ~= use_cblitbuffer then
         -- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,
         --       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).
-        --       c.f., koreader/koreader#4137, koreader/koreader#4752, koreader/koreader#4782
+        --       c.f., koreader/koreader#4137, koreader/koreader#4752, koreader/koreader#4782,
+        --       koreader/koreader#6736, #1233
         local val = use_cblitbuffer and 15 or 45
         jit.opt.start("loopunroll="..tostring(val))
         jit.flush()

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -134,12 +134,6 @@ void BB_color_blit_from(BlitBuffer *dest, BlitBuffer *source, int dest_x, int de
                         int offs_x, int offs_y, int w, int h, Color8A *color);
 ]]
 
--- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting our inner loops,
---       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).
---       This is necessary even with CBB on, as not everything goes through CBB.
---       c.f., koreader/koreader#4137, koreader/koreader#4752, koreader/koreader#4782, koreader/koreader#6736
-jit.opt.start("loopunroll=45")
-
 -- We'll load it later
 local cblitbuffer
 local use_cblitbuffer = false
@@ -1958,7 +1952,16 @@ end
 
 -- Set the actual enable/disable CBB flag. Returns the flag of whether it is (actually) enabled.
 function BB:enableCBB(enabled)
+    local old = use_cblitbuffer
     use_cblitbuffer = enabled and self.has_cblitbuffer
+    if old ~= use_cblitbuffer then
+        -- NOTE: This works-around a number of corner-cases which may end up with LuaJIT's optimizer blacklisting this very codepath,
+        --       which'd obviously *murder* performance (to the effect of a soft-lock, essentially).
+        --       c.f., koreader/koreader#4137, koreader/koreader#4752, koreader/koreader#4782
+        local val = use_cblitbuffer and 15 or 45
+        jit.opt.start("loopunroll="..tostring(val))
+        jit.flush()
+    end
     return use_cblitbuffer
 end
 


### PR DESCRIPTION
This PR solves the issue https://github.com/koreader/koreader-base/pull/1233#issuecomment-732227157 with extremely poor performance on `writeBMP` on Tolino. 
See also koreader/koreader#6736 on slow screenshot performance and the solution at the time #1205.


In my understanding the history of #1205 was the following:
I created an issue koreader/koreader#6736 on slow screenshot performance.
On Oct. 4 @ezdiy proposed a solution for the slow screenshot #1205, which worked at that time.
On Oct. 5 @NiLuJe improved blitbuffer.lua for "less crappy performance" #1206. This was a massive change in blitbuffer.lua which counteracted the improvement of the loopunroll. But nobody noticed that, because nobody used the folded loops on a slow device.

The whole genesis of this revert can be found in #1233.

This reverts commit 6705c0281996e4ab96472c89fbb50b471a2d5bd1, reversing
changes made to fc7946516b6c80394458a037af2dcec7caa3cfb6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1235)
<!-- Reviewable:end -->
