### PR TITLE
mupdf.lua: update frontend pboxes with MuPDF adjusted ones

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -693,6 +693,12 @@ function page_mt.__index:addMarkupAnnotation(points, n, type)
 
     ok = W.mupdf_pdf_set_markup_appearance(context(), doc, annot, color, alpha, line_thickness, line_height)
     if ok == nil then merror("could not set markup appearance") end
+
+    -- Fetch back MuPDF's stored coordinates of all quadpoints, as they may have been modified/rounded
+    -- (we need the exact ones that were saved if we want to be able to find them for deletion/update)
+    for i = 0, n-1 do
+        W.mupdf_pdf_annot_quad_point(context(), annot, i, points+i*8)
+    end
 end
 
 function page_mt.__index:deleteMarkupAnnotation(annot)
@@ -713,8 +719,12 @@ function page_mt.__index:getMarkupAnnotation(points, n)
             for i = 0, n-1 do
                 W.mupdf_pdf_annot_quad_point(context(), annot, i, quadpoint)
                 for k = 0, 7 do
-                    if points[i*8 + k] ~= quadpoint[k] then match = false end
+                    if points[i*8 + k] ~= quadpoint[k] then
+                        match = false
+                        break
+                    end
                 end
+                if not match then break end
             end
             if match then return annot end
         end


### PR DESCRIPTION
MuPDF may slightly update/round annotation boxes coordinates, and we need frontend to have them consistent for it to be able to delete/update annotations.
See https://github.com/koreader/koreader/issues/7928#issuecomment-882056494

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1388)
<!-- Reviewable:end -->
