### PR TITLE
Add reMarkable2 generateFakeEvents

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,13 @@ libs: \
 $(OUTPUT_DIR)/libs/libinkview-compat.so: input/inkview-compat.c
 	$(CC) $(DYNLIB_CFLAGS) -linkview -o $@ $<
 
-$(OUTPUT_DIR)/libs/libkoreader-input.so: input/*.c input/*.h $(if $(KINDLE),$(POPEN_NOSHELL_LIB),)
+$(OUTPUT_DIR)/libs/libkoreader-input.so: input/*.c input/*.h $(if $(or $(KINDLE),$(REMARKABLE)),$(POPEN_NOSHELL_LIB),)
 	@echo "Building koreader input module..."
 	$(CC) $(DYNLIB_CFLAGS) $(SYMVIS_FLAGS) -I$(POPEN_NOSHELL_DIR) -I./input \
 		$(if $(CERVANTES),-DCERVANTES,) $(if $(KOBO),-DKOBO,) $(if $(KINDLE),-DKINDLE,) $(if $(POCKETBOOK),-DPOCKETBOOK,) $(if $(REMARKABLE),-DREMARKABLE,) $(if $(SONY_PRSTUX),-DSONY_PRSTUX,)\
 		-o $@ \
 		input/input.c \
-		$(if $(KINDLE),$(POPEN_NOSHELL_LIB),) \
+		$(if $(or $(KINDLE),$(REMARKABLE)),$(POPEN_NOSHELL_LIB),) \
 		$(if $(POCKETBOOK),-linkview,)
 
 # Would need a bit of patching to be able to use -fvisibility=hidden...

--- a/input/input-remarkable.h
+++ b/input/input-remarkable.h
@@ -52,7 +52,7 @@ static void input_write_event(int fd, int code)
 
 /*
  * On wakeup, reMarkable 2 does not send Power Button events
- * So we watch DBus and insert a "Power Button Released" event when we wake up
+ * So we watch DBus and insert a "Power Button Released" event when the rM2 wakes up
  */
 static void generateFakeEventRM2(int pipefd) {
     FILE *fp;

--- a/input/input-remarkable.h
+++ b/input/input-remarkable.h
@@ -18,6 +18,7 @@
 #ifndef _KO_INPUT_REMARKABLE_H
 #define _KO_INPUT_REMARKABLE_H
 
+#define MACHINE_PATH "/sys/devices/soc0/machine"
 #define CHARGER_DEVPATH "/devices/soc0/soc/2100000.aips-bus/2184000.usb/power_supply/imx_usb_charger"
 #define CHARGER_ONLINE_PATH "/sys" CHARGER_DEVPATH "/online"
 #define BATTERY_DEVPATH "/devices/soc0/soc/2100000.aips-bus/21a0000.i2c/i2c-0/0-0055/power_supply/bq27441-0"
@@ -25,6 +26,8 @@
 
 #include "libue.h"
 #include "input.h"
+#include "popen_noshell.h"
+static struct popen_noshell_pass_to_pclose pclose_arg;
 
 static size_t read_file(char const* path, char* buf, size_t buflen)
 {
@@ -47,12 +50,58 @@ static void input_write_event(int fd, int code)
     }
 }
 
