### PR TITLE
BlitBuffer: Make sure we *never* update a color reference

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -749,7 +749,14 @@ static uint8_t
     // NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
     //       The only overflow we should ever catch should be for a few white (v = 0xFF) input pixels
     //       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
-    return (q > UINT8_MAX ? UINT8_MAX : (uint8_t) q);
+
+    const uint8_t c = q > UINT8_MAX ? UINT8_MAX : (uint8_t) q;
+
+    if (x < 250 && y < 50) {
+        printf("CBB: (%03d, %03d) #%02X -> #%02X\n", x, y, v, c);
+    }
+
+    return c;
 }
 
 void BB_dither_blit_to_BB8(const BlitBuffer * restrict src, BlitBuffer * restrict dst,

--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -749,14 +749,7 @@ static uint8_t
     // NOTE: We're doing unsigned maths, so, clamping is basically MIN(q, UINT8_MAX) ;).
     //       The only overflow we should ever catch should be for a few white (v = 0xFF) input pixels
     //       that get shifted to the next step (i.e., q = 272 (0xFF + 17)).
-
-    const uint8_t c = q > UINT8_MAX ? UINT8_MAX : (uint8_t) q;
-
-    if (x < 250 && y < 50) {
-        printf("CBB: (%03d, %03d) #%02X -> #%02X\n", x, y, v, c);
-    }
-
-    return c;
+    return (q > UINT8_MAX ? UINT8_MAX : (uint8_t) q);
 }
 
 void BB_dither_blit_to_BB8(const BlitBuffer * restrict src, BlitBuffer * restrict dst,

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -562,8 +562,8 @@ function ColorRGB32_mt.__index:invert()
 end
 
 -- comparison:
-function ColorRGB32_mt:__eq(c)
-    c = c:getColorRGB32()
+function ColorRGB32_mt:__eq(color)
+    local c = color:getColorRGB32()
     return (self:getR() == c:getR())
     and (self:getG() == c:getG())
     and (self:getB() == c:getB())
@@ -803,8 +803,8 @@ end
 -- Dithering (BB8 only)
 function BB8_mt.__index:setPixelDither(x, y, color, na, o_x, o_y)
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 then color = color:invert() end
     local c = color:getColor8()
+    if self:getInverse() == 1 then c = c:invert() end
     c.a = dither_o8x8(o_x, o_y, c.a)
     self:getPixelP(px, py)[0]:set(c)
 end
@@ -833,8 +833,8 @@ function BBRGB16_mt.__index:setPixelAdd(x, y, color, alpha)
     end
     -- this method uses an RGB color value
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 then color = color:invert() end
     local c = color:getColorRGB32()
+    if self:getInverse() == 1 then c = c:invert() end
     c.alpha = alpha
     self:getPixelP(px, py)[0]:blend(c)
 end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -775,6 +775,8 @@ function BB4_mt.__index:getPixelP(x, y)
     end
 end
 
+-- Do *NOT* write to the returned pointer!
+-- If you want an actual write pointer, use getPixelP
 function BB_mt.__index:getPixel(x, y)
     local px, py = self:getPhysicalCoordinates(x, y)
     local color = self:getPixelP(px, py)[0]

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -378,6 +378,8 @@ function Color8_mt.__index:ditherpmulblend(x, y, color)
 end
 
 -- color conversions:
+-- NOTE: These *always* return a new object, even when no conversion is needed.
+--       This ensures that, we you work on this new object, you won't potentially affect the source reference!
 -- to Color4L:
 function Color4L_mt.__index:getColor4L() return Color4L(band(0x0F, self.a)) end
 function Color4U_mt.__index:getColor4L() return Color4L(rshift(self.a, 4)) end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -267,10 +267,6 @@ local function dither_o8x8(x, y, v)
         c = q
     end
 
-    if (x < 250 and y < 50) then
-        print(string.format("Lua: (%03d, %03d) #%02X -> #%02X", x, y, tonumber(v), tonumber(c)))
-    end
-
     return c
 end
 
@@ -809,13 +805,6 @@ end
 function BB8_mt.__index:setPixelDither(x, y, color, na, o_x, o_y)
     local px, py = self:getPhysicalCoordinates(x, y)
     if self:getInverse() == 1 then color = color:invert() end
-    if (o_x < 250 and o_y < 50) then
-        if ffi.typeof(color) == R_Color8 then
-            print(string.format("setPixelDither: (%03d, %03d) #%02X", o_x, o_y, color.a))
-        else
-            print(string.format("setPixelDither: (%03d, %03d) #%02X%02X%02X", o_x, o_y, color.r, color.g, color.b))
-        end
-    end
     local c = color:getColor8()
     c.a = dither_o8x8(o_x, o_y, c.a)
     self:getPixelP(px, py)[0]:set(c)

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -782,8 +782,11 @@ end
 function BB_mt.__index:getPixel(x, y)
     local px, py = self:getPhysicalCoordinates(x, y)
     local color = self:getPixelP(px, py)[0]
-    if self:getInverse() == 1 then color = color:invert() end
-    return color
+    if self:getInverse() == 1 then
+        return color:invert()
+    else
+        return color
+    end
 end
 
 -- blitbuffer specific color conversions
@@ -797,8 +800,11 @@ function BBRGB32_mt.__index.getMyColor(color) return color:getColorRGB32() end
 -- set pixel values
 function BB_mt.__index:setPixel(x, y, color)
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 then color = color:invert() end
-    self:getPixelP(px, py)[0]:set(color)
+    if self:getInverse() == 1 then
+        self:getPixelP(px, py)[0]:set(color:invert())
+    else
+        self:getPixelP(px, py)[0]:set(color)
+    end
 end
 -- Dithering (BB8 only)
 function BB8_mt.__index:setPixelDither(x, y, color, na, o_x, o_y)
@@ -864,8 +870,11 @@ function BBRGB16_mt.__index:setPixelBlend(x, y, color)
         return self:setPixel(x, y, color)
     end
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 then color = color:invert() end
-    self:getPixelP(px, py)[0]:blend(color)
+    if self:getInverse() == 1 then
+        self:getPixelP(px, py)[0]:blend(color:invert())
+    else
+        self:getPixelP(px, py)[0]:blend(color)
+    end
 end
 BBRGB24_mt.__index.setPixelBlend = BBRGB16_mt.__index.setPixelBlend
 BBRGB32_mt.__index.setPixelBlend = BBRGB16_mt.__index.setPixelBlend
@@ -909,8 +918,11 @@ function BBRGB16_mt.__index:setPixelPmulBlend(x, y, color)
         return self:setPixel(x, y, color)
     end
     local px, py = self:getPhysicalCoordinates(x, y)
-    if self:getInverse() == 1 then color = color:invert() end
-    self:getPixelP(px, py)[0]:pmulblend(color)
+    if self:getInverse() == 1 then
+        self:getPixelP(px, py)[0]:pmulblend(color:invert())
+    else
+        self:getPixelP(px, py)[0]:pmulblend(color)
+    end
 end
 BBRGB24_mt.__index.setPixelPmulBlend = BBRGB16_mt.__index.setPixelPmulBlend
 BBRGB32_mt.__index.setPixelPmulBlend = BBRGB16_mt.__index.setPixelPmulBlend

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -248,7 +248,7 @@ local function dither_o8x8(x, y, v)
 
     -- map width & height = 8
     -- c = ClampToQuantum((l+(t >= map[(x % mw) + mw * (y % mh)])) * QuantumRange / (L-1));
-    local q = (l + (t >= threshold_map_o8x8[band(x, 7) + 8 * band(y, 7)] and 1 or 0)) * 17
+    local q = (l + (t >= threshold_map_o8x8[band(x, 7) + (8 * band(y, 7))] and 1 or 0)) * 17
     -- NOTE: For some arcane reason, on ARM (at least), this is noticeably faster than Pillow's CLIP8 macro.
     --       Following this logic with ternary operators yields similar results,
     --       so I'm guessing it's the < 256 part of Pillow's macro that doesn't agree with GCC/ARM...

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -315,7 +315,7 @@ function Color8_mt.__index:ditherblend(x, y, color)
     local alpha = color:getAlpha()
     -- simplified: we expect a 8bit grayscale "color" as parameter
     local value = div255(self.a * bxor(alpha, 0xFF) + color:getR() * alpha)
-    value = dither_o8x8(x, y, ffi.cast("uint8_t", value))
+    value = dither_o8x8(x, y, value)
     self:set(Color8(value))
 end
 -- Alpha blending with a premultiplied input (i.e., color OVER self, w/ color being premultiplied)
@@ -366,7 +366,7 @@ function Color8_mt.__index:ditherpmulblend(x, y, color)
     local alpha = color:getAlpha()
     -- simplified: we expect a 8bit grayscale "color" as parameter
     local value = div255(self.a * bxor(alpha, 0xFF) + color:getR() * 0xFF)
-    value = dither_o8x8(x, y, ffi.cast("uint8_t", value))
+    value = dither_o8x8(x, y, value)
     self:set(Color8(value))
 end
 
@@ -1207,10 +1207,7 @@ function BB_mt.__index:ditherblitFrom(source, dest_x, dest_y, offs_x, offs_y, wi
             ffi.cast(P_BlitBuffer, self),
             dest_x, dest_y, offs_x, offs_y, width, height)
     else
-        local t1 = os.clock()
         self:blitFrom(source, dest_x, dest_y, offs_x, offs_y, width, height, self.setPixelDither)
-        local t2 = os.clock()
-        print(string.format("ditherblitFrom took  %9.3f ms", (t2 - t1) * 1000))
     end
 end
 

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -489,7 +489,7 @@ function ColorRGB16_mt.__index:getColorRGB24()
     return ColorRGB24(lshift(r, 3) + rshift(r, 2), lshift(g, 2) + rshift(g, 4), lshift(b, 3) + rshift(b, 2))
 end
 function ColorRGB24_mt.__index:getColorRGB24() return ColorRGB24(self.r, self.g, self.b) end
-function ColorRGB32_mt.__index.getColorRGB24 = ColorRGB24_mt.__index.getColorRGB24
+ColorRGB32_mt.__index.getColorRGB24 = ColorRGB24_mt.__index.getColorRGB24
 
 -- to ColorRGB32:
 function Color4L_mt.__index:getColorRGB32()

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -179,16 +179,13 @@ local ColorRGB32_mt = {__index={}}
 
 -- color setting
 function Color4L_mt.__index:set(color)
-    local c = color:getColor4L()
-    self.a = bor(band(0xF0, self.a), c.a)
+    self.a = bor(band(0xF0, self.a), color:getColor4L().a)
 end
 function Color4U_mt.__index:set(color)
-    local c = color:getColor4U()
-    self.a = bor(band(0x0F, self.a), c.a)
+    self.a = bor(band(0x0F, self.a), color:getColor4U().a)
 end
 function Color8_mt.__index:set(color)
-    local c = color:getColor8()
-    self.a = c.a
+    self.a = color:getColor8().a
 end
 function Color8A_mt.__index:set(color)
     local c = color:getColor8A()
@@ -196,8 +193,7 @@ function Color8A_mt.__index:set(color)
     self.alpha = c.alpha
 end
 function ColorRGB16_mt.__index:set(color)
-    local c = color:getColorRGB16()
-    self.v = c.v
+    self.v = color:getColorRGB16().v
 end
 function ColorRGB24_mt.__index:set(color)
     local c = color:getColorRGB24()

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -257,6 +257,10 @@ local function dither_o8x8(x, y, v)
         c = q
     end
 
+    if (x < 250 and y < 50) then
+        print(string.format("Lua: (%03d, %03d) #%02X -> #%02X", x, y, tonumber(v), tonumber(c)))
+    end
+
     return c
 end
 

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -164,6 +164,8 @@ local P_ColorRGB16 = ffi.typeof("ColorRGB16*") -- luacheck: ignore 211
 local P_ColorRGB24 = ffi.typeof("ColorRGB24*") -- luacheck: ignore 211
 local P_ColorRGB32 = ffi.typeof("ColorRGB32*") -- luacheck: ignore 211
 
+local R_Color8 = ffi.typeof("Color8&")
+
 -- blitbuffer struct types (pointers)
 local P_BlitBuffer = ffi.typeof("BlitBuffer*")
 local P_BlitBuffer_ROData = ffi.typeof("const BlitBuffer*")
@@ -797,6 +799,13 @@ end
 function BB8_mt.__index:setPixelDither(x, y, color, na, o_x, o_y)
     local px, py = self:getPhysicalCoordinates(x, y)
     if self:getInverse() == 1 then color = color:invert() end
+    if (o_x < 250 and o_y < 50) then
+        if ffi.typeof(color) == R_Color8 then
+            print(string.format("setPixelDither: (%03d, %03d) #%02X", o_x, o_y, color.a))
+        else
+            print(string.format("setPixelDither: (%03d, %03d) #%02X%02X%02X", o_x, o_y, color.r, color.g, color.b))
+        end
+    end
     color = color:getColor8()
     color.a = dither_o8x8(o_x, o_y, color.a)
     self:getPixelP(px, py)[0]:set(color)


### PR DESCRIPTION
In the vast majority if cases, in blitbuffer, when we're passed a `Color?` object, it's a direct *reference* (e.g., `Color8 &`) to the buffer *itself*. As such, if we update it, we're *writing* to the buffer.

This is obviously a terrible idea (except in the cases where we actually *want* to write to the buffer ^^), and shit starts getting really scary when you remember that we most often do that via the `getColor?` methods, which do *pixel-format* conversions. Ouch.

I'm mildly amazed this has never blown up anywhere in fun and interesting ways before, but, this was at least exposed by @poire-z's testcase in https://github.com/koreader/koreader/issues/5916#issuecomment-779486154
ImageViewer starts by showing the image full-screen, then a tap scales it in order to show the buttons. Something was modifying the buffer in-between those two states, which meant that the scaled buffer was *slightly* off. This was made more obvious when dithering enters the fray, as this generated a different, more obvious dither pattern.

----

Also, compute the dither diffusion based on the *source* coordinates, not the target's. (Much like the C blitter).

----

This doesn't happen with the C blitter, because, there, the distinction between what's a pointer/ref and what's a value is much clearer in plain C. (Also, the compiler would shout at you very sternly when this kind of thing happens and involves type-punning. Also, `const` exists in C ^^).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1309)
<!-- Reviewable:end -->
