### PR TITLE
Input: Handle events in batches

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -154,76 +154,76 @@ end
 function input.waitForEvent(sec, usec)
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
-    while true do
-        -- check for queued events
-        if #inputQueue > 0 then
-            -- return oldest FIFO element
-            return true, table.remove(inputQueue, 1)
-        end
-        -- Will point to the the raw fd number
-        local fd     = ffi.new("int[1]")
-        -- Will point to the poll events
-        local events = ffi.new("int[1]")
-        -- Will point to the data passed at addFd/attachLooper time, c.f., the android_poll_source struct definition.
-        -- NOTE: Its id field is mostly redundant, as ALooper already returns the ident.
-        --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
-        --       TL;DR: We don't actually use it here.
-        local source = ffi.new("struct android_poll_source*[1]")
-        local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
-        if poll_state >= 0 then
-            -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
-            --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
-            --       we pass as the data pointer to ALooper in the glue code when registering a polling source.
-            --       Instead, we do everything here, which is why this may look eerily like the C functions
-            --       process_cmd & process_input in the glue code.
-            --       Sidebar: if you *actually* need to process stuff in C-land ASAP, use ALooper's native callback system.
-            if poll_state == C.LOOPER_ID_MAIN then
-                -- e.g., source[0].process(android.app, source[0]) where process would point to process_cmd
-                local cmd = android.glue.android_app_read_cmd(android.app)
-                android.glue.android_app_pre_exec_cmd(android.app, cmd)
-                commandHandler(cmd, 1)
-                android.glue.android_app_post_exec_cmd(android.app, cmd)
-            elseif poll_state == C.LOOPER_ID_INPUT then
-                -- e.g., source[0].process(android.app, source[0]) where process would point to process_input
-                local event = ffi.new("AInputEvent*[1]")
-                while android.lib.AInputQueue_getEvent(android.app.inputQueue, event) >= 0 do
-                    if android.lib.AInputQueue_preDispatchEvent(android.app.inputQueue, event[0]) == 0 then
-                        local event_type = android.lib.AInputEvent_getType(event[0])
-                        local handled = 1
-                        if event_type == C.AINPUT_EVENT_TYPE_MOTION then
-                            motionEventHandler(event[0])
-                        elseif event_type == C.AINPUT_EVENT_TYPE_KEY then
-                            handled = keyEventHandler(event[0])
-                        end
-                        android.lib.AInputQueue_finishEvent(android.app.inputQueue, event[0], handled)
-                    end
-                end
-            elseif poll_state == C.LOOPER_ID_USER then
-                local message = ffi.new("unsigned char [4]")
-                C.read(fd[0], message, 4)
-                if message[0] == C.AEVENT_POWER_CONNECTED then
-                    commandHandler(C.AEVENT_POWER_CONNECTED, 0)
-                elseif message[0] == C.AEVENT_POWER_DISCONNECTED then
-                    commandHandler(C.AEVENT_POWER_DISCONNECTED, 0)
-                end
-            end
-            if android.app.destroyRequested ~= 0 then
-                android.LOGI("Engine thread destroy requested!")
-                -- Do nothing, if this is set, we've already pushed an APP_CMD_DESTROY event that'll get handled in front.
-            end
-        elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
-            return false, C.ETIME
-        elseif poll_state == C.ALOOPER_POLL_ERROR then
-            android.LOGE("Encountered a polling error!")
-            return
-        end
-        -- NOTE: We never set callbacks, and we never call wake, so no need to check for ALOOPER_POLL_CALLBACK & ALOOPER_POLL_WAKE
 
