### PR TITLE
CLOEXEC related tweaks

### DIFF
--- a/ffi/input_pocketbook.lua
+++ b/ffi/input_pocketbook.lua
@@ -117,7 +117,7 @@ function input:open()
         -- You must chmod those to be readable by non-root somehow (or run as root)
         for i=1, max_fds-1 do
             local input_dev = "/dev/input/event"..tostring(i)
-            local fd = C.open(input_dev, C.O_RDONLY+C.O_NONBLOCK)
+            local fd = C.open(input_dev, bit.bor(C.O_RDONLY, C.O_NONBLOCK, C.O_CLOEXEC))
             if fd >= 0 then
                 poll_fds[poll_fds_count].fd = fd
                 poll_fds[poll_fds_count].events = C.POLLIN

--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -82,7 +82,7 @@ function Jpeg.encodeToFile(filename, source_ptr, w, stride, h, quality, color_ty
     if turbojpeg.tjCompress2(handle, source_ptr, w, stride, h, color_type,
         jpeg_image, jpeg_size, subsample, quality, 0) == 0 then
 
-        local fhandle = C.open(filename, bit.bor(C.O_WRONLY, C.O_CREAT, C.O_TRUNC), ffi.cast("int", bit.bor(C.S_IRUSR, C.S_IWUSR, C.S_IRGRP, C.S_IROTH)))
+        local fhandle = C.open(filename, bit.bor(C.O_WRONLY, C.O_CREAT, C.O_TRUNC, C.O_CLOEXEC), ffi.cast("int", bit.bor(C.S_IRUSR, C.S_IWUSR, C.S_IRGRP, C.S_IROTH)))
         if fhandle >= 0 then
             C.write(fhandle, jpeg_image[0], jpeg_size[0])
             C.close(fhandle)

--- a/ffi/kobolight.lua
+++ b/ffi/kobolight.lua
@@ -37,8 +37,8 @@ function kobolight.open(device)
 		light_fd = nil,
 	}
 
-	local ld = C.open(device or "/dev/ntx_io", bor(bor(C.O_RDONLY, C.O_NONBLOCK), C.O_CLOEXEC))
-	assert(ld ~= -1, "cannot open light device")
+	local ld = C.open(device or "/dev/ntx_io", bor(C.O_RDONLY, C.O_NONBLOCK, C.O_CLOEXEC))
+	assert(ld ~= -1, "cannot open ntx_io character device")
 	light.light_fd = ffi.gc(
 		ffi.new("light_fd", ld),
 		function (light_fd) C.close(light_fd.ld) end

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -515,7 +515,7 @@ function util.fsyncDirectory(path)
             return false, err
         end
     end
-    local dirfd = C.open(ffi.cast("char *", path), C.O_RDONLY)
+    local dirfd = C.open(ffi.cast("char *", path), bit.bor(C.O_RDONLY, C.O_CLOEXEC))
     if dirfd == -1 then
         err = ffi.errno()
         return false, ffi.string(C.strerror(err))

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -55,6 +55,10 @@ else()
     add_definitions(-DLINUX=1 -D_LINUX=1)
 endif()
 
+if(DEFINED ENV{LEGACY})
+    add_definitions(-DDISABLE_CLOEXEC)
+endif()
+
 add_definitions(
     -DUSE_FONTCONFIG=0
     -DUSE_FREETYPE=1


### PR DESCRIPTION
* CRe: Disable CLOEXEC on Kindle Legacy
* Use CLOEXEC in every one of our (ffi.C) open() calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1349)
<!-- Reviewable:end -->
