### PR TITLE
Android: Never ever touch the Lua blitter

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -221,7 +221,7 @@ static inline void BBRGB32_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotat
 }
 
 static inline unsigned int BB_GET_WIDTH(BlitBuffer * restrict bb) {
-    if (GET_BB_ROTATION(bb) & 1 == 0) {
+    if ((GET_BB_ROTATION(bb) & 1U) == 0U) {
         return bb->w;
     } else {
         return bb->h;
@@ -229,7 +229,7 @@ static inline unsigned int BB_GET_WIDTH(BlitBuffer * restrict bb) {
 }
 
 static inline unsigned int BB_GET_HEIGHT(BlitBuffer * restrict bb) {
-    if (GET_BB_ROTATION(bb) & 1 == 0) {
+    if ((GET_BB_ROTATION(bb) & 1U) == 0U) {
         return bb->h;
     } else {
         return bb->w;
@@ -2380,7 +2380,7 @@ void BB_paint_rounded_corner(BlitBuffer * restrict bb, unsigned int off_x, unsig
             }
         }
 
-        for (unsigned int tmp_y = y; tmp_y < y2; tmp_y--) {
+        for (unsigned int tmp_y = y; tmp_y > y2; tmp_y--) {
             if (bb_type == TYPE_BB8) {
                 const Color8 color = { .a = c };
 

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -180,6 +180,78 @@ static const char*
     } \
 })
 
+static inline void BB8_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8 * restrict color) {
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+        Color8 * restrict pixel;
+        BB_GET_PIXEL(bb, rotation, Color8, x, y, pixel);
+        *pixel = *color;
+    }
+}
+
+static inline void BB8A_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8A * restrict color) {
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+        Color8A * restrict pixel;
+        BB_GET_PIXEL(bb, rotation, Color8A, x, y, pixel);
+        *pixel = *color;
+    }
+}
+
+static inline void BBRGB16_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB16 * restrict color) {
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+        ColorRGB16 * restrict pixel;
+        BB_GET_PIXEL(bb, rotation, ColorRGB16, x, y, pixel);
+        *pixel = *color;
+    }
+}
+
+static inline void BBRGB24_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB24 * restrict color) {
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+        ColorRGB24 * restrict pixel;
+        BB_GET_PIXEL(bb, rotation, ColorRGB24, x, y, pixel);
+        *pixel = *color;
+    }
+}
+
+static inline void BBRGB32_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB32 * restrict color) {
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+        ColorRGB32 * restrict pixel;
+        BB_GET_PIXEL(bb, rotation, ColorRGB32, x, y, pixel);
+        *pixel = *color;
+    }
+}
+
+static inline unsigned int BB_GET_WIDTH(BlitBuffer * restrict bb) {
+    if (GET_BB_ROTATION(bb) & 1 == 0) {
+        return bb->w;
+    } else {
+        return bb->h;
+    }
+}
+
+static inline unsigned int BB_GET_HEIGHT(BlitBuffer * restrict bb) {
+    if (GET_BB_ROTATION(bb) & 1 == 0) {
+        return bb->h;
+    } else {
+        return bb->w;
+    }
+}
+
+function BB_mt.__index:getWidth()
+    if 0 == band(1, self:getRotation()) then
+        return self.w
+    else
+        return self.h
+    end
+end
+
+function BB_mt.__index:getHeight()
+    if 0 == band(1, self:getRotation()) then
+        return self.h
+    else
+        return self.w
+    end
+end
+
 
 void BB_fill(BlitBuffer * restrict bb, uint8_t v) {
     // Handle any target pitch properly

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -180,6 +180,33 @@ static const char*
     } \
 })
 
