### PR TITLE
Update to libjpeg-turbo 2.1.0

### DIFF
--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -46,7 +46,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/libjpeg-turbo/libjpeg-turbo.git
-    2.0.6
+    2.1.0
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Relevant to our interests: fancier NEON support. Would be even fancier if built w/ Clang, because GCC's NEON intrinsics support is generally subpar compared to Clang, and that's a problem here, so the build-system disables 'em.

(Namely, the inverse DCT which we could have used in our overwhelmingly-decompression-centered workloads)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1361)
<!-- Reviewable:end -->
