### PR TITLE
bump crengine: support for user hyphenation dictionary

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -3495,6 +3495,20 @@ static int getImageDataFromPosition(lua_State *L) {
     return 0;
 }
 
+static int setUserHyphenationDict(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *filename = luaL_checkstring(L, 2);
+    UserHyphenDict::init(filename);
+    return 0;
+}
+
+static int getHyphenation(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *word = luaL_checkstring(L, 2);
+    lString32 hyphenation = UserHyphenDict::getHyphenation(word);
+    lua_pushstring(L, UnicodeToLocal(hyphenation).c_str());
+    return 1;
+}
 
 static const struct luaL_Reg cre_func[] = {
     {"initCache", initCache},
@@ -3627,6 +3641,8 @@ static const struct luaL_Reg credocument_meth[] = {
     {"saveDefaults", saveDefaults},
     {"close", closeDocument},
     {"__gc", closeDocument},
+    {"setUserHyphenationDict", setUserHyphenationDict},
+    {"getHyphenation", getHyphenation},
     {NULL, NULL}
 };
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -3495,14 +3495,6 @@ static int getImageDataFromPosition(lua_State *L) {
     return 0;
 }
 
-static int setUserHyphenationDict(lua_State *L) {
-    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
-    const char *filename = luaL_checkstring(L, 2);
-    int no_sloppy_load = luaL_checkint(L, 3);
-    UserHyphenDict::init(filename, no_sloppy_load !=0);
-    return 0;
-}
-
 static int getHyphenationForWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
@@ -3511,7 +3503,7 @@ static int getHyphenationForWord(lua_State *L) {
     return 1;
 }
 
-static int getLower(lua_State *L) {
+static int getLowercasedWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
     lString32 word_lower = UserHyphenDict::getLower(word);
@@ -3659,9 +3651,8 @@ static const struct luaL_Reg credocument_meth[] = {
     {"saveDefaults", saveDefaults},
     {"close", closeDocument},
     {"__gc", closeDocument},
-    {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenationForWord", getHyphenationForWord},
-    {"getLower", getLower},
+    {"getLowercasedWord", getLowercasedWord},
     {"formatHyphenationSuggestion", formatHyphenationSuggestion},
     {NULL, NULL}
 };

--- a/cre.cpp
+++ b/cre.cpp
@@ -3500,7 +3500,7 @@ static int setUserHyphenationDict(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *filename = luaL_checkstring(L, 2);
     bool reload = lua_toboolean(L, 3);
-    lua_pushinteger(L, UserHyphenDict::init(filename, reload));
+    lua_pushinteger(L, UserHyphDict::init(filename, reload));
     return 1;
 }
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -3514,17 +3514,8 @@ static int getHyphenationForWord(lua_State *L) {
 static int getLowercasedWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
-    lString32 word_lower = UserHyphenDict::getLower(word);
-    lua_pushstring(L, UnicodeToLocal(word_lower).c_str());
-    return 1;
-}
-
-static int formatHyphenationSuggestion(lua_State *L) {
-    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
-    const char *hyphenation = luaL_checkstring(L, 2);
-    const char *word = luaL_checkstring(L, 3);
-    lString32 suggestion = UserHyphenDict::formatHyphenation(hyphenation, word);
-    lua_pushstring(L, UnicodeToLocal(suggestion).c_str());
+    lString32 word_str(word);
+    lua_pushstring(L, UnicodeToLocal(word_str.lowercase()).c_str());
     return 1;
 }
 
@@ -3655,14 +3646,13 @@ static const struct luaL_Reg credocument_meth[] = {
     {"getPageMapXPointerPageLabel", getPageMapXPointerPageLabel},
     {"getPageMapVisiblePageLabels", getPageMapVisiblePageLabels},
     {"hasNonLinearFlows", hasNonLinearFlows},
+    {"setUserHyphenationDict", setUserHyphenationDict},
+    {"getHyphenationForWord", getHyphenationForWord},
+    {"getLowercasedWord", getLowercasedWord},
     {"readDefaults", readDefaults},
     {"saveDefaults", saveDefaults},
     {"close", closeDocument},
     {"__gc", closeDocument},
-    {"setUserHyphenationDict", setUserHyphenationDict},
-    {"getHyphenationForWord", getHyphenationForWord},
-    {"getLowercasedWord", getLowercasedWord},
-    {"formatHyphenationSuggestion", formatHyphenationSuggestion},
     {NULL, NULL}
 };
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -30,7 +30,6 @@ extern "C" {
 #include "crengine.h"
 #include "lvdocview.h"
 #include "lvimg.h"
-#include "hyphman.h"
 
 static void replaceColor( char * str, lUInt32 color ) {
 	// in line like "0 c #80000000",

--- a/cre.cpp
+++ b/cre.cpp
@@ -3498,8 +3498,8 @@ static int getImageDataFromPosition(lua_State *L) {
 static int setUserHyphenationDict(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *filename = luaL_checkstring(L, 2);
-    int no_sloppy_load = luaL_checkint(L, 3);
-    UserHyphenDict::init(filename, no_sloppy_load !=0);
+    bool reload = lua_toboolean(L, 3);
+    UserHyphenDict::init(filename, reload);
     return 0;
 }
 
@@ -3511,7 +3511,7 @@ static int getHyphenationForWord(lua_State *L) {
     return 1;
 }
 
-static int getLower(lua_State *L) {
+static int getLowercasedWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
     lString32 word_lower = UserHyphenDict::getLower(word);
@@ -3661,7 +3661,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"__gc", closeDocument},
     {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenationForWord", getHyphenationForWord},
-    {"getLower", getLower},
+    {"getLowercasedWord", getLowercasedWord},
     {"formatHyphenationSuggestion", formatHyphenationSuggestion},
     {NULL, NULL}
 };

--- a/cre.cpp
+++ b/cre.cpp
@@ -3498,11 +3498,12 @@ static int getImageDataFromPosition(lua_State *L) {
 static int setUserHyphenationDict(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *filename = luaL_checkstring(L, 2);
-    UserHyphenDict::init(filename);
+    int no_sloppy_load = luaL_checkint(L, 3);
+    UserHyphenDict::init(filename, no_sloppy_load !=0);
     return 0;
 }
 
-static int getHyphenation(lua_State *L) {
+static int getHyphenationForWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
     lString32 hyphenation = UserHyphenDict::getHyphenation(word);
@@ -3518,7 +3519,7 @@ static int getLower(lua_State *L) {
     return 1;
 }
 
-static int formatHyphenation(lua_State *L) {
+static int formatHyphenationSuggestion(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *hyphenation = luaL_checkstring(L, 2);
     const char *word = luaL_checkstring(L, 3);
@@ -3659,9 +3660,9 @@ static const struct luaL_Reg credocument_meth[] = {
     {"close", closeDocument},
     {"__gc", closeDocument},
     {"setUserHyphenationDict", setUserHyphenationDict},
-    {"getHyphenation", getHyphenation},
+    {"getHyphenationForWord", getHyphenationForWord},
     {"getLower", getLower},
-    {"formatHyphenation", formatHyphenation},
+    {"formatHyphenationSuggestion", formatHyphenationSuggestion},
     {NULL, NULL}
 };
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -3510,6 +3510,14 @@ static int getHyphenation(lua_State *L) {
     return 1;
 }
 
+static int getLower(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *word = luaL_checkstring(L, 2);
+    lString32 word_lower = UserHyphenDict::getLower(word);
+    lua_pushstring(L, UnicodeToLocal(word_lower).c_str());
+    return 1;
+}
+
 static int formatHyphenation(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *hyphenation = luaL_checkstring(L, 2);
@@ -3652,6 +3660,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"__gc", closeDocument},
     {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenation", getHyphenation},
+    {"getLower", getLower},
     {"formatHyphenation", formatHyphenation},
     {NULL, NULL}
 };

--- a/cre.cpp
+++ b/cre.cpp
@@ -30,6 +30,7 @@ extern "C" {
 #include "crengine.h"
 #include "lvdocview.h"
 #include "lvimg.h"
+#include "hyphman.h"
 
 static void replaceColor( char * str, lUInt32 color ) {
 	// in line like "0 c #80000000",

--- a/cre.cpp
+++ b/cre.cpp
@@ -3507,7 +3507,7 @@ static int setUserHyphenationDict(lua_State *L) {
 static int getHyphenationForWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
-    lString32 hyphenation = UserHyphenDict::getHyphenation(word);
+    lString32 hyphenation = UserHyphDict::getHyphenation(word);
     lua_pushstring(L, UnicodeToLocal(hyphenation).c_str());
     return 1;
 }

--- a/cre.cpp
+++ b/cre.cpp
@@ -3510,6 +3510,15 @@ static int getHyphenation(lua_State *L) {
     return 1;
 }
 
+static int formatHyphenation(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *hyphenation = luaL_checkstring(L, 2);
+    const char *word = luaL_checkstring(L, 3);
+    lString32 suggestion = UserHyphenDict::formatHyphenation(hyphenation, word);
+    lua_pushstring(L, UnicodeToLocal(suggestion).c_str());
+    return 1;
+}
+
 static const struct luaL_Reg cre_func[] = {
     {"initCache", initCache},
     {"initHyphDict", initHyphDict},
@@ -3643,6 +3652,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"__gc", closeDocument},
     {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenation", getHyphenation},
+    {"formatHyphenation", formatHyphenation},
     {NULL, NULL}
 };
 

--- a/cre.cpp
+++ b/cre.cpp
@@ -3495,6 +3495,14 @@ static int getImageDataFromPosition(lua_State *L) {
     return 0;
 }
 
+static int setUserHyphenationDict(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *filename = luaL_checkstring(L, 2);
+    int no_sloppy_load = luaL_checkint(L, 3);
+    UserHyphenDict::init(filename, no_sloppy_load !=0);
+    return 0;
+}
+
 static int getHyphenationForWord(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
@@ -3503,7 +3511,7 @@ static int getHyphenationForWord(lua_State *L) {
     return 1;
 }
 
-static int getLowercasedWord(lua_State *L) {
+static int getLower(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *word = luaL_checkstring(L, 2);
     lString32 word_lower = UserHyphenDict::getLower(word);
@@ -3651,8 +3659,9 @@ static const struct luaL_Reg credocument_meth[] = {
     {"saveDefaults", saveDefaults},
     {"close", closeDocument},
     {"__gc", closeDocument},
+    {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenationForWord", getHyphenationForWord},
-    {"getLowercasedWord", getLowercasedWord},
+    {"getLower", getLower},
     {"formatHyphenationSuggestion", formatHyphenationSuggestion},
     {NULL, NULL}
 };

--- a/cre.cpp
+++ b/cre.cpp
@@ -3499,8 +3499,8 @@ static int setUserHyphenationDict(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *filename = luaL_checkstring(L, 2);
     bool reload = lua_toboolean(L, 3);
-    UserHyphenDict::init(filename, reload);
-    return 0;
+    lua_pushinteger(L, UserHyphenDict::init(filename, reload));
+    return 1;
 }
 
 static int getHyphenationForWord(lua_State *L) {


### PR DESCRIPTION
Apply this together with https://github.com/koreader/crengine/pull/439.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1374)
<!-- Reviewable:end -->
