### PR TITLE
BB: Ensure consistent types are being used in writePNG

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1810,7 +1810,7 @@ function BB_mt.__index:writePNGFromBGR(filename)
     local w, h = self:getWidth(), self:getHeight()
     local stride = w * 3
     local cdata = C.malloc(stride * h)
-    local mem = ffi.cast("char*", cdata)
+    local mem = ffi.cast(uint8pt, cdata)
     for y = 0, h-1 do
         local offset = stride * y
         for x = 0, w-1 do
@@ -1822,7 +1822,7 @@ function BB_mt.__index:writePNGFromBGR(filename)
             offset = offset + 3
         end
     end
-    Png.encodeToFile(filename, mem, w, h, 3)
+    Png.encodeToFile(filename, ffi.cast("const unsigned char*", mem), w, h, 3)
     C.free(cdata)
 end
 


### PR DESCRIPTION
Momentary brainfart lead to me using a char* instead of an unsigned
char*
Which doesn't change much in the grand scheme of things, but, oh, well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1238)
<!-- Reviewable:end -->