-        -- poll returned early with something we don't do anything with
-        if timeout ~= -1 and #inputQueue == 0 then
-            -- Back to Input:waitEvent to recompute the timeout
-            return false, C.EINTR
+    -- Reset the queue
+    inputQueue = {}
+
+    -- Will point to the the raw fd number
+    local fd     = ffi.new("int[1]")
+    -- Will point to the poll events
+    local events = ffi.new("int[1]")
+    -- Will point to the data passed at addFd/attachLooper time, c.f., the android_poll_source struct definition.
+    -- NOTE: Its id field is mostly redundant, as ALooper already returns the ident.
+    --       And its process function can be used as a weird delayed callback mechanism, but ALooper already has native callback handling :?.
+    --       TL;DR: We don't actually use it here.
+    local source = ffi.new("struct android_poll_source*[1]")
+    local poll_state = android.lib.ALooper_pollAll(timeout, fd, events, ffi.cast("void**", source))
+    if poll_state >= 0 then
+        -- NOTE: Since we actually want to process this in Lua-land (i.e., here), and not in C-land,
+        --       we do *NOT* make use of the weird delayed callback mechanism afforded by the android_poll_source struct
+        --       we pass as the data pointer to ALooper in the glue code when registering a polling source.
+        --       Instead, we do everything here, which is why this may look eerily like the C functions
+        --       process_cmd & process_input in the glue code.
+        --       Sidebar: if you *actually* need to process stuff in C-land ASAP, use ALooper's native callback system.
+        if poll_state == C.LOOPER_ID_MAIN then
+            -- e.g., source[0].process(android.app, source[0]) where process would point to process_cmd
+            local cmd = android.glue.android_app_read_cmd(android.app)
+            android.glue.android_app_pre_exec_cmd(android.app, cmd)
+            commandHandler(cmd, 1)
+            android.glue.android_app_post_exec_cmd(android.app, cmd)
+        elseif poll_state == C.LOOPER_ID_INPUT then
+            -- e.g., source[0].process(android.app, source[0]) where process would point to process_input
+            local event = ffi.new("AInputEvent*[1]")
+            while android.lib.AInputQueue_getEvent(android.app.inputQueue, event) >= 0 do
+                if android.lib.AInputQueue_preDispatchEvent(android.app.inputQueue, event[0]) == 0 then
+                    local event_type = android.lib.AInputEvent_getType(event[0])
+                    local handled = 1
+                    if event_type == C.AINPUT_EVENT_TYPE_MOTION then
+                        motionEventHandler(event[0])
+                    elseif event_type == C.AINPUT_EVENT_TYPE_KEY then
+                        handled = keyEventHandler(event[0])
+                    end
+                    android.lib.AInputQueue_finishEvent(android.app.inputQueue, event[0], handled)
+                end
+            end
+        elseif poll_state == C.LOOPER_ID_USER then
+            local message = ffi.new("unsigned char [4]")
+            C.read(fd[0], message, 4)
+            if message[0] == C.AEVENT_POWER_CONNECTED then
+                commandHandler(C.AEVENT_POWER_CONNECTED, 0)
+            elseif message[0] == C.AEVENT_POWER_DISCONNECTED then
+                commandHandler(C.AEVENT_POWER_DISCONNECTED, 0)
+            end
         end
+        if android.app.destroyRequested ~= 0 then
+            android.LOGI("Engine thread destroy requested!")
+            -- Do nothing, if this is set, we've already pushed an APP_CMD_DESTROY event that'll get handled in front.
+        end
+    elseif poll_state == C.ALOOPER_POLL_TIMEOUT then
+        return false, C.ETIME
+    elseif poll_state == C.ALOOPER_POLL_ERROR then
+        android.LOGE("Encountered a polling error!")
+        return
+    end
+    -- NOTE: We never set callbacks, and we never call wake, so no need to check for ALOOPER_POLL_CALLBACK & ALOOPER_POLL_WAKE
+
+    if #inputQueue > 0 then
+        -- We generated some actionable events
+        return true, inputQueue
+    else
+        -- poll returned early, but without an event we actually use.
+        -- Back to Input:waitEvent to recompute the timeout
+        return false, C.EINTR
     end
 end
 

--- a/input/input.c
+++ b/input/input.c
@@ -321,6 +321,8 @@ static int waitForInput(lua_State* L)
             size_t             j = 0U;
             lua_pushboolean(L, true);
             lua_newtable(L);  // We return an *array* of events, ev_array = {}
