### PR TITLE
SDL: Handle text input

### DIFF
--- a/ffi-cdecl/SDL2_0_decl.c
+++ b/ffi-cdecl/SDL2_0_decl.c
@@ -12,6 +12,8 @@ cdecl_type(Uint8)
 cdecl_type(Sint8)
 
 cdecl_struct(SDL_Keysym)
+cdecl_func(SDL_StartTextInput)
+cdecl_func(SDL_StopTextInput)
 
 cdecl_type(SDL_EventType)
 

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -121,6 +121,11 @@ function S.open(w, h, x, y)
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
     S.texture = S.createTexture()
 
+    -- Start delivering Unicode text as well as keypresses - this will
+    -- handle things like Shift-numbers and letters according to the layout
+    -- and will deliver SDL_TEXTINPUT with that text.
+    SDL.SDL_StartTextInput()
+
     openGameController()
 end
 
@@ -273,9 +278,11 @@ function S.waitForEvent(usecs)
             -- noop for trackpad finger inputs which interfere with emulated mouse inputs
             do end -- luacheck: ignore 541
         elseif event.type == SDL.SDL_KEYDOWN then
-            genEmuEvent(C.EV_KEY, event.key.keysym.scancode, 1)
+            genEmuEvent(C.EV_KEY, event.key.keysym.sym, 1)
         elseif event.type == SDL.SDL_KEYUP then
-            genEmuEvent(C.EV_KEY, event.key.keysym.scancode, 0)
+            genEmuEvent(C.EV_KEY, event.key.keysym.sym, 0)
+        elseif event.type == SDL.SDL_TEXTINPUT then
+            genEmuEvent(EV_SDL, SDL.SDL_TEXTINPUT, ffi.string(event.text.text))
         elseif event.type == SDL.SDL_MOUSEMOTION
             or event.type == SDL.SDL_FINGERMOTION then
             local is_finger = event.type == SDL.SDL_FINGERMOTION

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -121,12 +121,18 @@ function S.open(w, h, x, y)
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
     S.texture = S.createTexture()
 
+    openGameController()
+end
+
+function S:startTextInput()
     -- Start delivering Unicode text as well as keypresses - this will
     -- handle things like Shift-numbers and letters according to the layout
     -- and will deliver SDL_TEXTINPUT with that text.
     SDL.SDL_StartTextInput()
+end
 
-    openGameController()
+function S:stopTextInput()
+    SDL.SDL_StopTextInput()
 end
 
 function S.createTexture(w, h)

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -883,4 +883,5 @@ struct SDL_version {
   Uint8 patch;
 };
 void SDL_GetVersion(struct SDL_version *) __attribute__((visibility("default")));
+void SDL_StartTextInput(void);
 ]]

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -260,6 +260,8 @@ struct SDL_Keysym {
   Uint16 mod;
   Uint32 unused;
 };
+void SDL_StartTextInput(void);
+void SDL_StopTextInput(void);
 typedef enum {
   SDL_FIRSTEVENT = 0,
   SDL_QUIT = 256,
@@ -883,5 +885,4 @@ struct SDL_version {
   Uint8 patch;
 };
 void SDL_GetVersion(struct SDL_version *) __attribute__((visibility("default")));
-void SDL_StartTextInput(void);
 ]]


### PR DESCRIPTION
Turn on text input for SDL, which means it decodes key events
into text events according to the keyboard layout and delivers
it as Unicode.

This can then be wrapped in an SDL event and passed upwards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1277)
<!-- Reviewable:end -->
