### PR TITLE
Fix ZSTD rpath

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -222,6 +222,10 @@ ifdef DARWIN
 		`otool -L "$@" | grep "$(notdir $(JPEG_LIB)) " | awk '{print $$1}'` \
 		libs/$(notdir $(JPEG_LIB)) \
 		$@
+	install_name_tool -change \
+		`otool -L "$@" | grep "$(notdir $(ZSTD_LIB)) " | awk '{print $$1}'` \
+		libs/$(notdir $(ZSTD_LIB)) \
+		$@
 endif
 
 $(LUAJIT) $(LUAJIT_LIB) $(LUAJIT_JIT): $(THIRDPARTY_DIR)/luajit/*.*

--- a/Makefile.third
+++ b/Makefile.third
@@ -401,7 +401,7 @@ $(ZSTD_LIB): $(THIRDPARTY_DIR)/zstd/*.*
 	cd $(ZSTD_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) -DCC="$(CC)" -DCXX="$(CXX)" -DAR="$(AR)" \
 		-DCFLAGS="$(CFLAGS)" \
-		-DLDFLAGS="$(LDFLAGS) -Wl,-rpath,'$(ORIGIN_CMAKE_TO_AUTOCFG)/./libs'" \
+		-DLDFLAGS="$(LDFLAGS)" \
 		$(CURDIR)/$(THIRDPARTY_DIR)/zstd && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 	cp -fL $(ZSTD_DIR)/lib/$(notdir $(ZSTD_LIB)) $@

--- a/thirdparty/zstd/CMakeLists.txt
+++ b/thirdparty/zstd/CMakeLists.txt
@@ -16,6 +16,10 @@ assert_var_defined(LDFLAGS)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
+# Because escaping rpath is even more hellish than usual, for some reason...
+# NOTE: In ZSH, passing MOREFLAGS="-Wl,-rpath,'\\\$$\\\$\$ORIGIN/./libs'" works, too.
+set(PATCH_CMD "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/zstd-rpath.patch")
+
 # This a pure Makefile buildsystem, don't enforce CFLAGS via command line args, the buildsystem needs to be able to modify it.
 set(BUILD_ENV "env CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\"")
 
@@ -34,7 +38,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND ""
+    PATCH_COMMAND COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND COMMAND ${BUILD_CMD}
     INSTALL_COMMAND COMMAND ${INSTALL_CMD}

--- a/thirdparty/zstd/zstd-rpath.patch
+++ b/thirdparty/zstd/zstd-rpath.patch
@@ -1,0 +1,22 @@
+diff --git a/lib/Makefile b/lib/Makefile
+index 869d7663..cc3060b7 100644
+--- a/lib/Makefile
++++ b/lib/Makefile
+@@ -259,7 +259,7 @@ else  # not Windows
+ LIBZSTD = libzstd.$(SHARED_EXT_VER)
+ .PHONY: $(LIBZSTD)  # must be run every time
+ $(LIBZSTD): CFLAGS += -fPIC
+-$(LIBZSTD): LDFLAGS += -shared -fvisibility=hidden
++$(LIBZSTD): LDFLAGS += -shared -fvisibility=hidden -Wl,-rpath,'\$$\\$$\$$ORIGIN/./libs'
+ 
+ ifndef BUILD_DIR
+ # determine BUILD_DIR from compilation flags
+@@ -333,7 +333,7 @@ include $(wildcard $(DEPFILES))
+ # Special case : building library in single-thread mode _and_ without zstdmt_compress.c
+ ZSTDMT_FILES = compress/zstdmt_compress.c
+ ZSTD_NOMT_FILES = $(filter-out $(ZSTDMT_FILES),$(ZSTD_FILES))
+-libzstd-nomt: LDFLAGS += -shared -fPIC -fvisibility=hidden
++libzstd-nomt: LDFLAGS += -shared -fPIC -fvisibility=hidden -Wl,-rpath,'\$$\\$$\$$ORIGIN/./libs'
+ libzstd-nomt: $(ZSTD_NOMT_FILES)
+ 	@echo compiling single-thread dynamic library $(LIBVER)
+ 	@echo files : $(ZSTD_NOMT_FILES)


### PR DESCRIPTION
We don't really need it, but it was broken by the switch to env from `MOREFLAGS` ;).

Also fix CRe's dependencies on macOS to avoid it depending on brew's zstd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1260)
<!-- Reviewable:end -->
