### PR TITLE
Kobo: Allow toggling the WAIT_FOR_UPDATE_COMPLETE hack

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -488,6 +488,16 @@ function fb:getMxcWaitForBypass()
     return self.mxcfb_bypass_wait_for
 end
 
+function fb:toggleMxcWaitForBypass(toggle)
+    if toggle == true then
+        self.mxcfb_bypass_wait_for = true
+    elseif toggle == false then
+        self.mxcfb_bypass_wait_for = false
+    else
+        self.mxcfb_bypass_wait_for = not self.mxcfb_bypass_wait_for
+    end
+end
+
 function fb:saveCurrentBB()
     if self.saved_bb then self.saved_bb:free() end
     self.saved_bb = self.bb:copy()

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -37,6 +37,8 @@ local fb = {
     -- Lower level is the slowest and most conservative, increasing values trade speed for glitches and ghosting.
     wf_level = 0,
     wf_level_max = 0, -- Maximum supported value for wf_level.
+    -- Whether the user (or a Device cap check) chose to disable MXCFB_WAIT_FOR_UPDATE_* ioctls.
+    mxcfb_bypass_wait_for = false,
 }
 
 --[[
@@ -480,6 +482,10 @@ end
 
 function fb:getWaveformLevel()
     return math.min(self.wf_level_max, self.wf_level)
+end
+
+function fb:getMxcWaitForBypass()
+    return self.mxcfb_bypass_wait_for
 end
 
 function fb:saveCurrentBB()

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -488,16 +488,6 @@ function fb:getMxcWaitForBypass()
     return self.mxcfb_bypass_wait_for
 end
 
-function fb:toggleMxcWaitForBypass(toggle)
-    if toggle == true then
-        self.mxcfb_bypass_wait_for = true
-    elseif toggle == false then
-        self.mxcfb_bypass_wait_for = false
-    else
-        self.mxcfb_bypass_wait_for = not self.mxcfb_bypass_wait_for
-    end
-end
-
 function fb:saveCurrentBB()
     if self.saved_bb then self.saved_bb:free() end
     self.saved_bb = self.bb:copy()

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -833,6 +833,13 @@ function framebuffer:init()
                 self.mech_wait_update_complete = stub_mxc_wait_for_update_complete
             end
         end
+
+        local bypass_wait_for = self:getMxcWaitForBypass()
+        -- If the user (or a device cap check) requested bypassing the MXCFB_WAIT_FOR_UPDATE_COMPLETE ioctls, do so.
+        if bypass_wait_for then
+            -- The stub implementation just fakes this ioctl by sleeping for a tiny amount of time instead... :/.
+            self.mech_wait_update_complete = stub_mxc_wait_for_update_complete
+        end
     elseif self.device:isPocketBook() then
         require("ffi/mxcfb_pocketbook_h")
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -824,14 +824,6 @@ function framebuffer:init()
                                                     -- Nickel sometimes uses DU, but never w/ the MONOCHROME flag, so, do the same.
                                                     -- Plus, DU + MONOCHROME + INVERT is much more prone to the Mk. 7 EPDC bug where some/all
                                                     -- EPDC flags just randomly go bye-bye...
-            -- NOTE: The Libra apparently suffers from a mysterious issue where completely innocuous WAIT_FOR_UPDATE_COMPLETE ioctls
-            --       will mysteriously fail with a timeout (5s)...
-            --       This obviously leads to *terrible* user experience, so, until more is understood avout the issue,
-            --       just fake this ioctl by sleeping for a tiny amount of time instead... :/.
-            --       c.f., https://github.com/koreader/koreader/issues/7340
-            if self.device.model == "Kobo_storm" then
-                self.mech_wait_update_complete = stub_mxc_wait_for_update_complete
-            end
         end
 
         local bypass_wait_for = self:getMxcWaitForBypass()


### PR DESCRIPTION
Whether a device capcheck enables it by default or not.

(Followup to #1329).

Also, actually *log* failures for this ioctl in debug mode, which should help diagnosing affected devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1334)
<!-- Reviewable:end -->
