### PR TITLE
POSIX: Fix portability issues with clock_gettime

### DIFF
--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -251,16 +251,6 @@ elseif ffi.os == "BSD" then
     -- UPTIME == Linux's MONOTONIC, BOOTTIME == Linux's BOOTTIME
     -- (Meaning MONOTONIC starts ticking at an *undefined* positive value).
 
-    ffi.cdef[[
-static const int CLOCK_REALTIME = 0;
-static const int CLOCK_REALTIME_COARSE = -1;
-static const int CLOCK_MONOTONIC = 3;
-static const int CLOCK_MONOTONIC_COARSE = -1;
-static const int CLOCK_MONOTONIC_RAW = -1;
-static const int CLOCK_BOOTTIME = 6;
-static const int CLOCK_TAI = -1;
-]]
-
     -- NetBSD
     -- c.f., https://anonhg.netbsd.org/src/file/tip/sys/sys/time.h
     --[[
@@ -293,4 +283,43 @@ static const int CLOCK_TAI = -1;
     -- Portability notes:
     -- UPTIME == Linux's MONOTONIC
     -- (I assume that, like on OpenBSD, this means MONOTONIC starts ticking at an *undefined* positive value).
+
+    -- So, here comes probey-time!
+    local C = ffi.C
+    local probe_ts = ffi.new("struct timespec")
+    if C.clock_getres(15, probe_ts) == 0 then
+        -- FreeBSD
+        ffi.cdef[[
+static const int CLOCK_REALTIME = 0;
+static const int CLOCK_REALTIME_COARSE = 10;
+static const int CLOCK_MONOTONIC = 4;
+static const int CLOCK_MONOTONIC_COARSE = 12;
+static const int CLOCK_MONOTONIC_RAW = 11;
+static const int CLOCK_BOOTTIME = -1;
+static const int CLOCK_TAI = -1;
+]]
+    elseif C.clock_getres(0x40000000, probe_ts) == 0 then
+        -- NetBSD
+        ffi.cdef[[
+static const int CLOCK_REALTIME = 0;
+static const int CLOCK_REALTIME_COARSE = -1;
+static const int CLOCK_MONOTONIC = 3;
+static const int CLOCK_MONOTONIC_COARSE = -1;
+static const int CLOCK_MONOTONIC_RAW = -1;
+static const int CLOCK_BOOTTIME = -1;
+static const int CLOCK_TAI = -1;
+]]
+    else
+        -- OpenBSD
+        ffi.cdef[[
+static const int CLOCK_REALTIME = 0;
+static const int CLOCK_REALTIME_COARSE = -1;
+static const int CLOCK_MONOTONIC = 3;
+static const int CLOCK_MONOTONIC_COARSE = -1;
+static const int CLOCK_MONOTONIC_RAW = -1;
+static const int CLOCK_BOOTTIME = 6;
+static const int CLOCK_TAI = -1;
+]]
+    end
+    probe_ts = nil --luacheck: ignore
 end

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -224,7 +224,7 @@ elseif ffi.os == "OSX" then
     -- Portability notes:
     -- Unlike on Linux, MONO ticks during sleep (which is technically the POSIX-compliant behavior).
     -- CLOCK_UPTIME_* doesn't.
-    -- (e.g., macOS UPTIME == Linux's MONO, and macOS's MONO == Linux's BOOTTIME)
+    -- (e.g., macOS UPTIME == Linux MONO, and macOS MONO == Linux BOOTTIME)
 
     -- NOTE: Requires macOS 10.12
     ffi.cdef[[
@@ -248,7 +248,7 @@ elseif ffi.os == "BSD" then
     #define CLOCK_BOOTTIME           6
     --]]
     -- Portability notes:
-    -- UPTIME == Linux's MONOTONIC, BOOTTIME == Linux's BOOTTIME
+    -- OpenBSD UPTIME == Linux MONOTONIC, OpenBSD BOOTTIME == Linux BOOTTIME
     -- (Meaning MONOTONIC starts ticking at an *undefined* positive value).
 
     -- NetBSD
@@ -281,7 +281,7 @@ elseif ffi.os == "BSD" then
     #define CLOCK_PROCESS_CPUTIME_ID 15
     --]]
     -- Portability notes:
-    -- UPTIME == Linux's MONOTONIC
+    -- FreeBSD UPTIME == Linux MONOTONIC
     -- (I assume that, like on OpenBSD, this means MONOTONIC starts ticking at an *undefined* positive value).
 
     -- So, here comes probey-time!

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -223,7 +223,7 @@ elseif ffi.os == "OSX" then
     --]]
     -- Portability notes:
     -- Unlike on Linux, MONO ticks during sleep (which is technically the POSIX-compliant behavior).