+#define SET_PIXEL_CLAMPED(bb, bb_type, bb_rotation, x, y, width, height, color) \
+({ \
+    if (likely(x >= 0U && x < width && y >= 0 && y < height)) { \
+        if (bb_type == TYPE_BB8) { \
+            Color8 * restrict dstptr; \
+            BB_GET_PIXEL(bb, bb_rotation, Color8, x, y, &dstptr); \
+            *dstptr = *color; \
+        } else if (bb_type == TYPE_BB8A) { \
+            Color8A * restrict dstptr; \
+            BB_GET_PIXEL(bb, bb_rotation, Color8A, x, y, &dstptr); \
+            *dstptr = *color; \
+        } else if (bb_type == TYPE_BBRGB16) { \
+            ColorRGB16 * restrict dstptr; \
+            BB_GET_PIXEL(bb, bb_rotation, ColorRGB16, x, y, &dstptr); \
+            *dstptr = *color; \
+        } else if (bb_type == TYPE_BBRGB24) { \
+            ColorRGB24 * restrict dstptr; \
+            BB_GET_PIXEL(bb, bb_rotation, ColorRGB24, x, y, &dstptr); \
+            *dstptr = *color; \
+        } else if (bb_type == TYPE_BBRGB32) { \
+            ColorRGB32 * restrict dstptr; \
+            BB_GET_PIXEL(bb, bb_rotation, ColorRGB32, x, y, &dstptr); \
+            *dstptr = *color; \
+        } \
+    } \
+})
+
 static inline void BB8_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8 * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         Color8 * restrict pixel;
@@ -2367,6 +2394,9 @@ void BB_paint_rounded_corner(BlitBuffer * restrict bb, unsigned int off_x, unsig
     unsigned int x2 = 0U;
     unsigned int y2 = r2;
     float delta2 = 5.f/4.f - r;
+
+    const int bb_type = GET_BB_TYPE(bb);
+    const int bb_rotation = GET_BB_ROTATION(bb);
 
     while (x < y) {
         // decrease y if we are out of circle

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -189,7 +189,7 @@ static inline void BB8_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation,
 }
 
 static inline void BB8A_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8A * restrict color) {
-    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+    if (likely(x >= 0U && x < width && y >= 0U && y < height)) {
         Color8A * restrict pixel;
         BB_GET_PIXEL(bb, rotation, Color8A, x, y, &pixel);
         *pixel = *color;
@@ -197,7 +197,7 @@ static inline void BB8A_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation
 }
 
 static inline void BBRGB16_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB16 * restrict color) {
-    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+    if (likely(x >= 0U && x < width && y >= 0U && y < height)) {
         ColorRGB16 * restrict pixel;
         BB_GET_PIXEL(bb, rotation, ColorRGB16, x, y, &pixel);
         *pixel = *color;
@@ -205,7 +205,7 @@ static inline void BBRGB16_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotat
 }
 
 static inline void BBRGB24_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB24 * restrict color) {
-    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+    if (likely(x >= 0U && x < width && y >= 0U && y < height)) {
         ColorRGB24 * restrict pixel;
         BB_GET_PIXEL(bb, rotation, ColorRGB24, x, y, &pixel);
         *pixel = *color;
@@ -213,7 +213,7 @@ static inline void BBRGB24_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotat
 }
 
 static inline void BBRGB32_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB32 * restrict color) {
-    if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
+    if (likely(x >= 0U && x < width && y >= 0U && y < height)) {
         ColorRGB32 * restrict pixel;
         BB_GET_PIXEL(bb, rotation, ColorRGB32, x, y, &pixel);
         *pixel = *color;

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -183,7 +183,7 @@ static const char*
 static inline void BB8_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8 * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         Color8 * restrict pixel;
-        BB_GET_PIXEL(bb, rotation, Color8, x, y, pixel);
+        BB_GET_PIXEL(bb, rotation, Color8, x, y, &pixel);
         *pixel = *color;
     }
 }
@@ -191,7 +191,7 @@ static inline void BB8_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation,
 static inline void BB8A_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const Color8A * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         Color8A * restrict pixel;
