### PR TITLE
bump crengine: add support for MathML

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -706,6 +706,8 @@ CRENGINE_DIR=$(CURDIR)/$(CRENGINE_BUILD_DIR)
 CRENGINE_SRC_DIR=$(CURDIR)/$(THIRDPARTY_DIR)/kpvcrlib/crengine
 CRENGINE_SRC_FILES=$(wildcard $(CRENGINE_SRC_DIR)/crengine/src/*.cpp)
 CRENGINE_SRC_FILES+=$(wildcard $(CRENGINE_SRC_DIR)/crengine/include/*.h)
+CRENGINE_SRC_FILES+=$(wildcard $(CRENGINE_SRC_DIR)/crengine/src/*.h)
+CRENGINE_SRC_FILES+=$(wildcard $(CRENGINE_SRC_DIR)/crengine/src/*_h.*)
 CRENGINE_LIB=$(OUTPUT_DIR)/libs/libcrengine$(LIB_EXT)
 
 LUAJIT_BUILD_DIR=$(THIRDPARTY_DIR)/luajit/build/$(MACHINE)

--- a/cre.cpp
+++ b/cre.cpp
@@ -501,7 +501,7 @@ static int readDefaults(lua_State *L) {
 		doc->text_view->propsApply(props);
 	} else {
 		// Tweak the default settings to be slightly less random
-		props->setString(PROP_FALLBACK_FONT_FACE, "Noto Sans CJK SC");
+		props->setString(PROP_FALLBACK_FONT_FACES, "Noto Sans CJK SC");
 		props->setString(PROP_HYPHENATION_DICT, "English_US.pattern");
 		props->setString(PROP_STATUS_FONT_FACE, "Noto Sans");
 		props->setString(PROP_FONT_FACE, "Noto Serif");
@@ -1634,14 +1634,20 @@ static int getVisiblePageNumberCount(lua_State *L) {
 static int adjustFontSizes(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     int dpi = luaL_checkint(L, 2);
+    /* Previously used (when the hardcoded default was similar to USE_LIMITED_FONT_SIZES_SET=1):
     static int fontSizes[] = {	12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
 				31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
 				50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
 				69, 70, 71, 72, 78, 84, 90, 110, 130, 150, 170, 200, 230, 260, 300, 340};
     LVArray<int> sizes( fontSizes, sizeof(fontSizes)/sizeof(int) );
     doc->text_view->setFontSizes(sizes, false); // text
+    */
+    // Now, with crengine compiled with USE_LIMITED_FONT_SIZES_SET=0:
+    doc->text_view->setMinFontSize(12);
+    doc->text_view->setMaxFontSize(340);
+    // Top status bar font size
     if (dpi < 170) {
-        doc->text_view->setStatusFontSize(20);  // header
+        doc->text_view->setStatusFontSize(20);
     } else if (dpi > 250) {
         doc->text_view->setStatusFontSize(28);
     } else {

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -66,6 +66,7 @@ add_definitions(
     -DUSE_ZSTD=1
     -DALLOW_KERNING=1
     -DCR3_PATCH=1
+    -DMATHML_SUPPORT=1
 )
 
 if(${CMAKE_BUILD_TYPE} STREQUAL Debug)
@@ -163,6 +164,7 @@ set (CRENGINE_SOURCES
     ${CRE_DIR}/src/lvpagesplitter.cpp
     ${CRE_DIR}/src/lvtextfm.cpp
     ${CRE_DIR}/src/lvrend.cpp
+    ${CRE_DIR}/src/mathml.cpp
     ${CRE_DIR}/src/wolutil.cpp
     ${CRE_DIR}/src/hist.cpp
     ${CRE_DIR}/src/cri18n.cpp


### PR DESCRIPTION
Includes (among others):
- LVImg: Tweak JPEG decoding some more https://github.com/koreader/crengine/pull/427
- toStringV2(): fix (again) when target node is a boxing node https://github.com/koreader/crengine/pull/428
- LVFontCache::find(): give more weight to first fonts in list
- Page splitting: more accurate rendering progress
- getRenderedWidths(): fix nowrap around image/inlineBoxes
- Tables rendering: tweak column widths algorithm
- CSS: parse/handle "currentcolor", default for border-color
- CSS: add units 'ch' (just like 'ex')
- SVG images: proper alpha blending
- MathML: add parsing and rendering support files https://github.com/koreader/crengine/pull/429
- MathML: plug MathML code into crengine core
- MathML: <epub:switch/case/default>: accept MathML
- (Upstream) Make crengine.font.fallback.faces plural https://github.com/koreader/crengine/pull/430
- (Upstream) Option to not limit font size to a set
- Text: dont adjust space after consecutive initial marks/dashes
- Update German hyphenation patterns https://github.com/koreader/crengine/pull/431

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1337)
<!-- Reviewable:end -->
