### PR TITLE
Minor cosmetic tweak

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -723,13 +723,13 @@ end
 function BB_mt.__index:getPhysicalCoordinates(x, y)
     local rotation = self:getRotation()
     if rotation == 0 then
-        return x, y
+        return              x,              y
     elseif rotation == 1 then
-        return self.w - y - 1, x
+        return self.w - y - 1,              x
     elseif rotation == 2 then
         return self.w - x - 1, self.h - y - 1
     elseif rotation == 3 then
-        return y, self.h - x - 1
+        return              y, self.h - x - 1
     end
 end
 function BB_mt.__index:getPhysicalRect(x, y, w, h)


### PR DESCRIPTION
Completely random whitespace change while looking into https://www.mobileread.com/forums/showpost.php?p=4077126&postcount=334 (which, btw, makes no sense, unless there's some heinous viewport/rotation shenanigan going on. My one theory was an underflow, but 2020.12 wasn't using unsigned data types yet, and checkBounds should guard against negative values anyway; and 2020.12 was effectively using the Lua blitter for nightmode, so that magically working now makes no sense, again).

(Well, not so random, `getPhysicalRect` just below it is formatted the same way).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1280)
<!-- Reviewable:end -->