-        BB_GET_PIXEL(bb, rotation, Color8A, x, y, pixel);
+        BB_GET_PIXEL(bb, rotation, Color8A, x, y, &pixel);
         *pixel = *color;
     }
 }
@@ -199,7 +199,7 @@ static inline void BB8A_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation
 static inline void BBRGB16_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB16 * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         ColorRGB16 * restrict pixel;
-        BB_GET_PIXEL(bb, rotation, ColorRGB16, x, y, pixel);
+        BB_GET_PIXEL(bb, rotation, ColorRGB16, x, y, &pixel);
         *pixel = *color;
     }
 }
@@ -207,7 +207,7 @@ static inline void BBRGB16_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotat
 static inline void BBRGB24_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB24 * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         ColorRGB24 * restrict pixel;
-        BB_GET_PIXEL(bb, rotation, ColorRGB24, x, y, pixel);
+        BB_GET_PIXEL(bb, rotation, ColorRGB24, x, y, &pixel);
         *pixel = *color;
     }
 }
@@ -215,7 +215,7 @@ static inline void BBRGB24_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotat
 static inline void BBRGB32_SET_PIXEL_CLAMPED(BlitBuffer * restrict bb, int rotation, unsigned int x, unsigned int y, unsigned int width, unsigned int height, const ColorRGB32 * restrict color) {
     if (likely(x >= 0U && x < width && y >= 0 && y < height)) {
         ColorRGB32 * restrict pixel;
-        BB_GET_PIXEL(bb, rotation, ColorRGB32, x, y, pixel);
+        BB_GET_PIXEL(bb, rotation, ColorRGB32, x, y, &pixel);
         *pixel = *color;
     }
 }
@@ -2335,7 +2335,7 @@ void BB_paint_rounded_corner(BlitBuffer * restrict bb, unsigned int off_x, unsig
     }
     */
 
-    r = MIN(r, h, w);
+    r = MIN(r, MIN(h, w));
     if (bw > r) {
         bw = r;
     }

--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -164,4 +164,6 @@ DLL_PUBLIC void BB_invert_blit_from(BlitBuffer * restrict dest, const BlitBuffer
                          unsigned int offs_x, unsigned int offs_y, unsigned int w, unsigned int h);
 DLL_PUBLIC void BB_color_blit_from(BlitBuffer * restrict dest, const BlitBuffer * restrict source, unsigned int dest_x, unsigned int dest_y,
                         unsigned int offs_x, unsigned int offs_y, unsigned int w, unsigned int h, Color8A * restrict color);
+DLL_PUBLIC void BB_paint_rounded_corner(BlitBuffer * restrict bb, unsigned int off_x, unsigned int off_y, unsigned int w, unsigned int h,
+                        unsigned int bw, unsigned int r, uint8_t c);
 #endif

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -677,6 +677,7 @@ if os.getenv("IS_ANDROID") then
     --       too many given the way we handle nightmode on Android
     --       (which is a single invertBlitFrom when we flip the buffer to Android).
     --       Thankfully, the only setter that applies to is setPixel.
