### PR TITLE
Handle CRe's weird-ass pixel-format once and for all

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -3171,6 +3171,31 @@ static int drawCurrentPage(lua_State *L) {
 		doc->text_view->Draw(drawBuf, false);
 		drawn_images_count = drawBuf.getDrawnImagesCount();
 		drawn_images_surface = drawBuf.getDrawnImagesSurface();
+
+		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up... */
+		size_t pixel_count = w * h;
+
+		/*
+		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
+		while (pixel_count--) {
+			uint32_t px = *p;
+			// Swap B <-> R, keep G, invert A
+			*p++ = ((px << 16) & 0x00FF0000) | ((px >> 16) & 0x000000FF) | (px & 0x0000FF00) | ((px & 0xFF000000) ^ 0xFF000000);
+		}
+		*/
+
+		uint8_t * __restrict p = bb->data;
+		while (pixel_count--) {
+			// Swap B <-> R
+			const uint8_t b = p[0];
+			p[0] = p[2];
+			p[2] = b;
+			// Invert A
+			p[3] ^= 0xFFu;
+
+			// Next pixel!
+			p+=4;
+		}
 	}
 	else {
 		/* Set DrawBuf to 8bpp */

--- a/cre.cpp
+++ b/cre.cpp
@@ -31,31 +31,6 @@ extern "C" {
 #include "lvdocview.h"
 #include "lvimg.h"
 
-// For pixel format conversions
-typedef union
-{
-	uint32_t p;
-	struct
-	{
-		uint8_t r;
-		uint8_t g;
-		uint8_t b;
-		uint8_t a;
-	} color;
-} KOPixel;
-
-typedef union
-{
-	uint32_t p;
-	struct
-	{
-		uint8_t b;
-		uint8_t g;
-		uint8_t r;
-		uint8_t a;
-	} color;
-} CRePixel;
-
 static void replaceColor( char * str, lUInt32 color ) {
 	// in line like "0 c #80000000",
 	// replace value of color
@@ -3210,7 +3185,6 @@ static int drawCurrentPage(lua_State *L) {
 		}
 		*/
 
-		/*
 		uint8_t * __restrict p = bb->data;
 		while (pixel_count--) {
 			// Swap B <-> R
@@ -3222,20 +3196,6 @@ static int drawCurrentPage(lua_State *L) {
 
 			// Next pixel!
 			p+=4;
-		}
-		*/
-
-		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
-		while (pixel_count--) {
-			const CRePixel cre = { .p = *p };
-			// Can't do that in C++ :( (c.f., https://en.cppreference.com/w/cpp/language/aggregate_initialization)
-			//const KOPixel ko = { .color.r = cre.color.r, .color.g = cre.color.g, .color.b = cre.color.b, .color.a = cre.color.a ^ 0xFFu };
-			KOPixel ko;
-			ko.color.r = cre.color.r;
-			ko.color.g = cre.color.g;
-			ko.color.b = cre.color.b;
-			ko.color.a = cre.color.a ^ 0xFFu;
-			*p++ = ko.p;
 		}
 	}
 	else {

--- a/cre.cpp
+++ b/cre.cpp
@@ -3174,7 +3174,8 @@ static int drawCurrentPage(lua_State *L) {
 
 		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up,
 		 * as we expecet RGBA and straight alpha... */
-		size_t px_count = w * h;
+		const size_t px_count = w * h;
+		uint8_t * end = bb->data + (px_count << 2U);
 
 		/*
 		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
@@ -3185,17 +3186,21 @@ static int drawCurrentPage(lua_State *L) {
 		}
 		*/
 
+		/*
 		uint8_t * __restrict p = bb->data;
 		while (px_count--) {
+		*/
+		for (uint8_t * __restrict p = bb->data; p < end; p+=4) {
 			// Swap B <-> R
 			const uint8_t b = p[0];
 			p[0] = p[2];
 			p[2] = b;
 			// Invert A
 			p[3] ^= 0xFFu;
-
+		/*
 			// Next pixel!
 			p+=4;
+		*/
 		}
 
 		/*

--- a/cre.cpp
+++ b/cre.cpp
@@ -3172,7 +3172,8 @@ static int drawCurrentPage(lua_State *L) {
 		drawn_images_count = drawBuf.getDrawnImagesCount();
 		drawn_images_surface = drawBuf.getDrawnImagesSurface();
 
-		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up... */
+		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up,
+		 * as we expecet RGBA and straight alpha... */
 		size_t pixel_count = w * h;
 
 		/*

--- a/cre.cpp
+++ b/cre.cpp
@@ -3174,11 +3174,11 @@ static int drawCurrentPage(lua_State *L) {
 
 		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up,
 		 * as we expecet RGBA and straight alpha... */
-		size_t pixel_count = w * h;
+		size_t px_count = w * h;
 
 		/*
 		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
-		while (pixel_count--) {
+		while (px_count--) {
 			uint32_t px = *p;
 			// Swap B <-> R, keep G, invert A
 			*p++ = ((px << 16) & 0x00FF0000) | ((px >> 16) & 0x000000FF) | (px & 0x0000FF00) | ((px & 0xFF000000) ^ 0xFF000000);
@@ -3186,7 +3186,7 @@ static int drawCurrentPage(lua_State *L) {
 		*/
 
 		uint8_t * __restrict p = bb->data;
-		while (pixel_count--) {
+		while (px_count--) {
 			// Swap B <-> R
 			const uint8_t b = p[0];
 			p[0] = p[2];
@@ -3197,6 +3197,14 @@ static int drawCurrentPage(lua_State *L) {
 			// Next pixel!
 			p+=4;
 		}
+
+		/*
+		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
+		while (px_count--) {
+			// Invert A
+			*p++ ^= 0xFF000000;
+		}
+		*/
 	}
 	else {
 		/* Set DrawBuf to 8bpp */

--- a/cre.cpp
+++ b/cre.cpp
@@ -31,6 +31,31 @@ extern "C" {
 #include "lvdocview.h"
 #include "lvimg.h"
 
+// For pixel format conversions
+typedef union
+{
+	uint32_t p;
+	struct
+	{
+		uint8_t r;
+		uint8_t g;
+		uint8_t b;
+		uint8_t a;
+	} color;
+} KOPixel;
+
+typedef union
+{
+	uint32_t p;
+	struct
+	{
+		uint8_t b;
+		uint8_t g;
+		uint8_t r;
+		uint8_t a;
+	} color;
+} CRePixel;
+
 static void replaceColor( char * str, lUInt32 color ) {
 	// in line like "0 c #80000000",
 	// replace value of color
@@ -3185,6 +3210,7 @@ static int drawCurrentPage(lua_State *L) {
 		}
 		*/
 
+		/*
 		uint8_t * __restrict p = bb->data;
 		while (pixel_count--) {
 			// Swap B <-> R
@@ -3196,6 +3222,20 @@ static int drawCurrentPage(lua_State *L) {
 
 			// Next pixel!
 			p+=4;
+		}
+		*/
+
+		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
+		while (pixel_count--) {
+			const CRePixel cre = { .p = *p };
+			// Can't do that in C++ :( (c.f., https://en.cppreference.com/w/cpp/language/aggregate_initialization)
+			//const KOPixel ko = { .color.r = cre.color.r, .color.g = cre.color.g, .color.b = cre.color.b, .color.a = cre.color.a ^ 0xFFu };
+			KOPixel ko;
+			ko.color.r = cre.color.r;
+			ko.color.g = cre.color.g;
+			ko.color.b = cre.color.b;
+			ko.color.a = cre.color.a ^ 0xFFu;
+			*p++ = ko.p;
 		}
 	}
 	else {

--- a/cre.cpp
+++ b/cre.cpp
@@ -3173,43 +3173,20 @@ static int drawCurrentPage(lua_State *L) {
 		drawn_images_surface = drawBuf.getDrawnImagesSurface();
 
 		/* CRe uses inverted alpha *and* BGRA pixel order, so, fix that up,
-		 * as we expecet RGBA and straight alpha... */
-		const size_t px_count = w * h;
-		uint8_t * end = bb->data + (px_count << 2U);
-
-		/*
-		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
-		while (px_count--) {
-			uint32_t px = *p;
-			// Swap B <-> R, keep G, invert A
-			*p++ = ((px << 16) & 0x00FF0000) | ((px >> 16) & 0x000000FF) | (px & 0x0000FF00) | ((px & 0xFF000000) ^ 0xFF000000);
-		}
-		*/
-
-		/*
+		 * as we expect RGBA and straight alpha... */
+		size_t px_count = w * h;
 		uint8_t * __restrict p = bb->data;
 		while (px_count--) {
-		*/
-		for (uint8_t * __restrict p = bb->data; p < end; p+=4) {
 			// Swap B <-> R
 			const uint8_t b = p[0];
 			p[0] = p[2];
 			p[2] = b;
 			// Invert A
 			p[3] ^= 0xFFu;
-		/*
+
 			// Next pixel!
 			p+=4;
-		*/
 		}
-
-		/*
-		uint32_t * __restrict p = (uint32_t* __restrict) bb->data;
-		while (px_count--) {
-			// Invert A
-			*p++ ^= 0xFF000000;
-		}
-		*/
 	}
 	else {
 		/* Set DrawBuf to 8bpp */

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -125,8 +125,6 @@ message("Will build crengine library")
 add_definitions(-DHAVE_PROTOTYPES)
 add_definitions(-DHAVE_UNSIGNED_CHAR)
 add_definitions(-DCR_EMULATE_GETTEXT)
-# c.f., https://github.com/koreader/crengine/pull/275
-add_definitions(-DCR_RENDER_32BPP_RGB_PXFMT)
 add_definitions(-Dmain=xxxmain)
 set (CRENGINE_SOURCES
     ${CRE_DIR}/qimagescale/qimagescale.cpp


### PR DESCRIPTION
We expect RGBA, CRe uses BGRX (well, alpha is actually sane, but inverted. Which, AFAIK, is usually a weird legacy PNG/Gif quirk or something, but, oh, well).

As discussed in https://github.com/koreader/koreader/pull/7021

Depends on https://github.com/koreader/crengine/pull/402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1265)
<!-- Reviewable:end -->
