### PR TITLE
Process ALooper-FIFO

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -172,6 +172,12 @@ function input.waitForEvent(sec, usec)
 
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
 
+             require("logger").err("xxxxxxxxxxxxxx poll_state="..poll_state)
+
+            if source[0] ~= nil then
+                require("logger").err("xxxxxxxxxxxxxx source[0].id="..source[0].id)
+            end
+
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -216,10 +222,16 @@ function input.waitForEvent(sec, usec)
         elseif poll_state == C.ALOOPER_POLL_WAKE then
             -- this happens, when ALOOPER receives infos from the native_glue_fifo
             android.LOGD("ALOOPER_POLL_WAKE")
-            if android.isCharging() then
-                commandHandler(C.MSC_CHARGE, 1)
+            local message = ffi.cast("char*", android.app.userData)
+
+            require("logger").err("xxxxxxxxxxxxxx source[0].id="..message[0])
+
+            if message[0] == C.EVENT_POWER_CONNECTED then
+                commandHandler(C.EVENT_POWER_CONNECTED , 0)
+            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
+                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
             else
-                commandHandler(C.MSC_CHARGE, 0)
+                android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -220,16 +220,18 @@ function input.waitForEvent(sec, usec)
                 commandHandler(C.MSC_CHARGE, 0)
             end
         elseif poll_state == C.ALOOPER_POLL_WAKE then
-            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo.
+            -- For now the userData contains four bytes. The first one contains the message
+            -- the other three can be used vor additional values.
             android.LOGD("ALOOPER_POLL_WAKE")
             local message = ffi.cast("char*", android.app.userData)
 
             require("logger").err("xxxxxxxxxxxxxx source[0].id="..message[0])
 
-            if message[0] == C.EVENT_POWER_CONNECTED then
-                commandHandler(C.EVENT_POWER_CONNECTED , 0)
-            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
-                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
+            if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
+                commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)
+            elseif message[0] == C.ALOOPER_FIFO_POWER_DISCONNECTED then
+                commandHandler(C.ALOOPER_FIFO_POWER_DISCONNECTED , 0)
             else
                 android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -169,7 +169,7 @@ function input.waitForEvent(sec, usec)
         --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
-        local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
+        local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
 
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
@@ -207,7 +207,11 @@ function input.waitForEvent(sec, usec)
         elseif poll_state == C.ALOOPER_POLL_WAKE then
             -- this happens, when ALOOPER receives infos from the native_glue_fifo
             android.LOGD("ALOOPER_POLL_WAKE")
-            return
+            if android.isCharging() then
+                commandHandler(C.MSC_CHARGE, 1)
+            else
+                commandHandler(C.MSC_CHARGE, 0)
+            end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -169,7 +169,7 @@ function input.waitForEvent(sec, usec)
         --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
-        local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
+        local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
 
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
@@ -215,7 +215,11 @@ function input.waitForEvent(sec, usec)
         elseif poll_state == C.ALOOPER_POLL_WAKE then
             -- this happens, when ALOOPER receives infos from the native_glue_fifo
             android.LOGD("ALOOPER_POLL_WAKE")
-            return
+            if android.isCharging() then
+                commandHandler(C.MSC_CHARGE, 1)
+            else
+                commandHandler(C.MSC_CHARGE, 0)
+            end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -170,6 +170,7 @@ function input.waitForEvent(sec, usec)
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
         local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
+
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -211,6 +212,10 @@ function input.waitForEvent(sec, usec)
                 android.LOGI("Engine thread destroy requested!")
                 -- Do nothing, if this is set, we've already pushed an APP_CMD_DESTROY event that'll get handled in front.
             end
+        elseif poll_state == C.ALOOPER_POLL_WAKE then
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            android.LOGD("ALOOPER_POLL_WAKE")
+            return
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -222,10 +222,10 @@ function input.waitForEvent(sec, usec)
 
             android.LOGD("message received:" .. message[0])
 
-            if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
-                commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)
-            elseif message[0] == C.ALOOPER_FIFO_POWER_DISCONNECTED then
-                commandHandler(C.ALOOPER_FIFO_POWER_DISCONNECTED , 0)
+            if message[0] == C.EVENT_POWER_CONNECTED then
+                commandHandler(C.EVENT_POWER_CONNECTED , 0)
+            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
+                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
             else
                 android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -155,8 +155,6 @@ function input.waitForEvent(sec, usec)
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
     while true do
-require("logger").err("xxxxxxx + waitForEvent a   Timeout="..usecs)
-
         -- check for queued events
         if #inputQueue > 0 then
             -- return oldest FIFO element
