### PR TITLE
FrameBuffer: Rename getSize to allow overloading a getSize that actually

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -132,7 +132,7 @@ function fb:init()
     self.blitbuffer_rotation_mode = self.bb:getRotation()
     -- asking the framebuffer for orientation is error prone,
     -- so we do this simple heuristic (for now)
-    self.screen_size = self:getSize()
+    self.screen_size = self:getRawSize()
     if self.screen_size.w > self.screen_size.h and self.is_always_portrait then
         self.screen_size.w, self.screen_size.h = self.screen_size.h, self.screen_size.w
         -- some framebuffers need to be rotated counter-clockwise (they start in landscape mode)
@@ -307,7 +307,7 @@ function fb:calculateRealCoordinates(x, y, w, h)
     return x, y, w, h
 end
 
-function fb:getSize()
+function fb:getRawSize()
     return {w = self.bb:getWidth(), h = self.bb:getHeight()}
 end
 

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -148,7 +148,7 @@ function framebuffer:reinit()
         self.bb:invert()
     end
 
-    self.screen_size = self:getSize()
+    self.screen_size = self:getRawSize()
     self.bb:fill(BB.COLOR_WHITE)
 end
 


### PR DESCRIPTION
returns a Geom in front...

(For https://github.com/koreader/koreader/pull/7664)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1369)
<!-- Reviewable:end -->
