### PR TITLE
Kobo: Switch to DU for "fast"

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -179,6 +179,10 @@ function fb:refreshFastImp(x, y, w, h, d)
     -- default is fallback
     return self:refreshPartialImp(x, y, w, h, d)
 end
+function fb:refreshWaitForLastImp()
+    -- default is NOP
+    return
+end
 
 -- these should not be overridden, they provide the external refresh API:
 function fb:refreshFull(x, y, w, h, d)
@@ -204,6 +208,9 @@ end
 function fb:refreshFast(x, y, w, h, d)
     x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
     return self:refreshFastImp(x, y, w, h, d)
+end
+function fb:refreshWaitForLast()
+    return self:refreshWaitForLastImp()
 end
 
 -- should be overridden to free resources

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -555,9 +555,10 @@ function framebuffer:refreshFastImp(x, y, w, h, dither)
 end
 
 function framebuffer:refreshWaitForLastImp()
-    self.debug("refresh: waiting for previous update", self.marker)
-    if self.mech_wait_update_complete then
+    if self.mech_wait_update_complete and self.dont_wait_for_marker ~= self.marker then
+        self.debug("refresh: waiting for previous update", self.marker)
         self:mech_wait_update_complete(self.marker)
+        self.dont_wait_for_marker = self.marker
     end
 end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -450,7 +450,7 @@ local function refresh_kobo_mk7(fb, refreshtype, waveform_mode, x, y, w, h, dith
     -- Did we request HW dithering?
     if dither then
         refarea[0].dither_mode = C.EPDC_FLAG_USE_DITHERING_ORDERED
-        if waveform_mode == C.WAVEFORM_MODE_A2 then
+        if waveform_mode == C.WAVEFORM_MODE_A2 or waveform_mode == C.WAVEFORM_MODE_DU then
             refarea[0].quant_bit = 1;
         else
             refarea[0].quant_bit = 7;
@@ -727,7 +727,8 @@ function framebuffer:init()
             self.mech_wait_update_complete = kobo_mk7_mxc_wait_for_update_complete
 
             self.waveform_partial = C.WAVEFORM_MODE_GLR16
-            -- NOTE: DU may rarely be used instead of A2 by Nickel, but never w/ the MONOCHROME flag, so, keep using A2 everywhere on our end.
+            self.waveform_fast = C.WAVEFORM_MODE_DU -- A2 is much more prone to artifacts on Mk. 7 than before, because everything's faster.
+                                                    -- Nickel sometimes uses it, but never w/ the MONOCHROME flag, so, do the same.
         end
     elseif self.device:isPocketBook() then
         require("ffi/mxcfb_pocketbook_h")

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -554,6 +554,13 @@ function framebuffer:refreshFastImp(x, y, w, h, dither)
     self:mech_refresh(C.UPDATE_MODE_PARTIAL, self.waveform_fast, x, y, w, h, dither)
 end
 
+function framebuffer:refreshWaitForLastImp()
+    self.debug("refresh: waiting for previous update", self.marker)
+    if self.mech_wait_update_complete then
+        self:mech_wait_update_complete(self.marker)
+    end
+end
+
 -- Detect Allwinner boards. Those emulate mxcfb API in a custom driver (poorly).
 function framebuffer:isB288(fb)
     require("ffi/mxcfb_pocketbook_h")

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -722,6 +722,10 @@ function framebuffer:init()
         --       We handle that by NOT setting waveform_reagl (so _isREAGLWaveFormMode never matches), and just customizing waveform_partial.
         --       Nickel doesn't wait for completion of previous markers on those PARTIAL GLR16, so that's enough to keep our heuristics intact,
         --       while still doing the right thing everywhere ;).
+        --       Turns out there's a good reason for that: the EPDC will fence REAGL updates internally (possibly via the PxP).
+        --       This makes interaction between partial and other modes slightly finicky in practice in some corner-cases,
+        --       (c.f., the SkimTo widget workaround were we batch a button highlight with the reader's partial,
+        --       and then fence *that* manually to avoid the partial being delayed by the button's 'fast' highlight).
         if isMk7 then
             self.device.canHWDither = yes
             self.mech_refresh = refresh_kobo_mk7

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -677,7 +677,7 @@ function framebuffer:init()
         self.mech_refresh = refresh_kobo
         self.mech_wait_update_complete = kobo_mxc_wait_for_update_complete
 
-        self.waveform_fast = C.WAVEFORM_MODE_A2
+        self.waveform_fast = C.WAVEFORM_MODE_DU
         self.waveform_ui = C.WAVEFORM_MODE_AUTO
         self.waveform_flashui = self.waveform_ui
         self.waveform_full = C.NTX_WFM_MODE_GC16

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -729,7 +729,7 @@ function framebuffer:init()
 
             self.waveform_partial = C.WAVEFORM_MODE_GLR16
             self.waveform_fast = C.WAVEFORM_MODE_DU -- A2 is much more prone to artifacts on Mk. 7 than before, because everything's faster.
-                                                    -- Nickel sometimes uses it, but never w/ the MONOCHROME flag, so, do the same.
+                                                    -- Nickel sometimes uses DU, but never w/ the MONOCHROME flag, so, do the same.
                                                     -- Plus, DU + MONOCHROME + INVERT is much more prone to the Mk. 7 EPDC bug where some/all
                                                     -- EPDC flags just randomly go bye-bye...
         end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -730,6 +730,8 @@ function framebuffer:init()
             self.waveform_partial = C.WAVEFORM_MODE_GLR16
             self.waveform_fast = C.WAVEFORM_MODE_DU -- A2 is much more prone to artifacts on Mk. 7 than before, because everything's faster.
                                                     -- Nickel sometimes uses it, but never w/ the MONOCHROME flag, so, do the same.
+                                                    -- Plus, DU + MONOCHROME + INVERT is much more prone to the Mk. 7 EPDC bug where some/all
+                                                    -- EPDC flags just randomly go bye-bye...
         end
     elseif self.device:isPocketBook() then
         require("ffi/mxcfb_pocketbook_h")

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -724,8 +724,8 @@ function framebuffer:init()
         --       while still doing the right thing everywhere ;).
         --       Turns out there's a good reason for that: the EPDC will fence REAGL updates internally (possibly via the PxP).
         --       This makes interaction between partial and other modes slightly finicky in practice in some corner-cases,
-        --       (c.f., the SkimTo widget workaround were we batch a button highlight with the reader's partial,
-        --       and then fence *that* manually to avoid the partial being delayed by the button's 'fast' highlight).
+        --       (c.f., the SkimTo/Button widgets workaround where we batch a button's 'fast' highlight with the reader's 'partial',
+        --       and then fence *that batch* manually to avoid the (REAGL) 'partial' being delayed by the button's 'fast' highlight).
         if isMk7 then
             self.device.canHWDither = yes
             self.mech_refresh = refresh_kobo_mk7


### PR DESCRIPTION
Also, export `MXCFB_WAIT_FOR_UPDATE_COMPLETE` to allow calling it manually on the previous marker from front.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1283)
<!-- Reviewable:end -->
