### PR TITLE
Add KEY_BATTERY constant

### DIFF
--- a/ffi-cdecl/linux_input_decl.c
+++ b/ffi-cdecl/linux_input_decl.c
@@ -26,6 +26,8 @@ cdecl_const(SYN_CONFIG)
 cdecl_const(SYN_MT_REPORT)
 cdecl_const(SYN_DROPPED)
 
+cdecl_const(KEY_BATTERY)
+
 cdecl_const(BTN_TOOL_PEN)
 cdecl_const(BTN_TOOL_FINGER)
 cdecl_const(BTN_TOOL_RUBBER)

--- a/ffi/linux_input_h.lua
+++ b/ffi/linux_input_h.lua
@@ -20,6 +20,7 @@ static const int SYN_REPORT = 0;
 static const int SYN_CONFIG = 1;
 static const int SYN_MT_REPORT = 2;
 static const int SYN_DROPPED = 3;
+static const int KEY_BATTERY = 236;
 static const int BTN_TOOL_PEN = 320;
 static const int BTN_TOOL_FINGER = 325;
 static const int BTN_TOOL_RUBBER = 321;


### PR DESCRIPTION
Supposedly useful to grok the Elipsa's pen battery status, but I haven't actually seen one in the wild yet ;p.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1393)
<!-- Reviewable:end -->
