### PR TITLE
SDL: differenciate between ChromeOS/Linux.

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -47,6 +47,8 @@ local function SDL_Runs_On_ChromeOS()
     return os.execute("which sommelier >/dev/null 2>&1") == 0
 end
 
+local is_chromeos = SDL_Runs_On_ChromeOS()
+
 local function SDL_Linked_Version_AtLeast(x, y, z)
     return SDL_VersionNum(sdl_linked_ver[0].major, sdl_linked_ver[0].minor, sdl_linked_ver[0].patch) >= SDL_VersionNum(x, y, z)
 end
@@ -467,7 +469,7 @@ end
 
 function S.getPlatform()
     local detected = ffi.string(SDL.SDL_GetPlatform())
-    if detected == "Linux" and SDL_Runs_On_ChromeOS() then
+    if detected == "Linux" and is_chromeos then
         return "Chrome OS"
     else
         return detected
@@ -486,7 +488,7 @@ end
 
 function S.getPowerInfo()
     -- crostini/SDL bug: fails to retrieve battery charge.
-    if SDL_Runs_On_ChromeOS() then
+    if is_chromeos then
         return false, false, true, 0
     end
 


### PR DESCRIPTION
Sysfs is almost empty on Linux containers under ChromeOS. SDL relies of that kernel info to retrieve the battery status.

Since we need to figure out if we're running inside a ChromeOS container (aka Crostini) I took the liberty of renaming device.model from "Linux" to "Chrome OS" too, but that shouldn't be really needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1394)
<!-- Reviewable:end -->