-static void generateFakeEvent(int pipefd[2]) {
+/*
+ * On wakeup, reMarkable 2 does not send Power Button events
+ * So we watch DBus and insert a "Power Button Released" event when we wake up
+ */
+static void generateFakeEventRM2(int pipefd) {
+    FILE *fp;
+    char std_out[256];
+    int status;
+    struct input_event ev;
+
+    ev.type = EV_KEY;
+    ev.code = 116; // rM2 "Power button" key
+    ev.value = 0; // Key released
+
+    char *argv[] = { "dbus-monitor", "--system", "member='PrepareForSleep'", (char *)NULL };
+    fp = popen_noshell("dbus-monitor", (const char * const *)argv, "r", &pclose_arg, 0);
+    if (!fp) {
+        fprintf(stderr, "[remarkable-fake-event] Failed to popen_noshell dbus-monitor\n");
+        return;
+    }
+
+    fflush(fp);
+
+    while (fgets(std_out, sizeof(std_out)-1, fp)) {
+        if (!strncmp(std_out, "   boolean false", 16)) {
+            gettimeofday(&ev.time, NULL);
+            if (write(pipefd, &ev, sizeof(struct input_event)) == -1) {
+                fprintf(stderr, "Failed to generate Power Button Released event.\n");
+            }
+        }
+    }
+
+    status = pclose_noshell(&pclose_arg);
+    if (status == -1) {
+        err(EXIT_FAILURE, "pclose_noshell()");
+    } else {
+        if (WIFEXITED(status)) {
+            printf("dbus-monitor exited normally with status: %d\n", WEXITSTATUS(status));
+        } else if (WIFSIGNALED(status)) {
+            printf("dbus-monitor was killed by signal %d\n", WTERMSIG(status));
+        } else if (WIFSTOPPED(status)) {
+            printf("dbus-monitor was stopped by signal %d\n", WSTOPSIG(status));
+        } else if (WIFCONTINUED(status)) {
+            printf("dbus-monitor continued\n");
+        }
+    }
+}
+
+static void generateFakeEventRM1(int pipefd) {
     int re;
     struct uevent_listener listener;
     struct uevent uev;
-
-    close(pipefd[0]);
 
     re = ue_init_listener(&listener);
     if (re < 0) {
@@ -70,7 +119,7 @@ static void generateFakeEvent(int pipefd[2]) {
                 if (read_file(CHARGER_ONLINE_PATH, fbuf, sizeof(fbuf))) {
                     int new_state = strcmp(fbuf, "1\n") == 0? 1 : 0;
                     if (new_state != charger_state) {
-                        input_write_event(pipefd[1], new_state? CODE_FAKE_USB_PLUG_IN : CODE_FAKE_USB_PLUG_OUT);
+                        input_write_event(pipefd, new_state? CODE_FAKE_USB_PLUG_IN : CODE_FAKE_USB_PLUG_OUT);
                     }
                     charger_state = new_state;
                 }
@@ -79,12 +128,23 @@ static void generateFakeEvent(int pipefd[2]) {
                 if (read_file(BATTERY_STATUS_PATH, fbuf, sizeof(fbuf))) {
                     int new_state = strcmp(fbuf, "Charging\n") == 0? 1 : 0;
                     if (new_state != battery_state) {
-                        input_write_event(pipefd[1], new_state? CODE_FAKE_CHARGING : CODE_FAKE_NOT_CHARGING);
+                        input_write_event(pipefd, new_state? CODE_FAKE_CHARGING : CODE_FAKE_NOT_CHARGING);
                     }
                     battery_state = new_state;
                 }
             }
         }
+    }
+}
+
+static void generateFakeEvent(int pipefd[2]) {
+    close(pipefd[0]);
+
+    char mbuf[32];
+    if (read_file(MACHINE_PATH, mbuf, sizeof(mbuf)) && !strncmp(mbuf, "reMarkable 2.0", 14)) {
+        generateFakeEventRM2(pipefd[1]);
+    } else {
+        generateFakeEventRM1(pipefd[1]);
     }
 }
 


### PR DESCRIPTION
When the reMarkable2 is suspended and the user presses the Power button, the device wakes up but does NOT send the power button "pressed" or "released" events to `/dev/input`.
This PR is an alternate solution to https://github.com/koreader/koreader/pull/7345

If someone has a cleaner way to watch DBus events on the reMarkable2, let me know.
This code simply launches the command
```
dbus-monitor --system member='PrepareForSleep'
```
and then watches for a line that starts with
```
[three spaces]boolean false
```

That feels a bit klunky and brittle, but it's working on my machine, so [*shrug*]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1318)
<!-- Reviewable:end -->
