### PR TITLE
Android: Drain the CMD & USER pipes in a single waitForEvent iteration

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -183,6 +183,7 @@ function input.waitForEvent(sec, usec)
                 commandHandler(cmd, 1)
                 android.glue.android_app_post_exec_cmd(android.app, cmd)
 
+                -- Should return -1 (EAGAIN) when we've drained the pipe
                 cmd = android.glue.android_app_read_cmd(android.app)
             end
         elseif poll_state == C.LOOPER_ID_INPUT then
@@ -202,6 +203,7 @@ function input.waitForEvent(sec, usec)
             end
         elseif poll_state == C.LOOPER_ID_USER then
             local message = ffi.new("unsigned char [4]")
+            -- Similarly, read will return -1 (EGAIN) when we've drained the pipe
             while C.read(fd[0], message, 4) == 4 do
                 if message[0] == C.AEVENT_POWER_CONNECTED then
                     commandHandler(C.AEVENT_POWER_CONNECTED, 0)

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -202,7 +202,7 @@ function input.waitForEvent(sec, usec)
             end
         elseif poll_state == C.LOOPER_ID_USER then
             local message = ffi.new("unsigned char [4]")
-            while C.read(fd[0], message, 4) == 4 then
+            while C.read(fd[0], message, 4) == 4 do
                 if message[0] == C.AEVENT_POWER_CONNECTED then
                     commandHandler(C.AEVENT_POWER_CONNECTED, 0)
                 elseif message[0] == C.AEVENT_POWER_DISCONNECTED then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -202,11 +202,12 @@ function input.waitForEvent(sec, usec)
             end
         elseif poll_state == C.LOOPER_ID_USER then
             local message = ffi.new("unsigned char [4]")
-            C.read(fd[0], message, 4)
-            if message[0] == C.AEVENT_POWER_CONNECTED then
-                commandHandler(C.AEVENT_POWER_CONNECTED, 0)
-            elseif message[0] == C.AEVENT_POWER_DISCONNECTED then
-                commandHandler(C.AEVENT_POWER_DISCONNECTED, 0)
+            while C.read(fd[0], message, 4) == 4 then
+                if message[0] == C.AEVENT_POWER_CONNECTED then
+                    commandHandler(C.AEVENT_POWER_CONNECTED, 0)
+                elseif message[0] == C.AEVENT_POWER_DISCONNECTED then
+                    commandHandler(C.AEVENT_POWER_DISCONNECTED, 0)
+                end
             end
         end
         if android.app.destroyRequested ~= 0 then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -203,7 +203,7 @@ function input.waitForEvent(sec, usec)
             end
         elseif poll_state == C.LOOPER_ID_USER then
             local message = ffi.new("unsigned char [4]")
-            -- Similarly, read will return -1 (EGAIN) when we've drained the pipe
+            -- Similarly, read will return -1 (EAGAIN) when we've drained the pipe
             while C.read(fd[0], message, 4) == 4 do
                 if message[0] == C.AEVENT_POWER_CONNECTED then
                     commandHandler(C.AEVENT_POWER_CONNECTED, 0)

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -178,9 +178,13 @@ function input.waitForEvent(sec, usec)
         if poll_state == C.LOOPER_ID_MAIN then
             -- e.g., source[0].process(android.app, source[0]) where process would point to process_cmd
             local cmd = android.glue.android_app_read_cmd(android.app)
-            android.glue.android_app_pre_exec_cmd(android.app, cmd)
-            commandHandler(cmd, 1)
-            android.glue.android_app_post_exec_cmd(android.app, cmd)
+            while cmd ~= -1 do
+                android.glue.android_app_pre_exec_cmd(android.app, cmd)
+                commandHandler(cmd, 1)
+                android.glue.android_app_post_exec_cmd(android.app, cmd)
+
+                cmd = android.glue.android_app_read_cmd(android.app)
+            end
         elseif poll_state == C.LOOPER_ID_INPUT then
             -- e.g., source[0].process(android.app, source[0]) where process would point to process_input
             local event = ffi.new("AInputEvent*[1]")


### PR DESCRIPTION
They're now marked NONBLOCK, so we can safely do read loops until we hit EAGAIN ;).

Requires https://github.com/koreader/android-luajit-launcher/pull/299

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1356)
<!-- Reviewable:end -->
