### PR TITLE
Input: Batched reads & batched table allocations

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -29,6 +29,7 @@ cdecl_const(EINTR)
 cdecl_const(ETIME)
 cdecl_const(EAGAIN)
 cdecl_const(EINVAL)
+cdecl_const(EPIPE)
 cdecl_const(ENOSYS)
 cdecl_const(ETIMEDOUT)
 

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -160,5 +160,7 @@ int sched_yield(void) __attribute__((nothrow, leaf));
 -- clock_gettime & friends require librt on old glibc (< 2.17) versions...
 if ffi.os == "Linux" then
     -- Load it in the global namespace to make it easier on callers...
-    pcall(ffi.load, "/lib/librt.so.1", true)
+    -- NOTE: There's no librt.so symlink, so, specify the SOVER, but not the full path,
+    --       in order to let the dynamic loader figure it out on its own.
+    pcall(ffi.load, "rt.so.1", true)
 end

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -16,6 +16,7 @@ static const int EINTR = 4;
 static const int ETIME = 62;
 static const int EAGAIN = 11;
 static const int EINVAL = 22;
+static const int EPIPE = 32;
 static const int ENOSYS = 38;
 static const int ETIMEDOUT = 110;
 struct timezone {

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -161,6 +161,6 @@ int sched_yield(void) __attribute__((nothrow, leaf));
 if ffi.os == "Linux" then
     -- Load it in the global namespace to make it easier on callers...
     -- NOTE: There's no librt.so symlink, so, specify the SOVER, but not the full path,
-    --       in order to let the dynamic loader figure it out on its own.
+    --       in order to let the dynamic loader figure it out on its own (e.g.,  multilib).
     pcall(ffi.load, "rt.so.1", true)
 end

--- a/input/input.c
+++ b/input/input.c
@@ -285,13 +285,14 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
     lua_rawset(L, -3);                        // ev.time = time
 }
 