-    -- CLOCK_UPTIME_RAW & CLOCK_UPTIME_RAW_APPROX (9) don't.
+    -- CLOCK_UPTIME_* doesn't.
     -- (e.g., macOS UPTIME == Linux's MONO, and macOS's MONO == Linux's BOOTTIME)
 
     -- NOTE: Requires macOS 10.12

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -322,4 +322,25 @@ static const int CLOCK_TAI = -1;
 ]]
     end
     probe_ts = nil --luacheck: ignore
+else
+    -- Assume minimal Linux compat on other OSes.
+
+    -- This holds true for Windows via mingw,
+    -- c.f., https://github.com/mirror/mingw-w64/blob/master/mingw-w64-libraries/winpthreads/include/pthread_time.h
+    --[[
+    #define CLOCK_REALTIME           0
+    #define CLOCK_MONOTONIC          1
+    #define CLOCK_PROCESS_CPUTIME_ID 2
+    #define CLOCK_THREAD_CPUTIME_ID  3
+    --]]
+
+    ffi.cdef[[
+static const int CLOCK_REALTIME = 0;
+static const int CLOCK_REALTIME_COARSE = -1;
+static const int CLOCK_MONOTONIC = 1;
+static const int CLOCK_MONOTONIC_COARSE = -1;
+static const int CLOCK_MONOTONIC_RAW = -1;
+static const int CLOCK_BOOTTIME = -1;
+static const int CLOCK_TAI = -1;
+]]
 end

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -269,10 +269,10 @@ elseif ffi.os == "BSD" then
     #define CLOCK_VIRTUAL            1
     #define CLOCK_PROF               2
     #define CLOCK_MONOTONIC          4
-    #define CLOCK_UPTIME             5 /* FreeBSD-specific. */
-    #define CLOCK_UPTIME_PRECISE     7 /* FreeBSD-specific. */
-    #define CLOCK_UPTIME_FAST        8 /* FreeBSD-specific. */
-    #define CLOCK_REALTIME_PRECISE   9 /* FreeBSD-specific. */
+    #define CLOCK_UPTIME             5  /* FreeBSD-specific. */
+    #define CLOCK_UPTIME_PRECISE     7  /* FreeBSD-specific. */
+    #define CLOCK_UPTIME_FAST        8  /* FreeBSD-specific. */
+    #define CLOCK_REALTIME_PRECISE   9  /* FreeBSD-specific. */
     #define CLOCK_REALTIME_FAST      10 /* FreeBSD-specific. */
     #define CLOCK_MONOTONIC_PRECISE  11 /* FreeBSD-specific. */
     #define CLOCK_MONOTONIC_FAST     12 /* FreeBSD-specific. */

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -207,9 +207,8 @@ static const int CLOCK_MONOTONIC_RAW = 4;
 static const int CLOCK_BOOTTIME = 7;
 static const int CLOCK_TAI = 11;
 ]]
-elseif ffi.os == "OSX" or ffi.os == "BSD" then
+elseif ffi.os == "OSX" then
     -- NOTE: Requires macOS 10.12
-    -- NOTE: Unverified on other BSDs
     ffi.cdef[[
 static const int CLOCK_REALTIME = 0;
 static const int CLOCK_REALTIME_COARSE = -1;
@@ -224,4 +223,18 @@ static const int CLOCK_TAI = -1;
     -- Unlike on Linux, MONO ticks during sleep.
     -- CLOCK_UPTIME_RAW (8) & CLOCK_UPTIME_RAW_APPROX (9) don't.
     -- (e.g., macOS UPTIME == Linux's MONO, and macOS's MONO == Linux's BOOTTIME)
+elseif ffi.os == "BSD" then
+    -- OpenBSD: https://github.com/openbsd/src/blob/master/sys/sys/_time.h
+    ffi.cdef[[
+static const int CLOCK_REALTIME = 0;
+static const int CLOCK_REALTIME_COARSE = -1;
+static const int CLOCK_MONOTONIC = 3;
+static const int CLOCK_MONOTONIC_COARSE = -1;
+static const int CLOCK_MONOTONIC_RAW = -1;
+static const int CLOCK_BOOTTIME = 6;
+static const int CLOCK_TAI = -1;
+]]
+    -- Various portability notes:
+    -- CLOCK_UPTIME (5)
+    -- UPTIME == Linux's MONOTONIC
 end


### PR DESCRIPTION
The constants are hilariously not portable. So, fix 'em on macOS & most common BSD flavors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1360)
<!-- Reviewable:end -->
