### PR TITLE
Completely random table alloc tweaks in Lua/C modules

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1045,7 +1045,7 @@ static int getTableOfContent(lua_State *L) {
 
 	LVTocItem * toc = doc->text_view->getToc();
 
-	lua_createtable(L, toc->getChildCount(), 0);
+	lua_createtable(L, toc->getChildCount(), 0); // pre-alloc for top-level elements, at least
 	int count = 1;
 	walkTableOfContent(L, toc, &count);
 
@@ -1273,7 +1273,7 @@ static int getPageMapVisiblePageLabels(lua_State *L) {
     }
     int start = left;
 
-    lua_createtable(L, nb, 0);
+    lua_newtable(L); // We might end up w/ less that (nb - start) elements, so, don't overshot
     int count = 1;
     for (int i = start; i < nb; i++)  {
         LVPageMapItem * item = pagemap->getChild(i);
@@ -2151,7 +2151,7 @@ static int getWordBoxesFromPositions(lua_State *L) {
 		lvRect charRect, wordRect, lineRect;
 		int lcount = 1;
 		int lastx = -1;
-		lua_createtable(L, words.length(), 0); // new word boxes
+		lua_createtable(L, words.length(), 0); // new array of word boxes
 		lua_createtable(L, 0, 4); // first line box
 		for (int i=0; i<words.length(); i++) {
 			if (ldomXRange(words[i]).getRectEx(wordRect)) {

--- a/cre.cpp
+++ b/cre.cpp
@@ -1041,7 +1041,7 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
  */
 static int getTableOfContent(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
-	lua_pop(L, lua_gettop(L)); // Pop function args
+	lua_settop(L, 0); // Pop function arg
 
 	LVTocItem * toc = doc->text_view->getToc();
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -1411,11 +1411,11 @@ static int setHeaderProgressMarks(lua_State *L) {
         m_section_bounds.clear();
         m_section_bounds.add(0);
         if ( lua_istable(L, 3) ) {
-            int len = lua_objlen(L, 3);
-            for (int i = 1; i <= len; i++) {
+            size_t len = lua_objlen(L, 3);
+            for (size_t i = 1; i <= len; i++) {
                 lua_rawgeti(L, 3, i);
                 if ( lua_isnumber(L, -1) ) {
-                    int n = lua_tointeger(L, -1);
+                    int n = (int) lua_tointeger(L, -1);
                     m_section_bounds.add( 10000 * (n-1) / pages);
                 }
             }

--- a/cre.cpp
+++ b/cre.cpp
@@ -1041,11 +1041,12 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
  */
 static int getTableOfContent(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+	lua_pop(L, lua_gettop(L)); // Pop function args
 
 	LVTocItem * toc = doc->text_view->getToc();
-	int count = 1;
 
 	lua_createtable(L, toc->getChildCount(), 0);
+	int count = 1;
 	walkTableOfContent(L, toc, &count);
 
 	return 1;

--- a/cre.cpp
+++ b/cre.cpp
@@ -348,7 +348,7 @@ public:
             return;
         lua_rawgeti(_L, LUA_REGISTRYINDEX, _r_cb);
         lua_pushstring(_L, event);
-        lua_pushnumber(_L, number);
+        lua_pushinteger(_L, number);
         lua_pcall(_L, 2, 0, 0);
     }
     void callback(const char * event, const char * str) {
@@ -535,12 +535,12 @@ static int saveDefaults(lua_State *L) {
 }
 
 static int getLatestDomVersion(lua_State *L) {
-    lua_pushnumber(L, gDOMVersionCurrent);
+    lua_pushinteger(L, gDOMVersionCurrent);
     return 1;
 }
 
 static int getDomVersionWithNormalizedXPointers(lua_State *L) {
-    lua_pushnumber(L, DOM_VERSION_WITH_NORMALIZED_XPOINTERS); // defined in lvtinydom.h
+    lua_pushinteger(L, DOM_VERSION_WITH_NORMALIZED_XPOINTERS); // defined in lvtinydom.h
     return 1;
 }
 
@@ -616,8 +616,8 @@ static int getHyphDictList(lua_State *L) {
 
 static int getSelectedHyphDict(lua_State *L) {
 	lua_pushstring(L, UnicodeToLocal(HyphMan::getSelectedDictionary()->getId()).c_str());
-	lua_pushnumber(L, TextLangMan::getMainLangHyphMethod()->getLeftHyphenMin());
-	lua_pushnumber(L, TextLangMan::getMainLangHyphMethod()->getRightHyphenMin());
+	lua_pushinteger(L, TextLangMan::getMainLangHyphMethod()->getLeftHyphenMin());
+	lua_pushinteger(L, TextLangMan::getMainLangHyphMethod()->getRightHyphenMin());
 	return 3;
 }
 
@@ -991,7 +991,7 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
 		/* set subtable, Toc entry */
 		lua_createtable(L, 0, 4);
 		lua_pushstring(L, "page");
-		lua_pushnumber(L, toc_tmp->getPage()+1);
+		lua_pushinteger(L, toc_tmp->getPage()+1);
 		lua_rawset(L, -3);
 
 		// Note: toc_tmp->getXPointer().toString() and toc_tmp->getPath() return
@@ -1004,7 +1004,7 @@ static int walkTableOfContent(lua_State *L, LVTocItem *toc, int *count) {
 		lua_rawset(L, -3);
 
 		lua_pushstring(L, "depth");
-		lua_pushnumber(L, toc_tmp->getLevel());
+		lua_pushinteger(L, toc_tmp->getLevel());
 		lua_rawset(L, -3);
 
 		lua_pushstring(L, "title");
@@ -1092,7 +1092,7 @@ static int getPageMap(lua_State *L) {
         lua_createtable(L, 0, 4);
 
         lua_pushstring(L, "page");
-        lua_pushnumber(L, item->getPage()+1);
+        lua_pushinteger(L, item->getPage()+1);
         lua_rawset(L, -3);
 
         // Note: toc_tmp->getXPointer().toString() and toc_tmp->getPath() return
@@ -1104,7 +1104,7 @@ static int getPageMap(lua_State *L) {
         lua_rawset(L, -3);
 
         lua_pushstring(L, "doc_y");
-        lua_pushnumber(L, item->getDocY());
+        lua_pushinteger(L, item->getDocY());
         lua_rawset(L, -3);
 
         lua_pushstring(L, "label");
@@ -1293,15 +1293,15 @@ static int getPageMapVisiblePageLabels(lua_State *L) {
         lua_createtable(L, 0, 6);
 
         lua_pushstring(L, "screen_page");
-        lua_pushnumber(L, screen_page);
+        lua_pushinteger(L, screen_page);
         lua_rawset(L, -3);
 
         lua_pushstring(L, "screen_y");
-        lua_pushnumber(L, screen_y);
+        lua_pushinteger(L, screen_y);
         lua_rawset(L, -3);
 
         lua_pushstring(L, "page");
-        lua_pushnumber(L, item->getPage()+1);
+        lua_pushinteger(L, item->getPage()+1);
         lua_rawset(L, -3);
 
         lua_pushstring(L, "xpointer");
@@ -1309,7 +1309,7 @@ static int getPageMapVisiblePageLabels(lua_State *L) {
         lua_rawset(L, -3);
 
         lua_pushstring(L, "doc_y");
-        lua_pushnumber(L, item->getDocY());
+        lua_pushinteger(L, item->getDocY());
         lua_rawset(L, -3);
 
         lua_pushstring(L, "label");
@@ -1515,7 +1515,7 @@ static int zoomFont(lua_State *L) {
 
 	doc->text_view->ZoomFont(delta);
 
-	lua_pushnumber(L, doc->text_view->getFontSize());
+	lua_pushinteger(L, doc->text_view->getFontSize());
 	return 1;
 }
 
@@ -1656,19 +1656,19 @@ static int getPageMargins(lua_State *L) {
 	lua_createtable(L, 0, 4);
 
 	lua_pushstring(L, "left");
-	lua_pushnumber(L, rc.left);
+	lua_pushinteger(L, rc.left);
 	lua_rawset(L, -3);
 
 	lua_pushstring(L, "top");
-	lua_pushnumber(L, rc.top);
+	lua_pushinteger(L, rc.top);
 	lua_rawset(L, -3);
 
 	lua_pushstring(L, "right");
-	lua_pushnumber(L, rc.right);
+	lua_pushinteger(L, rc.right);
 	lua_rawset(L, -3);
 
 	lua_pushstring(L, "bottom");
-	lua_pushnumber(L, rc.bottom);
+	lua_pushinteger(L, rc.bottom);
 	lua_rawset(L, -3);
 
 	return 1;

--- a/cre.cpp
+++ b/cre.cpp
@@ -1413,8 +1413,7 @@ static int setHeaderProgressMarks(lua_State *L) {
         if ( lua_istable(L, 3) ) {
             int len = lua_objlen(L, 3);
             for (int i = 1; i <= len; i++) {
-                lua_pushinteger(L, i);
-                lua_gettable(L, 3);
+                lua_rawgeti(L, 3, i);
                 if ( lua_isnumber(L, -1) ) {
                     int n = lua_tointeger(L, -1);
                     m_section_bounds.add( 10000 * (n-1) / pages);

--- a/cre.cpp
+++ b/cre.cpp
@@ -1273,7 +1273,7 @@ static int getPageMapVisiblePageLabels(lua_State *L) {
     }
     int start = left;
 
-    lua_newtable(L); // We might end up w/ less that (nb - start) elements, so, don't overshot
+    lua_newtable(L); // We might end up w/ less than (nb - start) elements, so, don't overshot
     int count = 1;
     for (int i = start; i < nb; i++)  {
         LVPageMapItem * item = pagemap->getChild(i);

--- a/djvu.c
+++ b/djvu.c
@@ -451,17 +451,17 @@ static int getPageInfo(lua_State *L) {
  * @param yheight  Page height. DjVu zones are origined at the bottom-left, but
  *                   koptinterface convention origins at top-left.
  */
-bool lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
+void lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 	if (!L) {
-		return false;
+		return;
 	}
 	if (!miniexp_consp(anno)) {
-		return false;
+		return;
 	}
 
 	miniexp_t anno_type = miniexp_nth(SI_ZONE_NAME, anno);
 	if (!miniexp_symbolp(anno_type)) {
-		return false;
+		return;
 	}
 
 	int xmin = int_from_miniexp_nth(SI_ZONE_XMIN, anno);
@@ -484,14 +484,12 @@ bool lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 			lua_setkeyval(L, string, zname, txt);
 		} else {
 			// New line or word!
-			lua_createtable(L, miniexp_length(data) - SI_ZONE_DATA, 4); // line/word = {}; pre-allocated to the correct amount of elements and its box
+			lua_createtable(L, miniexp_length(data) - SI_ZONE_DATA, 4); // line/word = {}; pre-allocated to the correct amount of elements and its own box
 			lua_settable_djvu_anno(L, data, yheight);
 			// We're done with it, insert it in the page/line array
 			lua_rawseti(L, -2, tindex);
 		}
 	}
-
-	return true;
 }
 
 static int getPageText(lua_State *L) {

--- a/djvu.c
+++ b/djvu.c
@@ -491,10 +491,11 @@ bool lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 			printf("line.%s=%s\n", zname, txt);
 		} else {
 			// New line!
-			lua_createtable(L, 0, 4); // line = {}; number of array elements (words) unclear, but at least 4 fields for the box
-			printf("line = {} (#stack: %d)\n", lua_gettop(L));
+			lua_createtable(L, miniexp_length(data) - SI_ZONE_DATA, 4); // line = {}; pre-allocated to the correct amount of words and its line box
+			printf("line = {} (%u elems, #stack: %d)\n", miniexp_length(data) - SI_ZONE_DATA, lua_gettop(L));
 			lua_settable_djvu_anno(L, data, yheight);
 			// We're done with it, insert it in the lines array
+			printf("Line %d (%zu) had %zu words\n", tindex, lua_objlen(L, -2), lua_objlen(L, -1));
 			lua_rawseti(L, -2, tindex);
 			printf("table.insert(lines, line, %d) (#stack: %d)\n", tindex, lua_gettop(L));
 		}
@@ -534,11 +535,12 @@ static int getPageText(lua_State *L) {
 		handle(L, doc->context, True);
 	}
 
-	lua_createtable(L, 0, 4); // lines = {}; number of array elements (lines) unclear, but it does have a page box
-	printf("lines = {}\n");
+	lua_createtable(L, miniexp_length(sexp) - SI_ZONE_DATA, 4); // lines = {}; pre-allocated to the correct amount of lines and its page box
+	printf("lines = {} (%u elems)\n", miniexp_length(sexp) - SI_ZONE_DATA);
 	printf("#stack: %d\n", lua_gettop(L));
 	lua_settable_djvu_anno(L, sexp, info.height);
 	printf("Final #stack: %d\n", lua_gettop(L));
+	printf("#lines: %zu\n", lua_objlen(L, -1));
 	return 1;
 }
 

--- a/djvu.c
+++ b/djvu.c
@@ -41,7 +41,7 @@
 #define lua_setkeyval(L, type, key, val) do { \
 	lua_pushstring(L, key); \
 	lua_push##type(L, val); \
-	lua_settable(L, LUA_SETTABLE_STACK_TOP); \
+	lua_rawset(L, LUA_SETTABLE_STACK_TOP); \
 } while(0)
 
 
@@ -237,7 +237,7 @@ static int getMetadata(lua_State *L) {
 		if (value) {
 			lua_pushstring(L, miniexp_to_name(keys[i]));
 			lua_pushstring(L, value);
-			lua_settable(L, -3);
+			lua_rawset(L, -3);
 		}
 	}
 
@@ -258,46 +258,39 @@ static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) 
 
 	int length = miniexp_length(r);
 	int counter = 0;
-	const char* page_name;
-	int page_number;
-	uint32_t page_name_num_idx;
-
 	while(counter < length-1) {
-		lua_pushnumber(L, *count);
-		lua_newtable(L);
+		lua_createtable(L, 0, 3);
 
 		lua_pushstring(L, "page");
-		page_name = miniexp_to_str(miniexp_car(miniexp_cdr(miniexp_nth(counter, lista))));
+		const char* page_name = miniexp_to_str(miniexp_car(miniexp_cdr(miniexp_nth(counter, lista))));
 		if(page_name != NULL && page_name[0] == '#') {
 			errno = 0;
-			page_name_num_idx = 1;  /* skip leading # */
+			uint32_t page_name_num_idx = 1U;  /* skip leading # */
 			while (page_name[page_name_num_idx] && !isdigit(page_name[page_name_num_idx])) {
 				page_name_num_idx++;
 			}
-			page_number = strtol(page_name+page_name_num_idx, NULL, 10);
+			int page_number = (int) strtol(page_name+page_name_num_idx, NULL, 10);
 			if(!errno) {
-				lua_pushnumber(L, page_number);
+				lua_pushinteger(L, page_number);
 			} else {
 				/* we can not parse this as a number, TODO: parse page names */
-				lua_pushnumber(L, -1);
+				lua_pushinteger(L, -1);
 			}
 		} else {
 			/* something we did not expect here */
-			lua_pushnumber(L, -1);
+			lua_pushinteger(L, -1);
 		}
-		lua_settable(L, -3);
+		lua_rawset(L, -3);
 
 		lua_pushstring(L, "depth");
-		lua_pushnumber(L, depth);
-		lua_settable(L, -3);
+		lua_pushinteger(L, depth);
+		lua_rawset(L, -3);
 
 		lua_pushstring(L, "title");
 		lua_pushstring(L, miniexp_to_str(miniexp_car(miniexp_nth(counter, lista))));
-		lua_settable(L, -3);
+		lua_rawset(L, -3);
 
-		lua_settable(L, -3);
-
-		(*count)++;
+		lua_rawseti(L, -1, (*count)++);
 
 		if (miniexp_length(miniexp_cdr(miniexp_nth(counter, lista))) > 1) {
 			walkTableOfContent(L, miniexp_cdr(miniexp_nth(counter, lista)), count, depth);
@@ -317,7 +310,7 @@ static int getTableOfContent(lua_State *L) {
 
 	//printf("lista: %s\n", miniexp_to_str(miniexp_car(miniexp_nth(1, miniexp_cdr(r)))));
 
-	lua_newtable(L);
+	lua_createtable(L, miniexp_length(r), 0);
 	walkTableOfContent(L, r, &count, 0);
 
 	return 1;
@@ -388,8 +381,8 @@ static int getOriginalPageSize(lua_State *L) {
 		handle(L, doc->context, TRUE);
 	}
 
-	lua_pushnumber(L, info.width);
-	lua_pushnumber(L, info.height);
+	lua_pushinteger(L, info.width);
+	lua_pushinteger(L, info.height);
 
 	return 2;
 }
@@ -397,32 +390,28 @@ static int getOriginalPageSize(lua_State *L) {
 static int getPageInfo(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
 	int pageno = luaL_checkint(L, 2);
-	ddjvu_page_t *djvu_page;
-	int page_width, page_height, page_dpi;
-	double page_gamma;
-	ddjvu_page_type_t page_type;
-	char *page_type_str;
 
-	djvu_page = ddjvu_page_create_by_pageno(doc->doc_ref, pageno - 1);
+	ddjvu_page_t *djvu_page = ddjvu_page_create_by_pageno(doc->doc_ref, pageno - 1);
 	if (! djvu_page)
 		return luaL_error(L, "cannot create djvu_page #%d", pageno);
 
 	while (! ddjvu_page_decoding_done(djvu_page))
 		handle(L, doc->context, TRUE);
 
-	page_width = ddjvu_page_get_width(djvu_page);
-	lua_pushnumber(L, page_width);
+	int page_width = ddjvu_page_get_width(djvu_page);
+	lua_pushinteger(L, page_width);
 
-	page_height = ddjvu_page_get_height(djvu_page);
-	lua_pushnumber(L, page_height);
+	int page_height = ddjvu_page_get_height(djvu_page);
+	lua_pushinteger(L, page_height);
 
-	page_dpi = ddjvu_page_get_resolution(djvu_page);
-	lua_pushnumber(L, page_dpi);
+	int page_dpi = ddjvu_page_get_resolution(djvu_page);
+	lua_pushinteger(L, page_dpi);
 
-	page_gamma = ddjvu_page_get_gamma(djvu_page);
+	double page_gamma = ddjvu_page_get_gamma(djvu_page);
 	lua_pushnumber(L, page_gamma);
 
-	page_type = ddjvu_page_get_type(djvu_page);
+	const char *page_type_str;
+	ddjvu_page_type_t page_type = ddjvu_page_get_type(djvu_page);
 	switch (page_type) {
 		case DDJVU_PAGETYPE_UNKNOWN:
 			page_type_str = "UNKNOWN";
@@ -486,10 +475,9 @@ void lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 			const char *txt = miniexp_to_str(data);
 			lua_setkeyval(L, string, zname, txt);
 		} else {
-			lua_pushinteger(L, tindex);
 			lua_newtable(L);
 			lua_settable_djvu_anno(L, data, yheight);
-			lua_settable(L, LUA_SETTABLE_STACK_TOP);
+			lua_rawseti(L, -2, tindex);
 		}
 	}
 }
@@ -519,6 +507,9 @@ static int getPageText(lua_State *L) {
 		handle(L, doc->context, True);
 	}
 
+	// FIXME: hash vs. array parts is unclear. I feel like the table we create here should be an array,
+	//        and each element, hash-only, ought to be created *inside* (at the top of) lua_settable_djvu_anno...
+	//        i.e., return an array of hash-tables.
 	lua_newtable(L);
 	lua_settable_djvu_anno(L, sexp, info.height);
 	return 1;
@@ -721,7 +712,7 @@ static int getCacheSize(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
 	unsigned long size = ddjvu_cache_get_size(doc->context);
 	//printf("## ddjvu_cache_get_size = %d\n", (int)size);
-	lua_pushnumber(L, size);
+	lua_pushinteger(L, size);
 	return 1;
 }
 

--- a/djvu.c
+++ b/djvu.c
@@ -17,7 +17,6 @@
 */
 
 #include <stdint.h>
-#include <stdbool.h>
 #include <math.h>
 #include <string.h>
 #include <errno.h>
@@ -292,7 +291,7 @@ static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) 
 		lua_pushstring(L, miniexp_to_str(miniexp_car(miniexp_nth(counter, lista))));
 		lua_rawset(L, -3);
 
-		lua_rawseti(L, -1, (*count)++);
+		lua_rawseti(L, -2, (*count)++);
 
 		if (miniexp_length(miniexp_cdr(miniexp_nth(counter, lista))) > 1) {
 			walkTableOfContent(L, miniexp_cdr(miniexp_nth(counter, lista)), count, depth);

--- a/djvu.c
+++ b/djvu.c
@@ -304,15 +304,16 @@ static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) 
 
 static int getTableOfContent(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
-	miniexp_t r;
-	int count = 1;
+	lua_pop(L, lua_gettop(L)); // Pop function args
 
+	miniexp_t r;
 	while ((r=ddjvu_document_get_outline(doc->doc_ref))==miniexp_dummy)
 		handle(L, doc->context, True);
 
 	//printf("lista: %s\n", miniexp_to_str(miniexp_car(miniexp_nth(1, miniexp_cdr(r)))));
 
 	lua_createtable(L, miniexp_length(r), 0);
+	int count = 1;
 	walkTableOfContent(L, r, &count, 0);
 
 	return 1;

--- a/djvu.c
+++ b/djvu.c
@@ -304,7 +304,7 @@ static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) 
 
 static int getTableOfContent(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
-	lua_pop(L, lua_gettop(L)); // Pop function args
+	lua_settop(L, 0); // Pop function arg
 
 	miniexp_t r;
 	while ((r=ddjvu_document_get_outline(doc->doc_ref))==miniexp_dummy)
@@ -496,7 +496,7 @@ void lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 static int getPageText(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
 	int pageno = luaL_checkint(L, 2);
-	lua_pop(L, lua_gettop(L)); // Pop function args
+	lua_settop(L, 0); // Pop function args
 
 	/* get page height for coordinates transform */
 	ddjvu_pageinfo_t info;

--- a/djvu.c
+++ b/djvu.c
@@ -252,26 +252,26 @@ static int getNumberOfPages(lua_State *L) {
 	return 1;
 }
 
-static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) {
+static void walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) {
 	depth++;
 
-	miniexp_t lista = miniexp_cdr(r); // go inside bookmars in the list
+	miniexp_t lista = miniexp_cdr(r); // go inside bookmarks in the list
 
-	int length = miniexp_length(r);
+	int length = miniexp_length(r) - 1; // Minus the sentinel NUL
 	int counter = 0;
-	while(counter < length-1) {
+	while (counter < length) {
 		lua_createtable(L, 0, 3);
 
 		lua_pushstring(L, "page");
 		const char* page_name = miniexp_to_str(miniexp_car(miniexp_cdr(miniexp_nth(counter, lista))));
-		if(page_name != NULL && page_name[0] == '#') {
+		if (page_name != NULL && page_name[0] == '#') {
 			errno = 0;
 			uint32_t page_name_num_idx = 1U;  /* skip leading # */
 			while (page_name[page_name_num_idx] && !isdigit(page_name[page_name_num_idx])) {
 				page_name_num_idx++;
 			}
 			int page_number = (int) strtol(page_name+page_name_num_idx, NULL, 10);
-			if(!errno) {
+			if (!errno) {
 				lua_pushinteger(L, page_number);
 			} else {
 				/* we can not parse this as a number, TODO: parse page names */
@@ -298,7 +298,6 @@ static int walkTableOfContent(lua_State *L, miniexp_t r, int *count, int depth) 
 		}
 		counter++;
 	}
-	return 0;
 }
 
 static int getTableOfContent(lua_State *L) {
@@ -311,7 +310,7 @@ static int getTableOfContent(lua_State *L) {
 
 	//printf("lista: %s\n", miniexp_to_str(miniexp_car(miniexp_nth(1, miniexp_cdr(r)))));
 
-	lua_createtable(L, miniexp_length(r), 0); // pre-alloc for top-level elements, at least
+	lua_createtable(L, miniexp_length(r) - 1, 0); // pre-alloc for top-level elements, at least
 	int count = 1;
 	walkTableOfContent(L, r, &count, 0);
 

--- a/djvu.c
+++ b/djvu.c
@@ -311,7 +311,7 @@ static int getTableOfContent(lua_State *L) {
 
 	//printf("lista: %s\n", miniexp_to_str(miniexp_car(miniexp_nth(1, miniexp_cdr(r)))));
 
-	lua_createtable(L, miniexp_length(r), 0);
+	lua_createtable(L, miniexp_length(r), 0); // pre-alloc for top-level elements, at least
 	int count = 1;
 	walkTableOfContent(L, r, &count, 0);
 

--- a/djvu.c
+++ b/djvu.c
@@ -709,8 +709,10 @@ static int drawPage(lua_State *L) {
 	 * So we don't set rotation here.
 	 */
 
-	if (!ddjvu_page_render(page->page_ref, djvu_render_mode, &pagerect, &renderrect, page->doc->pixelformat, bb->w*page->doc->pixelsize, imagebuffer))
+	if (!ddjvu_page_render(page->page_ref, djvu_render_mode, &pagerect, &renderrect, page->doc->pixelformat, bb->w*page->doc->pixelsize, imagebuffer)) {
+		// Clear to white on failure
 		memset(imagebuffer, 0xFF, bbsize);
+	}
 
 	return 0;
 }

--- a/djvu.c
+++ b/djvu.c
@@ -451,42 +451,33 @@ static int getPageInfo(lua_State *L) {
  * @param yheight  Page height. DjVu zones are origined at the bottom-left, but
  *                   koptinterface convention origins at top-left.
  */
-bool lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
-	if (!L) {
-		return false;
-	}
-	if (!miniexp_consp(anno)) {
-		return false;
-	}
+void lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
+	if (!L) return;
+	if (!miniexp_consp(anno)) return;
 
 	miniexp_t anno_type = miniexp_nth(SI_ZONE_NAME, anno);
-	if (!miniexp_symbolp(anno_type)) {
-		return false;
-	}
-
-	// New element in the array
-	lua_createtable(L, 0, 4); // line = {}, At least 4 fields
-	printf("line = {} (#stack: %d)\n", lua_gettop(L));
+	if (!miniexp_symbolp(anno_type)) return;
 
 	int xmin = int_from_miniexp_nth(SI_ZONE_XMIN, anno);
 	int ymin = int_from_miniexp_nth(SI_ZONE_YMIN, anno);
 	int xmax = int_from_miniexp_nth(SI_ZONE_XMAX, anno);
 	int ymax = int_from_miniexp_nth(SI_ZONE_YMAX, anno);
 
+	printf("#stack: %d\n", lua_gettop(L));
 	lua_setkeyval(L, integer, djvuZoneLuaKey[SI_ZONE_XMIN], xmin);
-	printf("h.%s=%d\n", djvuZoneLuaKey[SI_ZONE_XMIN], xmin);
+	printf("?.%s=%d\n", djvuZoneLuaKey[SI_ZONE_XMIN], xmin);
 	lua_setkeyval(L, integer, djvuZoneLuaKey[SI_ZONE_YMIN], yheight - ymin);
-	printf("h.%s=%d\n", djvuZoneLuaKey[SI_ZONE_YMIN], yheight - ymin);
+	printf("?.%s=%d\n", djvuZoneLuaKey[SI_ZONE_YMIN], yheight - ymin);
 	lua_setkeyval(L, integer, djvuZoneLuaKey[SI_ZONE_XMAX], xmax);
-	printf("h.%s=%d\n", djvuZoneLuaKey[SI_ZONE_XMAX], xmax);
+	printf("?.%s=%d\n", djvuZoneLuaKey[SI_ZONE_XMAX], xmax);
 	lua_setkeyval(L, integer, djvuZoneLuaKey[SI_ZONE_YMAX], yheight - ymax);
-	printf("h.%s=%d\n", djvuZoneLuaKey[SI_ZONE_YMAX], yheight - ymax);
+	printf("?.%s=%d\n", djvuZoneLuaKey[SI_ZONE_YMAX], yheight - ymax);
 
 	printf("miniexp_length(anno): %d\n", miniexp_length(anno));
 	for (int i = SI_ZONE_DATA; i < miniexp_length(anno); i++) {
 		miniexp_t data = miniexp_nth(i, anno);
 		int tindex = i - SI_ZONE_DATA + 1; // Lua tables are 1-indexed
-		printf("tindex: %d @ i: %d\n", tindex, i);
+		printf("tindex: %d @ i: %d (#stack: %d)\n", tindex, i, lua_gettop(L));
 
 		if (miniexp_stringp(data)) {
 			const char *zname = miniexp_to_name(anno_type);
@@ -494,26 +485,20 @@ bool lua_settable_djvu_anno(lua_State *L, miniexp_t anno, int yheight) {
 			lua_setkeyval(L, string, zname, txt);
 			printf("h.%s=%s\n", zname, txt);
 		} else {
-			// We're done with this line, insert it in the array
-			lua_rawseti(L, -2, tindex);
-			printf("table.insert(lines, line, %d) (#stack: %d)\n", tindex, lua_gettop(L));
-			// And onward to the next line
+			lua_pushinteger(L, tindex);
+			lua_newtable(L);
+			printf("line = {} (#stack: %d)\n", lua_gettop(L));
 			lua_settable_djvu_anno(L, data, yheight);
+			lua_settable(L, LUA_SETTABLE_STACK_TOP);
+			printf("table.insert(lines, line, %d) (#stack: %d)\n", tindex, lua_gettop(L));
 		}
 	}
-
-	// FIXME: Can we reach this without entering the loop?
-	//        Because that would leave us with a bogus hash table on top of the stack instead of the array...
-	//        Or abort early if miniexp_length(anno) is SI_ZONE_DATA - 1?
-	printf("lua_settable_djvu_anno: true (#stack: %d)\n", lua_gettop(L));
-
-	return true;
 }
 
 static int getPageText(lua_State *L) {
 	DjvuDocument *doc = (DjvuDocument*) luaL_checkudata(L, 1, "djvudocument");
 	int pageno = luaL_checkint(L, 2);
-	lua_pop(L, lua_gettop(L)); // Pop function args
+	lua_pop(L, lua_gettop(L));
 
 	/* get page height for coordinates transform */
 	ddjvu_pageinfo_t info;
@@ -536,7 +521,7 @@ static int getPageText(lua_State *L) {
 		handle(L, doc->context, True);
 	}
 
-	lua_newtable(L); // lines = {}; Number of elements unclear, no pre-alloc
+	lua_newtable(L);
 	printf("lines = {}\n");
 	printf("#stack: %d\n", lua_gettop(L));
 	lua_settable_djvu_anno(L, sexp, info.height);

--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -105,6 +105,7 @@ cdecl_func(ioctl)
 //cdecl_func(Sleep) // Win32
 cdecl_func(sleep)
 cdecl_func(usleep)
+cdecl_func(nanosleep)
 cdecl_func(statvfs)
 cdecl_func(gettimeofday)
 cdecl_func(realpath)

--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -33,6 +33,8 @@ cdecl_const(EPIPE)
 cdecl_const(ENOSYS)
 cdecl_const(ETIMEDOUT)
 
+// NOTE: Let's hope we'll all have moved to 64-bit by the time Y2038 becomes an issue...
+//       c.f., https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit?id=152194fe9c3f
 cdecl_type(off_t)
 cdecl_type(time_t)
 cdecl_type(suseconds_t)

--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -124,6 +124,8 @@ cdecl_const(CLOCK_TAI)
 cdecl_func(clock_getres)
 cdecl_func(clock_gettime)
 cdecl_func(clock_settime)
+cdecl_const(TIMER_ABSTIME)
+cdecl_func(clock_nanosleep)
 
 cdecl_func(malloc)
 cdecl_func(calloc)

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -101,6 +101,8 @@ static const int CLOCK_TAI = 11;
 int clock_getres(clockid_t, struct timespec *) __attribute__((nothrow, leaf));
 int clock_gettime(clockid_t, struct timespec *) __attribute__((nothrow, leaf));
 int clock_settime(clockid_t, const struct timespec *) __attribute__((nothrow, leaf));
+static const int TIMER_ABSTIME = 1;
+int clock_nanosleep(clockid_t, int, const struct timespec *, struct timespec *);
 void *malloc(size_t) __attribute__((malloc, leaf, nothrow));
 void *calloc(size_t, size_t) __attribute__((malloc, leaf, nothrow));
 void free(void *) __attribute__((leaf, nothrow));

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -85,6 +85,7 @@ int ioctl(int, long unsigned int, ...) __attribute__((nothrow, leaf));
 void Sleep(int ms);
 unsigned int sleep(unsigned int);
 int usleep(unsigned int);
+int nanosleep(const struct timespec *, struct timespec *);
 int statvfs(const char *restrict, struct statvfs *restrict) __attribute__((nothrow, leaf));
 int gettimeofday(struct timeval *restrict, struct timezone *restrict) __attribute__((nothrow, leaf));
 char *realpath(const char *restrict, char *restrict) __attribute__((nothrow, leaf));

--- a/input/input.c
+++ b/input/input.c
@@ -287,8 +287,9 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
 
 static inline size_t drain_input_queue(lua_State* L, struct input_event* input_queue, size_t ev_count, size_t j)
 {
-    if (!lua_istable(L, -1)) {
-        // First call, create our array, pre-allocated to the necessary number of elements...
+    if (lua_gettop(L) == 1) {
+        // Only a single element in the stack? (that would be our `true` bool)?
+        // That means this is the first call, create our array, pre-allocated to the necessary number of elements...
         // ...for this call, at least. Subsequent ones will insert event by event.
         // That said, multiple calls should be extremely rare:
         // We'd need to have filled the input_queue buffer *during* a single batch of events on the same fd ;).

--- a/input/input.c
+++ b/input/input.c
@@ -146,7 +146,7 @@ static int openInputDevice(lua_State* L)
     }
 
     // We're done w/ inputdevice, pop it
-    lua_pop(L, lua_gettop(L));
+    lua_settop(L, 0);
 
     // Compute select's nfds argument.
     // That's not the actual number of fds in the set, like poll(),
@@ -198,7 +198,7 @@ static int fakeTapInput(lua_State* L)
     }
 
     // Pop function args, now that we're done w/ inputdevice
-    lua_pop(L, lua_gettop(L));
+    lua_settop(L, 0);
 
     struct input_event ev = { 0 };
     gettimeofday(&ev.time, NULL);
@@ -308,7 +308,7 @@ static int waitForInput(lua_State* L)
 {
     lua_Integer sec  = luaL_optinteger(L, 1, -1);  // Fallback to -1 to handle detecting a nil
     lua_Integer usec = luaL_optinteger(L, 2, 0);
-    lua_pop(L, lua_gettop(L));  // Pop the function arguments
+    lua_settop(L, 0);  // Pop the function arguments
 
     struct timeval  timeout;
     struct timeval* timeout_ptr = NULL;
@@ -361,21 +361,21 @@ static int waitForInput(lua_State* L)
                         // Kernel queue drained :)
                         break;
                     }
-                    lua_pop(L, lua_gettop(L));  // Kick our bogus bool (and potentially the ev_array table) from the stack
+                    lua_settop(L, 0);  // Kick our bogus bool (and potentially the ev_array table) from the stack
                     lua_pushboolean(L, false);
                     lua_pushinteger(L, errno);
                     return 2;  // false, errno
                 }
                 if (len == 0) {
                     // Should never happen
-                    lua_pop(L, lua_gettop(L));
+                    lua_settop(L, 0);
                     lua_pushboolean(L, false);
                     lua_pushinteger(L, EPIPE);
                     return 2;  // false, EPIPE
                 }
                 if (len > 0 && len % sizeof(*input_queue) != 0) {
                     // Truncated read?! (not a multiple of struct input_event)
-                    lua_pop(L, lua_gettop(L));
+                    lua_settop(L, 0);
                     lua_pushboolean(L, false);
                     lua_pushinteger(L, EINVAL);
                     return 2;  // false, EINVAL

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -118,7 +118,7 @@ static int setTimer(lua_State* L)
     clockid_t   clock         = luaL_checkint(L, 1);
     time_t      deadline_sec  = luaL_checkinteger(L, 2);
     suseconds_t deadline_usec = luaL_checkinteger(L, 3);
-    lua_pop(L, lua_gettop(L));  // Pop function args
+    lua_settop(L, 0);  // Pop function args
 
     // Unlike in input.c, we know we're running a kernel recent enough to support the flags
     int fd = timerfd_create(clock, TFD_NONBLOCK | TFD_CLOEXEC);
@@ -167,7 +167,7 @@ static int setTimer(lua_State* L)
 static int clearTimer(lua_State* L)
 {
     timerfd_node_t* restrict expired_node = (timerfd_node_t * restrict) lua_touserdata(L, 1);
-    lua_pop(L, lua_gettop(L));  // Pop function arg
+    lua_settop(L, 0);  // Pop function arg
 
     timerfd_list_delete_node(&timerfds, expired_node);
 

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -401,7 +401,7 @@ public:
     // both utf8 decoding algorithms (but we can aim later at having
     // a single good one).
     void setTextFromUTF8CharsLuaArray(lua_State * L, int n) {
-        m_length = lua_objlen(L, n);
+        m_length = (int) lua_objlen(L, n); // NOTE: size_t -> int, as that's what both FriBidi & HarfBuzz expect.
         m_text = (uint32_t *)malloc(m_length * sizeof(*m_text));
         m_is_valid = true; // assume it is valid if coming from Lua array
         m_has_rtl = false;

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -1141,50 +1141,50 @@ public:
         // We could have used some indirection to make that more
         // generic, but let's push a table suitable to be added
         // directly to TextBoxWidget.vertical_string_list
-        lua_newtable(m_L);
+        lua_createtable(m_L, 0, 5); // 5 hash fields for sure
 
         lua_pushstring(m_L, "offset");
         lua_pushinteger(m_L, start+1); // (Lua indices start at 1)
-        lua_settable(m_L, -3);
+        lua_rawset(m_L, -3);
 
         lua_pushstring(m_L, "end_offset");
         lua_pushinteger(m_L, candidate_end+1); // (Lua indices start at 1)
-        lua_settable(m_L, -3);
+        lua_rawset(m_L, -3);
 
         lua_pushstring(m_L, "can_be_justified");
         lua_pushboolean(m_L, can_be_justified);
-        lua_settable(m_L, -3);
+        lua_rawset(m_L, -3);
 
         lua_pushstring(m_L, "width");
         lua_pushinteger(m_L, candidate_line_width);
-        lua_settable(m_L, -3);
+        lua_rawset(m_L, -3);
 
         lua_pushstring(m_L, "targeted_width");
         lua_pushinteger(m_L, targeted_width);
-        lua_settable(m_L, -3);
+        lua_rawset(m_L, -3);
 
         if ( no_allowed_break_met ) {
             lua_pushstring(m_L, "no_allowed_break_met");
             lua_pushboolean(m_L, true);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
         }
 
         if ( has_tabs ) {
             lua_pushstring(m_L, "has_tabs");
             lua_pushboolean(m_L, true);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
         }
 
         if ( next_line_start_offset >= 0 && next_line_start_offset < m_length ) {
             // next_start_offset is to be nil if end of text
             lua_pushstring(m_L, "next_start_offset");
             lua_pushinteger(m_L, next_line_start_offset+1); // (Lua indices start at 1)
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
         }
         else if ( forced_break && next_line_start_offset == m_length ) {
             lua_pushstring(m_L, "hard_newline_at_eot");
             lua_pushboolean(m_L, true);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
         }
     }
 
@@ -1431,7 +1431,7 @@ public:
         int nb_can_extend_fallback = 0;
         bool has_tabs = false;
 
-        lua_createtable(m_L, nb_glyphs, 0 ); // array of glyphs, pre-sized
+        lua_createtable(m_L, nb_glyphs, 0); // array of glyphs, pre-sized
         for(int i = 0; i < nb_glyphs; i++) {
             xtext_shapeinfo_t * s = &s_shape_result[i];
 
@@ -1441,62 +1441,62 @@ public:
             if (s->can_extend_fallback)
                 nb_can_extend_fallback++;
 
-            lua_newtable(m_L); // key/value table of info about a single glyph
+            lua_createtable(m_L, 0, 11); // key/value table of info about a single glyph, at least 11 fields
 
             lua_pushstring(m_L, "font_num");
             lua_pushinteger(m_L, s->font_num);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "glyph");
             lua_pushinteger(m_L, s->glyph);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "text_index");
             lua_pushinteger(m_L, s->text_index + 1); // (Lua indices start at 1)
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "x_advance");
             lua_pushinteger(m_L, s->x_advance);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "x_offset");
             lua_pushinteger(m_L, s->x_offset);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "y_offset");
             lua_pushinteger(m_L, s->y_offset);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "is_rtl");
             lua_pushboolean(m_L, s->is_rtl);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             if ( m_has_bidi ) {
                 lua_pushstring(m_L, "bidi_level");
                 lua_pushinteger(m_L, m_bidi_levels[s->text_index]);
-                lua_settable(m_L, -3);
+                lua_rawset(m_L, -3);
             }
 
             lua_pushstring(m_L, "is_cluster_start");
             lua_pushboolean(m_L, s->is_cluster_start);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "cluster_len");
             lua_pushinteger(m_L, s->cluster_len);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "can_extend");
             lua_pushboolean(m_L, s->can_extend);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             lua_pushstring(m_L, "can_extend_fallback");
             lua_pushboolean(m_L, s->can_extend_fallback);
-            lua_settable(m_L, -3);
+            lua_rawset(m_L, -3);
 
             if ( s->is_tab ) {
                 lua_pushstring(m_L, "is_tab");
                 lua_pushboolean(m_L, true);
-                lua_settable(m_L, -3);
+                lua_rawset(m_L, -3);
                 has_tabs = true;
             }
 

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -1504,19 +1504,28 @@ public:
         }
 
         // Add some global line metrics as keys/values
+        lua_pushstring(m_L, "width");
         lua_pushinteger(m_L, total_advance);
-        lua_setfield(m_L, -2, "width");
+        lua_rawset(m_L, -3);
+
+        lua_pushstring(m_L, "nb_can_extend");
         lua_pushinteger(m_L, nb_can_extend);
-        lua_setfield(m_L, -2, "nb_can_extend");
+        lua_rawset(m_L, -3);
+
+        lua_pushstring(m_L, "nb_can_extend_fallback");
         lua_pushinteger(m_L, nb_can_extend_fallback);
-        lua_setfield(m_L, -2, "nb_can_extend_fallback");
+        lua_rawset(m_L, -3);
+
         if (m_charinfo[start].flags & CHAR_PARA_IS_RTL) {
+            lua_pushstring(m_L, "para_is_rtl");
             lua_pushboolean(m_L, true);
-            lua_setfield(m_L, -2, "para_is_rtl");
+            lua_rawset(m_L, -3);
         }
+
         if ( has_tabs ) {
+            lua_pushstring(m_L, "has_tabs");
             lua_pushboolean(m_L, true);
-            lua_setfield(m_L, -2, "has_tabs");
+            lua_rawset(m_L, -3);
         }
 
         // Note: instead of returning an array table, we could allocate

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -1431,7 +1431,7 @@ public:
         int nb_can_extend_fallback = 0;
         bool has_tabs = false;
 
-        lua_createtable(m_L, nb_glyphs, 0); // array of glyphs, pre-sized
+        lua_createtable(m_L, nb_glyphs, 3); // array of glyphs, pre-sized
         for(int i = 0; i < nb_glyphs; i++) {
             xtext_shapeinfo_t * s = &s_shape_result[i];
 


### PR DESCRIPTION
Mainly pre-alloc when we can know/estimate the amount of elements, unify usage of *raw* setters for metatable-less tables, and stricter typing (e.g., don't cast integers to double by limiting usage of `pushnumber` to actual floats).

Also added some comments for the twistiest bits of logic (djvu, lookin' at ya').

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1350)
<!-- Reviewable:end -->