-static inline size_t drain_input_queue(lua_State* L, struct input_event* input_queue, size_t ev_count, size_t j) {
+static inline size_t drain_input_queue(lua_State* L, struct input_event* input_queue, size_t ev_count, size_t j)
+{
     if (!lua_istable(L, -1)) {
         // First call, create our array, pre-allocated to the necessary number of elements...
         // ...for this call, at least. Subsequent ones will insert event by event.
         // That said, multiple calls should be extremely rare:
         // We'd need to have filled the input_queue buffer *during* a single batch of events on the same fd ;).
-        lua_createtable(L, ev_count, 0); // We return an *array* of events, ev_array = {}
+        lua_createtable(L, ev_count, 0);  // We return an *array* of events, ev_array = {}
     }
 
     // Iterate over every input event in the queue buffer
@@ -343,15 +344,15 @@ static int waitForInput(lua_State* L)
     for (size_t i = 0U; i < num_fds; i++) {
         if (FD_ISSET(inputfds[i], &rfds)) {
             lua_pushboolean(L, true);
-            size_t j = 0U;  // Index of ev_array's tail
+            size_t j        = 0U;  // Index of ev_array's tail
             size_t ev_count = 0U;  // Amount of buffered events
             // NOTE: This should be more than enough ;).
             //       FWIW, this matches libevdev's default on most of our target devices,
             //       because they generally don't support querying the exact slot count via ABS_MT_SLOT.
             //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
-            struct input_event input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
-            struct input_event* queue_pos = input_queue;
-            size_t queue_available_size = sizeof(input_queue);
+            struct input_event  input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
+            struct input_event* queue_pos            = input_queue;
+            size_t              queue_available_size = sizeof(input_queue);
             for (;;) {
                 ssize_t len = read(inputfds[i], queue_pos, queue_available_size);
 
@@ -388,9 +389,9 @@ static int waitForInput(lua_State* L)
                     // If we're out of buffer space in the queue, drain it *now*
                     j = drain_input_queue(L, input_queue, ev_count, j);
                     // Rewind to the start of the queue to recycle the buffer
-                    queue_pos = input_queue;
+                    queue_pos            = input_queue;
                     queue_available_size = sizeof(input_queue);
-                    ev_count = 0U;
+                    ev_count             = 0U;
                 } else {
                     // Otherwise, update our position in the queue buffer
                     queue_pos += n;

--- a/input/input.c
+++ b/input/input.c
@@ -322,10 +322,10 @@ static int waitForInput(lua_State* L)
             size_t j = 0U;    // Index of ev_array's tail
             for (;;) {
                 // NOTE: This should be more than enough ;).
-                //       FWIW, libevdev would default to 256 on most of our target devices,
+                //       FWIW, this matches libevdev's default nn most of our target devices,
                 //       because they don't support ABS_MT_SLOT.
                 //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
-                struct input_event input_queue[512U];  // 8K on 32-bit, 12K on 64-bit
+                struct input_event input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
                 ssize_t            len = read(inputfds[i], &input_queue, sizeof(input_queue));
 
                 if (len < 0) {

--- a/input/input.c
+++ b/input/input.c
@@ -351,7 +351,7 @@ static int waitForInput(lua_State* L)
             //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
             struct input_event input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
             struct input_event* queue_pos = input_queue;
-            struct input_event* const queue_end = queue_pos + 256U;
+            struct input_event* const queue_end = queue_pos + sizeof(input_queue) / sizeof(*input_queue);
             printf("queue_pos: %p\n", queue_pos);
             printf("queue_end: %p\n", queue_end);
             for (;;) {

--- a/input/input.c
+++ b/input/input.c
@@ -343,7 +343,7 @@ static int waitForInput(lua_State* L)
             size_t ev_count = 0U;  // Amount of buffered events
             // NOTE: This should be more than enough ;).
             //       FWIW, this matches libevdev's default on most of our target devices,
-            //       because they don't support querying the exact slot count via ABS_MT_SLOT.
+            //       because they generally don't support querying the exact slot count via ABS_MT_SLOT.
             //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
             struct input_event input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
             struct input_event* queue_pos = input_queue;

--- a/input/input.c
+++ b/input/input.c
@@ -355,7 +355,6 @@ static int waitForInput(lua_State* L)
 
                 // Okay, compute the amount of events we've just read
                 size_t ev_count = len / sizeof(*input_queue);
-                printf("Read %zu events\n", ev_count);
 
                 // Iterate over them
                 for (const struct input_event* event = input_queue; event < input_queue + ev_count; event++) {
@@ -364,7 +363,6 @@ static int waitForInput(lua_State* L)
                     lua_rawseti(L, -2, ++j);  // table.insert(ev_array, ev) [, j]
                 }
             }
-            printf("Pushed %zu (%zu) events\n", lua_objlen(L, -1), j);
             return 2;  // true, ev_array
         }
     }

--- a/input/input.c
+++ b/input/input.c
@@ -360,7 +360,13 @@ static int waitForInput(lua_State* L)
                 printf("Read %zu events\n", ev_count);
 
                 if (!lua_istable(L, -1)) {
-                    // First iteration, create our array, pre-allocated to the necessary number of elements.
+                    // First iteration, create our array, pre-allocated to the necessary number of elements...
+                    // ...for this iteration, at least. Subsequent ones will insert event by event.
+                    // This isn't the end of the world:
+                    // * In *most* cases, we iterate only once.
+                    // * Buffering events across multiple iterations would require pointer shenanigans
+                    //   to keep track of our position inside input_queue, and handle filling/recycling the buffer,
+                    //   making this simple bit of code more complex.
                     lua_createtable(L, ev_count, 0); // We return an *array* of events, ev_array = {}
                     printf("Allocated array w/ %zu elements\n", ev_count);
                 }

--- a/input/input.c
+++ b/input/input.c
@@ -296,7 +296,6 @@ static inline void drain_input_queue(lua_State* L, struct input_event* input_que
         set_event_table(L, event);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
         // NOTE: Here, rawseti basically inserts -1 in -2 @ [j]. We ensure that j always points at the tail.
         lua_rawseti(L, -2, ++(*j));  // table.insert(ev_array, ev) [, j]
-        printf("Inserted in %zu\n", *j);
     }
     printf("Inserted %zu elements\n", *j);
     *ev_count = 0U;
@@ -396,10 +395,10 @@ static int waitForInput(lua_State* L)
                     printf("queue full\n");
                     drain_input_queue(L, input_queue, &ev_count, &j);
                     queue_pos = input_queue;
+                } else {
+                    // Update our position in the queue
+                    queue_pos += n;
                 }
-
-                // Update our position in the queue
-                queue_pos += ev_count;
                 printf("queue_pos: %p\n", queue_pos);
             }
             drain_input_queue(L, input_queue, &ev_count, &j);

--- a/input/input.c
+++ b/input/input.c
@@ -390,7 +390,7 @@ static int waitForInput(lua_State* L)
                 ev_count += n;
                 printf("Event count now at %zu\n", ev_count);
 
-                // If we're out of buffer space in the queue, drain it
+                // If we're out of buffer space in the queue, drain it *now*
                 if ((size_t) len == queue_available_size) {
                     printf("queue full\n");
                     drain_input_queue(L, input_queue, &ev_count, &j);
@@ -401,6 +401,7 @@ static int waitForInput(lua_State* L)
                 }
                 printf("queue_pos: %p\n", queue_pos);
             }
+            // We've drained the kernel's input queue, now drain our buffer
             drain_input_queue(L, input_queue, &ev_count, &j);
             printf("Returning %zu elements\n", j);
             return 2;  // true, ev_array

--- a/input/input.c
+++ b/input/input.c
@@ -342,11 +342,9 @@ static int waitForInput(lua_State* L)
 
     for (size_t i = 0U; i < num_fds; i++) {
         if (FD_ISSET(inputfds[i], &rfds)) {
-            printf("gettop before: %d\n", lua_gettop(L));
             lua_pushboolean(L, true);
-            printf("gettop after: %d\n", lua_gettop(L));
-            size_t j = 0U;    // Index of ev_array's tail
-            size_t ev_count = 0U; // Amount of buffered events
+            size_t j = 0U;  // Index of ev_array's tail
+            size_t ev_count = 0U;  // Amount of buffered events
             // NOTE: This should be more than enough ;).
             //       FWIW, this matches libevdev's default on most of our target devices,
             //       because they don't support querying the exact slot count via ABS_MT_SLOT.
@@ -360,7 +358,7 @@ static int waitForInput(lua_State* L)
 
                 if (len < 0) {
                     if (errno == EAGAIN) {
-                        // Queue drained :)
+                        // Kernel queue drained :)
                         break;
                     }
                     lua_pop(L, lua_gettop(L));  // Kick our bogus bool (and potentially the ev_array table) from the stack
@@ -398,7 +396,7 @@ static int waitForInput(lua_State* L)
                     queue_available_size = sizeof(input_queue);
                     ev_count = 0U;
                 } else {
-                    // Update our position in the queue
+                    // Update our position in the queue buffer
                     queue_pos += n;
                     queue_available_size = queue_available_size - (size_t) len;
                 }

--- a/input/input.c
+++ b/input/input.c
@@ -145,6 +145,9 @@ static int openInputDevice(lua_State* L)
         }
     }
 
+    // We're done w/ inputdevice, pop it
+    lua_pop(L, lua_gettop(L));
+
     // Compute select's nfds argument.
     // That's not the actual number of fds in the set, like poll(),
     // but the highest fd number in the set + 1 (c.f., select(2)).
@@ -193,6 +196,9 @@ static int fakeTapInput(lua_State* L)
     if (inputfd == -1) {
         return luaL_error(L, "Cannot open input device <%s>: %d", inputdevice, errno);
     }
+
+    // Pop function args, now that we're done w/ inputdevice
+    lua_pop(L, lua_gettop(L));
 
     struct input_event ev = { 0 };
     gettimeofday(&ev.time, NULL);

--- a/input/input.c
+++ b/input/input.c
@@ -359,7 +359,7 @@ static int waitForInput(lua_State* L)
 
                 // Iterate over them
                 for (const struct input_event* event = input_queue; event < input_queue + ev_count; event++) {
-                    set_event_table(L, event);  // New ev table all filled up at the top of the stack (that's -1)
+                    set_event_table(L, event);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
                     // NOTE: Here, rawseti basically inserts -1 in -2 @ [j]. We ensure that j always points at the tail.
                     lua_rawseti(L, -2, ++j);  // table.insert(ev_array, ev) [, j]
                 }

--- a/input/input.c
+++ b/input/input.c
@@ -325,7 +325,7 @@ static int waitForInput(lua_State* L)
                 //       FWIW, libevdev would default to 256 on most of our target devices,
                 //       because they don't support ABS_MT_SLOT.
                 //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
-                struct input_event input_queue[512U];  // 8K
+                struct input_event input_queue[512U];  // 8K on 32-bit, 12K on 64-bit
                 ssize_t            len = read(inputfds[i], &input_queue, sizeof(input_queue));
 
                 if (len < 0) {

--- a/input/input.c
+++ b/input/input.c
@@ -322,8 +322,8 @@ static int waitForInput(lua_State* L)
             size_t j = 0U;    // Index of ev_array's tail
             for (;;) {
                 // NOTE: This should be more than enough ;).
-                //       FWIW, this matches libevdev's default nn most of our target devices,
-                //       because they don't support ABS_MT_SLOT.
+                //       FWIW, this matches libevdev's default on most of our target devices,
+                //       because they don't support querying the exact slot count via ABS_MT_SLOT.
                 //       c.f., https://gitlab.freedesktop.org/libevdev/libevdev/-/blob/8d70f449892c6f7659e07bb0f06b8347677bb7d8/libevdev/libevdev.c#L66-101
                 struct input_event input_queue[256U];  // 4K on 32-bit, 6K on 64-bit
                 ssize_t            len = read(inputfds[i], &input_queue, sizeof(input_queue));

--- a/input/input.c
+++ b/input/input.c
@@ -364,7 +364,7 @@ static int waitForInput(lua_State* L)
                     lua_rawseti(L, -2, ++j);  // table.insert(ev_array, ev) [, j]
                 }
             }
-            printf("Pushed %zu events\n", lua_objlen(L, -1));
+            printf("Pushed %zu (%zu) events\n", lua_objlen(L, -1), j);
             return 2;  // true, ev_array
         }
     }