@@ -173,15 +171,6 @@ require("logger").err("xxxxxxx + waitForEvent a   Timeout="..usecs)
         local source = ffi.new("struct android_poll_source*[1]")
 
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
-
-require("logger").err("xxxxxxx + waitForEvent c")
-
-            require("logger").err("xxxxxxx ++ poll_state="..poll_state)
-
-        if source[0] ~= nil then
-            require("logger").err("xxxxxxx ++ source[0].id="..source[0].id)
-        end
-
 
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
@@ -227,7 +216,11 @@ require("logger").err("xxxxxxx + waitForEvent c")
         elseif poll_state == C.ALOOPER_POLL_WAKE then
             -- this happens, when ALOOPER receives infos from the native_glue_fifo
             android.LOGD("ALOOPER_POLL_WAKE")
-            return
+            if android.isCharging() then
+                commandHandler(C.MSC_CHARGE, 1)
+            else
+                commandHandler(C.MSC_CHARGE, 0)
+            end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -169,9 +169,7 @@ function input.waitForEvent(sec, usec)
         --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
-
-        local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
-
+        local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -200,34 +198,18 @@ function input.waitForEvent(sec, usec)
                         android.lib.AInputQueue_finishEvent(android.app.inputQueue, event[0], handled)
                     end
                 end
+            elseif poll_state == C.LOOPER_ID_USER then
+                local message = ffi.new("unsigned char [4]")
+                C.read(fd[0], message, 4)
+                if message[0] == C.AEVENT_POWER_CONNECTED then
+                    commandHandler(C.AEVENT_POWER_CONNECTED, 0)
+                elseif message[0] == C.AEVENT_POWER_DISCONNECTED then
+                    commandHandler(C.AEVENT_POWER_DISCONNECTED, 0)
+                end
             end
             if android.app.destroyRequested ~= 0 then
                 android.LOGI("Engine thread destroy requested!")
                 -- Do nothing, if this is set, we've already pushed an APP_CMD_DESTROY event that'll get handled in front.
-            end
-        elseif poll_state == C.ALOOPER_POLL_WAKE then
-            -- this happens, when ALOOPER receives infos from the native_glue_fifo
-            android.LOGD("ALOOPER_POLL_WAKE")
-            if android.isCharging() then
-                commandHandler(C.MSC_CHARGE, 1)
-            else
-                commandHandler(C.MSC_CHARGE, 0)
-            end
-        elseif poll_state == C.ALOOPER_POLL_WAKE then
-            -- this happens, when ALOOPER receives infos from the native_glue_fifo.
-            -- For now the userData contains four bytes. The first one contains the message
-            -- the other three can be used vor additional values.
-            android.LOGD("ALOOPER_POLL_WAKE")
-            local message = ffi.cast("char*", android.app.userData)
-
-            android.LOGD("message received:" .. message[0])
-
-            if message[0] == C.EVENT_POWER_CONNECTED then
-                commandHandler(C.EVENT_POWER_CONNECTED , 0)
-            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
-                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
-            else
-                android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -170,6 +170,7 @@ function input.waitForEvent(sec, usec)
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
         local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
+
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -203,6 +204,10 @@ function input.waitForEvent(sec, usec)
                 android.LOGI("Engine thread destroy requested!")
                 -- Do nothing, if this is set, we've already pushed an APP_CMD_DESTROY event that'll get handled in front.
             end
+        elseif poll_state == C.ALOOPER_POLL_WAKE then
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            android.LOGD("ALOOPER_POLL_WAKE")
+            return
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -172,12 +172,6 @@ function input.waitForEvent(sec, usec)
 
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
 
-             require("logger").err("xxxxxxxxxxxxxx poll_state="..poll_state)
-
-            if source[0] ~= nil then
-                require("logger").err("xxxxxxxxxxxxxx source[0].id="..source[0].id)
-            end
-
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -226,7 +220,7 @@ function input.waitForEvent(sec, usec)
             android.LOGD("ALOOPER_POLL_WAKE")
             local message = ffi.cast("char*", android.app.userData)
 
-            require("logger").err("xxxxxxxxxxxxxx source[0].id="..message[0])
+            android.LOGD("message received:" .. message[0])
 
             if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
                 commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -172,12 +172,6 @@ function input.waitForEvent(sec, usec)
 
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
 
-             require("logger").err("xxxxxxxxxxxxxx poll_state="..poll_state)
-
-            if source[0] ~= nil then
-                require("logger").err("xxxxxxxxxxxxxx source[0].id="..source[0].id)
-            end
-
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
             --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
@@ -234,7 +228,7 @@ function input.waitForEvent(sec, usec)
             android.LOGD("ALOOPER_POLL_WAKE")
             local message = ffi.cast("char*", android.app.userData)
 