+    -- FIXME: Implement paintRounded* in the C BB and get rid of this hack.
     fake_invert = true
 else
     -- Determine if a pair of buffers can use CBB in relation to each other, or whether CBB is used at all.

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -145,7 +145,6 @@ void BB_paint_rounded_corner(BlitBuffer * restrict bb, unsigned int off_x, unsig
 -- We'll load it later
 local cblitbuffer
 local use_cblitbuffer
-local fake_invert
 
 -- color value types
 local Color4U = ffi.typeof("Color4U")

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2181,6 +2181,10 @@ function BB:setUseCBB(enabled)
    use_cblitbuffer = enabled
 end
 
+function BB:getUseCBB(enabled)
+   return use_cblitbuffer
+end
+
 -- Set the actual enable/disable CBB flag and tweak JIT opts accordingly.
 -- Returns the actual state.
 function BB:enableCBB(enabled)

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -671,14 +671,6 @@ end
 if os.getenv("IS_ANDROID") then
     BB_mt.__index.canUseCbbTogether = BB.getUseCBB
     BB_mt.__index.canUseCbb = BB.getUseCBB
-
-    -- NOTE: While we can go through the C BB for *mostly* everything, and as such completely ignore the
-    --       invert flag (because the C BB doesn't support it), a very few things may call setPixel directly,
-    --       outside of blit* methods: most notably the paintRounded* stuff.
-    --       As such, we'll use this flag to bypass the inversion there, otherwise that'll be one inversion
-    --       too many given the way we handle nightmode on Android
-    --       (which is a single invertBlitFrom when we flip the buffer to Android).
-    --       Thankfully, the only setter that applies to is setPixel.
 else
     -- Determine if a pair of buffers can use CBB in relation to each other, or whether CBB is used at all.
     -- Used to skip unsupported modes such as unrelated inverses.

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -679,8 +679,6 @@ if os.getenv("IS_ANDROID") then
     --       too many given the way we handle nightmode on Android
     --       (which is a single invertBlitFrom when we flip the buffer to Android).
     --       Thankfully, the only setter that applies to is setPixel.
-    -- FIXME: Implement paintRounded* in the C BB and get rid of this hack.
-    fake_invert = true
 else
     -- Determine if a pair of buffers can use CBB in relation to each other, or whether CBB is used at all.
     -- Used to skip unsupported modes such as unrelated inverses.
@@ -786,7 +784,7 @@ function BBRGB32_mt.__index.getMyColor(color) return color:getColorRGB32() end
 -- set pixel values
 function BB_mt.__index:setPixel(x, y, color)
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 and not fake_invert then color = color:invert() end
+    if self:getInverse() == 1 then color = color:invert() end
     self:getPixelP(px, py)[0]:set(color)
 end
 -- Dithering (BB8 only)

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -130,6 +130,7 @@ function framebuffer:_updateWindow()
         bb:setInverse(ext_bb:getInverse())
         bb:setRotation(ext_bb:getRotation())
 
+        -- getUseCBB should *always* be true on Android, but let's be thorough...
         if bb:getInverse() == 1 and BB:getUseCBB() then
             -- If we're using the CBB (which we should), the invert flag has been thoroughly ignored up until now,
             -- so, simply invert everything *now* ;).

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -129,7 +129,16 @@ function framebuffer:_updateWindow()
         -- All we need is to do is simply clone the invert and rotation settings, so that the blit below becomes 1:1 copy.
         bb:setInverse(ext_bb:getInverse())
         bb:setRotation(ext_bb:getRotation())
-        bb:blitFrom(ext_bb)
+
+        if bb:getInverse() == 1 and BB:getUseCBB() then
+            -- If we're using the CBB (which we should), the invert flag has been thoroughly ignored up until now,
+            -- so, simply invert everything *now* ;).
+            -- The idea is that we absolutely want to avoid the Lua BB on Android, because it is *extremely* erratic,
+            -- because of the mcode alloc issues...
+            bb:invertblitFrom(ext_bb)
+        else
+            bb:blitFrom(ext_bb)
+        end
     end
 
     android.lib.ANativeWindow_unlockAndPost(android.app.window);


### PR DESCRIPTION
As a side-effect of #1200, software nightmode was no-longer handled in the C blitter, it instead went through to the Lua blitter.

This exacerbated the latent issues with LuaJIT and mcode_alloc on that platform (remember, the C blitter was initially implemented *specifically* to avoid stressing LuaJIT with the blitter code on Android because of that fact).

So, without going back to the admittedly messy way this was handled before, tweak a few things to make Android a special snowflake again, so that nightmode on Android no longer goes through the Lua blitter.

In fact, port `paintRoundedRect` to the C blitter to make doubly sure of that (and get rid of an ugly hack that was necessary to handle inversion quirks in setPixel otherwise ;p).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1268)
<!-- Reviewable:end -->
