### PR TITLE
[CI, macOS] Use files most relevant to build to invalidate cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Cache for ccache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         env:
           cache-name: cache-ccache
         with:
           path: ~/.ccache # ccache cache files are stored in `~/.ccache` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('Makefile', 'Makefile.defs', 'Makefile.third', '**/CMakeLists.txt') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-


### PR DESCRIPTION
Something along these lines should solve the issue that ccache is becoming so outdated that it's barely even helpful anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1276)
<!-- Reviewable:end -->