-            require("logger").err("xxxxxxxxxxxxxx source[0].id="..message[0])
+            android.LOGD("message received:" .. message[0])
 
             if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
                 commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -228,16 +228,18 @@ function input.waitForEvent(sec, usec)
                 commandHandler(C.MSC_CHARGE, 0)
             end
         elseif poll_state == C.ALOOPER_POLL_WAKE then
-            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo.
+            -- For now the userData contains four bytes. The first one contains the message
+            -- the other three can be used vor additional values.
             android.LOGD("ALOOPER_POLL_WAKE")
             local message = ffi.cast("char*", android.app.userData)
 
             require("logger").err("xxxxxxxxxxxxxx source[0].id="..message[0])
 
-            if message[0] == C.EVENT_POWER_CONNECTED then
-                commandHandler(C.EVENT_POWER_CONNECTED , 0)
-            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
-                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
+            if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
+                commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)
+            elseif message[0] == C.ALOOPER_FIFO_POWER_DISCONNECTED then
+                commandHandler(C.ALOOPER_FIFO_POWER_DISCONNECTED , 0)
             else
                 android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -155,6 +155,8 @@ function input.waitForEvent(sec, usec)
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
     while true do
+require("logger").err("xxxxxxx + waitForEvent a   Timeout="..usecs)
+
         -- check for queued events
         if #inputQueue > 0 then
             -- return oldest FIFO element
@@ -169,7 +171,17 @@ function input.waitForEvent(sec, usec)
         --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
+
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
+
+require("logger").err("xxxxxxx + waitForEvent c")
+
+            require("logger").err("xxxxxxx ++ poll_state="..poll_state)
+
+        if source[0] ~= nil then
+            require("logger").err("xxxxxxx ++ source[0].id="..source[0].id)
+        end
+
 
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
@@ -212,6 +224,10 @@ function input.waitForEvent(sec, usec)
             else
                 commandHandler(C.MSC_CHARGE, 0)
             end
+        elseif poll_state == C.ALOOPER_POLL_WAKE then
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            android.LOGD("ALOOPER_POLL_WAKE")
+            return
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -155,6 +155,8 @@ function input.waitForEvent(sec, usec)
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
     while true do
+require("logger").err("xxxxxxx + waitForEvent a   Timeout="..usecs)
+
         -- check for queued events
         if #inputQueue > 0 then
             -- return oldest FIFO element
@@ -169,7 +171,17 @@ function input.waitForEvent(sec, usec)
         --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
         --       TL;DR: We don't actually use it here.
         local source = ffi.new("struct android_poll_source*[1]")
+
         local poll_state = android.lib.ALooper_pollAll(timeout, nil, events, ffi.cast("void**", source))
+
+require("logger").err("xxxxxxx + waitForEvent c")
+
+            require("logger").err("xxxxxxx ++ poll_state="..poll_state)
+
+        if source[0] ~= nil then
+            require("logger").err("xxxxxxx ++ source[0].id="..source[0].id)
+        end
+
 
         if poll_state >= 0 then
             -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
@@ -220,6 +232,10 @@ function input.waitForEvent(sec, usec)
             else
                 commandHandler(C.MSC_CHARGE, 0)
             end
+        elseif poll_state == C.ALOOPER_POLL_WAKE then
+            -- this happens, when ALOOPER receives infos from the native_glue_fifo
+            android.LOGD("ALOOPER_POLL_WAKE")
+            return
         elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
             return false, C.ETIME
         elseif poll_state == C.ALOOPER_POLL_ERROR then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -230,10 +230,10 @@ function input.waitForEvent(sec, usec)
 
             android.LOGD("message received:" .. message[0])
 
-            if message[0] == C.ALOOPER_FIFO_POWER_CONNECTED then
-                commandHandler(C.ALOOPER_FIFO_POWER_CONNECTED , 0)
-            elseif message[0] == C.ALOOPER_FIFO_POWER_DISCONNECTED then
-                commandHandler(C.ALOOPER_FIFO_POWER_DISCONNECTED , 0)
+            if message[0] == C.EVENT_POWER_CONNECTED then
+                commandHandler(C.EVENT_POWER_CONNECTED , 0)
+            elseif message[0] == C.EVENT_POWER_DISCONNECTED then
+                commandHandler(C.EVENT_POWER_DISCONNECTED , 0)
             else
                 android.LOGE("Unknown ALOOPER_POLL_WAKE message")
             end


### PR DESCRIPTION
This is a very draft for demonstrating the functionality of `alooper.fifo`. This connects the `luajit-launcher` with the frontend.

Of course the `require("logger").err("xxxxxxx` will disappear. 

The important lines are from 183 down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1326)
<!-- Reviewable:end -->
