### PR TITLE
Unbreak tar on older kernels

### DIFF
--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -14,16 +14,23 @@ assert_var_defined(LIBS)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
+# O_PATH may be defined in our ToolChains, but older devices actually run kernels where it's not entirely usable...
+# (Usage in tar via gnulib's https://git.savannah.gnu.org/cgit/gnulib.git/log/lib/fchmodat.c)
+if(NOT DEFINED ENV{EMULATE_READER})
+    set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/tar-1.33-remove-o_path-usage.patch")
+endif()
+
 # The wordsplit changes introduced in 1.31 require glob.h, which is not present on Androdi before ABI 28 (c.f., #787)
 if(DEFINED ENV{ANDROID})
-    set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/tar-1.31-revert-wordsplit-for-android-glob.patch")
+    set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/tar-1.31-revert-wordsplit-for-android-glob.patch")
 endif()
-#set(PATCH_CMD2 sh -c "touch ABOUT-NLS po/Makevars.template")
-#set(PATCH_CMD3 sh -c "AUTOPOINT=true ./bootstrap --skip-po")
+
+#set(PATCH_CMD3 sh -c "touch ABOUT-NLS po/Makevars.template")
+#set(PATCH_CMD4 sh -c "AUTOPOINT=true ./bootstrap --skip-po")
 
 # Avoid pulling > GLIBC_2.4 symbols on crappy platforms
 if(DEFINED ENV{LEGACY} OR DEFINED ENV{POCKETBOOK})
-	set(CFG_ENV_VAR "ac_cv_func_utimensat=no ac_cv_func_futimens=no")
+    set(CFG_ENV_VAR "ac_cv_func_utimensat=no ac_cv_func_futimens=no")
 endif()
 
 set(CFG_ENV_VAR "${CFG_ENV_VAR} CC=\"${CC} -DHAVE_MKFIFO=1\" CFLAGS=\"${CFLAGS}\" LDFLAGS=\"${LDFLAGS}\"")
@@ -59,10 +66,10 @@ ExternalProject_Add(
     URL http://ftpmirror.gnu.org/tar/tar-${TAR_VER}.tar.gz
     URL_MD5 de0816a6bae5d2a982d9bde76b79b291
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
-    PATCH_COMMAND COMMAND ${PATCH_CMD1}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2}
     #DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     #BUILD_IN_SOURCE 1
-    #PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3}
+    #PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}
     # The buildsystem outputs binaries in a subdirectory...

--- a/thirdparty/tar/tar-1.33-remove-o_path-usage.patch
+++ b/thirdparty/tar/tar-1.33-remove-o_path-usage.patch
@@ -1,0 +1,24 @@
+diff -Nuarp tar-1.33-ori/gnu/fchmodat.c tar-1.33/gnu/fchmodat.c
+--- tar-1.33-ori/gnu/fchmodat.c	2021-01-07 15:29:44.000000000 +0100
++++ tar-1.33/gnu/fchmodat.c	2021-01-16 00:41:39.414012004 +0100
+@@ -68,7 +68,7 @@ fchmodat (int dir, char const *file, mod
+     {
+       struct stat st;
+ 
+-#  if defined O_PATH && defined AT_EMPTY_PATH
++#  if defined NOPE_PATH && defined AT_EMPTY_PATH
+       /* Open a file descriptor with O_NOFOLLOW, to make sure we don't
+          follow symbolic links, if /proc is mounted.  O_PATH is used to
+          avoid a failure if the file is not readable.
+diff -Nuarp tar-1.33-ori/gnu/lchmod.c tar-1.33/gnu/lchmod.c
+--- tar-1.33-ori/gnu/lchmod.c	2021-01-07 15:28:45.000000000 +0100
++++ tar-1.33/gnu/lchmod.c	2021-01-16 00:41:28.708012124 +0100
+@@ -45,7 +45,7 @@
+ int
+ lchmod (char const *file, mode_t mode)
+ {
+-#if defined O_PATH && defined AT_EMPTY_PATH
++#if defined NOPE_PATH && defined AT_EMPTY_PATH
+   /* Open a file descriptor with O_NOFOLLOW, to make sure we don't
+      follow symbolic links, if /proc is mounted.  O_PATH is used to
+      avoid a failure if the file is not readable.


### PR DESCRIPTION
Re https://github.com/koreader/koreader/issues/7140

("Regression" thanks to a gnulib update in tar 1.33).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1288)
<!-- Reviewable:end -->