--- a/input/input.c
+++ b/input/input.c
@@ -253,7 +253,7 @@ static int fakeTapInput(lua_State* L)
 
 static inline void set_event_table(lua_State* L, const struct input_event* input)
 {
-    lua_newtable(L);  // ev = {}
+    lua_createtable(L, 0, 4);  // ev = {} (pre-allocated for its four fields)
     lua_pushstring(L, "type");
     lua_pushinteger(L, input->type);  // uint16_t
     // NOTE: rawset does t[k] = v, with v @ -1, k @ -2 and t at the specified index, here, that's ev @ -3.
@@ -269,7 +269,7 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
     lua_pushstring(L, "time");
     // NOTE: This is TimeVal-like, but it doesn't feature its metatable!
     //       The frontend (device/input.lua) will convert it to a proper TimeVal object.
-    lua_newtable(L);  // time = {}
+    lua_createtable(L, 0, 2);  // time = {} (pre-allocated for its two fields)
     lua_pushstring(L, "sec");
     lua_pushinteger(L, input->time.tv_sec);  // time_t
     lua_rawset(L, -3);                       // time.sec = input.time.tv_sec

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -118,6 +118,7 @@ static int setTimer(lua_State* L)
     clockid_t   clock         = luaL_checkint(L, 1);
     time_t      deadline_sec  = luaL_checkinteger(L, 2);
     suseconds_t deadline_usec = luaL_checkinteger(L, 3);
+    lua_pop(L, lua_gettop(L)); // Pop function args
 
     // Unlike in input.c, we know we're running a kernel recent enough to support the flags
     int fd = timerfd_create(clock, TFD_NONBLOCK | TFD_CLOEXEC);
@@ -166,6 +167,7 @@ static int setTimer(lua_State* L)
 static int clearTimer(lua_State* L)
 {
     timerfd_node_t* restrict expired_node = (timerfd_node_t * restrict) lua_touserdata(L, 1);
+    lua_pop(L, lua_gettop(L)); // Pop function arg
 
     timerfd_list_delete_node(&timerfds, expired_node);
 

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -118,7 +118,7 @@ static int setTimer(lua_State* L)
     clockid_t   clock         = luaL_checkint(L, 1);
     time_t      deadline_sec  = luaL_checkinteger(L, 2);
     suseconds_t deadline_usec = luaL_checkinteger(L, 3);
-    lua_pop(L, lua_gettop(L)); // Pop function args
+    lua_pop(L, lua_gettop(L));  // Pop function args
 
     // Unlike in input.c, we know we're running a kernel recent enough to support the flags
     int fd = timerfd_create(clock, TFD_NONBLOCK | TFD_CLOEXEC);
@@ -167,7 +167,7 @@ static int setTimer(lua_State* L)
 static int clearTimer(lua_State* L)
 {
     timerfd_node_t* restrict expired_node = (timerfd_node_t * restrict) lua_touserdata(L, 1);
-    lua_pop(L, lua_gettop(L)); // Pop function arg
+    lua_pop(L, lua_gettop(L));  // Pop function arg
 
     timerfd_list_delete_node(&timerfds, expired_node);
 


### PR DESCRIPTION
Okay, turns out, reading the full batch of events at once (or at least in as few `read` as possible) isn't too gnarly, and allows us to do nifty things with Lua table allocations, by telling Lua exactly how many elements we're going to insert.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1346)
<!-- Reviewable:end -->