+            // NOTE: We could read the full queue at once, but this would require some buffer & queue handling in C.
+            //       Better just move to libevdev if that ever strikes our fancy ;).
             while (read(inputfds[i], &input, sizeof(input)) == sizeof(input)) {
                 set_event_table(L, input);  // New ev table all filled up at the top of the stack (that's -1)
                 lua_rawseti(L, -2, ++j);    // table.insert(ev_array, ev) [, j] (i.e., insert -1 in -2 @ [j], which always points at the tail)

--- a/input/input.c
+++ b/input/input.c
@@ -323,7 +323,7 @@ static int waitForInput(lua_State* L)
             lua_newtable(L);  // We return an *array* of events, ev_array = {}
             while (read(inputfds[i], &input, sizeof(input)) == sizeof(input)) {
                 set_event_table(L, input);  // New ev table all filled up at the top of the stack (that's -1)
-                lua_rawseti(L, -2, ++j);    // table.insert(ev_array, ev) [, j] (j always points at the tail)
+                lua_rawseti(L, -2, ++j);    // table.insert(ev_array, ev) [, j] (i.e., insert -1 in -2 @ [j], which always points at the tail)
             }
             printf("Read %zu events\n", j);
             if (j > 0) {

--- a/input/input.c
+++ b/input/input.c
@@ -253,30 +253,30 @@ static int fakeTapInput(lua_State* L)
 
 static inline void set_event_table(lua_State* L, struct input_event input)
 {
-    lua_newtable(L); // ev = {}
+    lua_newtable(L);  // ev = {}
     lua_pushstring(L, "type");
     lua_pushinteger(L, input.type);  // uint16_t
     // NOTE: rawset does t[k] = v, with v @ -1, k @ -2 and t at the specified index, here, that's ev @ -3.
     //       This is why we always follow the same pattern: push table, push key, push value, set table[key] = value (which pops key & value)
-    lua_rawset(L, -3); // ev.type = input.type
+    lua_rawset(L, -3);  // ev.type = input.type
     lua_pushstring(L, "code");
     lua_pushinteger(L, input.code);  // uint16_t
-    lua_rawset(L, -3); // ev.code = input.type
+    lua_rawset(L, -3);               // ev.code = input.type
     lua_pushstring(L, "value");
     lua_pushinteger(L, input.value);  // int32_t
-    lua_rawset(L, -3); // ev.value = input.value
+    lua_rawset(L, -3);                // ev.value = input.value
 
     lua_pushstring(L, "time");
     // NOTE: This is TimeVal-like, but it doesn't feature its metatable!
     //       The frontend (device/input.lua) will convert it to a proper TimeVal object.
-    lua_newtable(L); // time = {}
+    lua_newtable(L);  // time = {}
     lua_pushstring(L, "sec");
     lua_pushinteger(L, input.time.tv_sec);  // time_t
-    lua_rawset(L, -3); // time.sec = input.time.tv_sec
+    lua_rawset(L, -3);                      // time.sec = input.time.tv_sec
     lua_pushstring(L, "usec");
     lua_pushinteger(L, input.time.tv_usec);  // suseconds_t
-    lua_rawset(L, -3); // time.usec = input.time.tv_usec
-    lua_rawset(L, -3); // ev.time = time
+    lua_rawset(L, -3);                       // time.usec = input.time.tv_usec
+    lua_rawset(L, -3);                       // ev.time = time
 }
 
 static int waitForInput(lua_State* L)
@@ -318,19 +318,19 @@ static int waitForInput(lua_State* L)
     for (size_t i = 0U; i < num_fds; i++) {
         if (FD_ISSET(inputfds[i], &rfds)) {
             struct input_event input;
-            size_t j = 0U;
+            size_t             j = 0U;
             lua_pushboolean(L, true);
-            lua_newtable(L); // We return an *array* of events, ev_array = {}
+            lua_newtable(L);  // We return an *array* of events, ev_array = {}
             while (read(inputfds[i], &input, sizeof(input)) == sizeof(input)) {
-                set_event_table(L, input); // New ev table at the top of the stack (that's -1)
-                lua_rawseti(L, -2, ++j); // table.insert(ev_array, ev) [, j] (j always points at the tail)
+                set_event_table(L, input);  // New ev table all filled up at the top of the stack (that's -1)
+                lua_rawseti(L, -2, ++j);    // table.insert(ev_array, ev) [, j] (j always points at the tail)
             }
             printf("Read %zu events\n", j);
             if (j > 0) {
                 return 2;  // true, ev_array
             } else {
                 // Read failure?
-                lua_pop(L, 2); // Kick our bogus bool & empty table from the stack
+                lua_pop(L, 2);  // Kick our bogus bool & empty table from the stack
                 return 0;
             }
         }

--- a/input/input.c
+++ b/input/input.c
@@ -316,8 +316,8 @@ static int waitForInput(lua_State* L)
     for (size_t i = 0U; i < num_fds; i++) {
         if (FD_ISSET(inputfds[i], &rfds)) {
             struct input_event input;
-            ssize_t            readsz = read(inputfds[i], &input, sizeof(struct input_event));
-            if (readsz == sizeof(struct input_event)) {
+            ssize_t            readsz = read(inputfds[i], &input, sizeof(input));
+            if (readsz == sizeof(input)) {
                 lua_pushboolean(L, true);
                 set_event_table(L, input);
                 return 2;  // true, ev

--- a/input/input.c
+++ b/input/input.c
@@ -352,7 +352,7 @@ static int waitForInput(lua_State* L)
     }
 #endif
 
-    return 0;  // Unreachable
+    return 0;  // Unreachable (unless something is seriously screwy)
 }
 
 static const struct luaL_Reg input_func[] = { { "open", openInputDevice },

--- a/input/input.c
+++ b/input/input.c
@@ -316,12 +316,12 @@ static int waitForInput(lua_State* L)
     for (size_t i = 0U; i < num_fds; i++) {
         if (FD_ISSET(inputfds[i], &rfds)) {
             struct input_event input;
-            size_t j = 1U;
+            size_t j = 0U;
             lua_pushboolean(L, true);
             lua_newtable(L);
             while (read(inputfds[i], &input, sizeof(input)) == sizeof(input)) {
                 set_event_table(L, input);
-                lua_rawseti(L, -2, j++);
+                lua_rawseti(L, -2, ++j);
             }
             printf("Read %zu events\n", j);
             return 2;  // true, ev


### PR DESCRIPTION
The legacy design of consuming events one by one made the SDL & Android backends somewhat awkward, because they needed to generate many evdev events from possibly a single native event.

Moreover, even on plain Linux, you're mostly guaranteed that events will be readable in a batch, with boundaries at each `SYN_REPORT`.
Actually draining the queue ASAP pushes the possibility of a queue overflow (and as such, a `SYN_DROPPED`, which we don't actually handle) even further away from the realm of possibility, which is good, because, again, we're not handling this case anyway ;).

Except for PB being a special snowflake with its custom loop and timeout handling that I'm not touching, this makes the Android/SDL implementations code flow much closer to the C implementation's.

Speaking of, since I had to play with the C Lua API to handle the table wrapping, I documented the stack handling in the C backend, because that stuff is mind bending when you're not used to it.
And I switched to `rawset`/`rawseti` since we're dealing with a plain table with no metamethods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1344)
<!-- Reviewable:end -->
