### PR TITLE
thirdparty/sdcv current master for fast synonym search

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -70,7 +70,7 @@ set(PATCH_CMD "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv.patch")
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/Dushistov/sdcv.git
-    v0.5.2
+    4ae420734990ab9f5ccc038262368256b9323f4a
     ${SOURCE_DIR}
 )
 
@@ -79,7 +79,7 @@ download_project(
     GIT_REPOSITORY
     https://github.com/Dushistov/sdcv.git
     GIT_TAG
-    v0.5.2
+    4ae420734990ab9f5ccc038262368256b9323f4a
     #DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     PATCH_COMMAND COMMAND ${PATCH_CMD}
 )

--- a/thirdparty/sdcv/sdcv.patch
+++ b/thirdparty/sdcv/sdcv.patch
@@ -2,10 +2,11 @@ diff --git a/src/sdcv.cpp b/src/sdcv.cpp
 index 0c75eb1..2e40b6d 100644
 --- a/src/sdcv.cpp
 +++ b/src/sdcv.cpp
-@@ -62,7 +62,10 @@ using StrArr = ResourceWrapper<gchar *, gchar *, free_str_array>;
+@@ -66,7 +66,10 @@ using StrArr = ResourceWrapper<gchar *, gchar *, free_str_array>;
  static void list_dicts(const std::list<std::string> &dicts_dir_list, bool use_json);
  
- int main(int argc, char *argv[]) try {
+ int main(int argc, char *argv[])
+ try {
 -    setlocale(LC_ALL, "");
 +    // LC_ALL and LANG may be empty on Android, and GLib would consider locale to be 'C'
 +    // and try to convert our provided utf8 to utf8 which would fail


### PR DESCRIPTION
Cf. <https://github.com/Dushistov/sdcv/pull/67>.

Also update patch file to account for current master.
Cf. <https://github.com/Dushistov/sdcv/commit/7facbe215e9d318adc32fab793e05364c4b4d7ea>

PS Also re. <https://github.com/koreader/koreader/issues/3496#issuecomment-749997714>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1269)
<!-- Reviewable:end -->
