### PR TITLE
SDL/Android: Actually honor polling timeouts

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -257,6 +257,7 @@ function S.waitForEvent(sec, usec)
     local event = ffi.new("union SDL_Event")
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
+    print("SDL:", timeout)
     while true do
         -- check for queued events
         if #inputQueue > 0 then
@@ -266,6 +267,7 @@ function S.waitForEvent(sec, usec)
 
         -- otherwise, wait for event
         local got_event = SDL.SDL_WaitEventTimeout(event, timeout)
+        print("got_event:", got_event)
         if got_event == 0 then
             -- ETIME
             return false, C.ETIME
@@ -400,6 +402,12 @@ function S.waitForEvent(sec, usec)
             -- send Alt + F4
             genEmuEvent(C.EV_KEY, 1073742050, 1)
             genEmuEvent(C.EV_KEY, 1073741885, 1)
+        end
+
+        -- We got an event we don't know how to handle
+        if #inputQueue == 0 then
+            -- Back to Input:waitEvent to recompute the timeout
+            return false, C.EINTR
         end
     end
 end

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -257,7 +257,6 @@ function S.waitForEvent(sec, usec)
     local event = ffi.new("union SDL_Event")
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
-    print("SDL:", timeout)
     while true do
         -- check for queued events
         if #inputQueue > 0 then
@@ -267,7 +266,6 @@ function S.waitForEvent(sec, usec)
 
         -- otherwise, wait for event
         local got_event = SDL.SDL_WaitEventTimeout(event, timeout)
-        print("got_event:", got_event)
         if got_event == 0 then
             -- ETIME
             return false, C.ETIME
@@ -404,7 +402,7 @@ function S.waitForEvent(sec, usec)
             genEmuEvent(C.EV_KEY, 1073741885, 1)
         end
 
-        -- We got an event we don't know how to handle
+        -- We got an event we don't do anything with (e.g., SDL_MOUSEMOTION)
         if #inputQueue == 0 then
             -- Back to Input:waitEvent to recompute the timeout
             return false, C.EINTR

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -403,7 +403,7 @@ function S.waitForEvent(sec, usec)
         end
 
         -- We got an event we don't do anything with (e.g., SDL_MOUSEMOTION)
-        if #inputQueue == 0 then
+        if timeout ~= -1 and #inputQueue == 0 then
             -- Back to Input:waitEvent to recompute the timeout
             return false, C.EINTR
         end

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -402,7 +402,7 @@ function S.waitForEvent(sec, usec)
             genEmuEvent(C.EV_KEY, 1073741885, 1)
         end
 
-        -- We got an event we don't do anything with (e.g., SDL_MOUSEMOTION)
+        -- We got an event we don't necessarily do anything with (e.g., SDL_MOUSEMOTION)
         if timeout ~= -1 and #inputQueue == 0 then
             -- Back to Input:waitEvent to recompute the timeout
             return false, C.EINTR

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -212,7 +212,7 @@ function input.waitForEvent(sec, usec)
         -- NOTE: We never set callbacks, and we never call wake, so no need to check for ALOOPER_POLL_CALLBACK & ALOOPER_POLL_WAKE
 
         -- poll returned early with something we don't do anything with
-        if #inputQueue == 0 then
+        if timeout ~= -1 and #inputQueue == 0 then
             -- Back to Input:waitEvent to recompute the timeout
             return false, C.EINTR
         end

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -210,6 +210,12 @@ function input.waitForEvent(sec, usec)
             return
         end
         -- NOTE: We never set callbacks, and we never call wake, so no need to check for ALOOPER_POLL_CALLBACK & ALOOPER_POLL_WAKE
+
+        -- poll returned early with something we don't do anything with
+        if #inputQueue == 0 then
+            -- Back to Input:waitEvent to recompute the timeout
+            return false, C.EINTR
+        end
     end
 end
 


### PR DESCRIPTION
Hopefully can't happen on Android, but very common on SDL because we don't do anything with mouse pointer events.

Only noticed tonight because my gamepad happens to be spamming gyro events tonight (which we don't do anything with, too) ;p.

Basically, waitForEvent is designed to poll *once* and return *one* event. But the SDL & Android version need to generate evdev input events from Abdroid/SDL input events, which mean they nerd to handle 1 => many scenarios. This is handled via a FIFO queue, which means the polling is stuck in a forever loop.
That means we were never going back to Lua to recompute timeouts, which was bad: that meant scheduled task would only actually run on the next input event instead of the scheduled time.

PB is a special snowflake, and, while it's also a forever loop, it's one that happens to re-compute its timeout (an uses custom timeouts anyway).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1343)
<!-- Reviewable:end -->
