### PR TITLE
BMP in 8bit grayscale

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2051,12 +2051,12 @@ function BB_mt.__index:getBufferData()
     return bbdump, source_ptr, w, stride, h
 end
 
-function BB_mt.__index:writeBMP(filename)
+function BB_mt.__index:writeBMP(filename, grayscale)
     if not Jpeg then Jpeg = require("ffi/jpeg") end
 
     local bbdump, source_ptr, w, stride, h = self:getBufferData()
 
-    Jpeg.writeBMP(filename, source_ptr, w, stride, h)
+    Jpeg.writeBMP(filename, source_ptr, w, stride, h, grayscale)
 
     if bbdump then
         bbdump:free()
@@ -2075,13 +2075,13 @@ function BB_mt.__index:writeJPG(filename, quality)
     end
 end
 
-function BB_mt.__index:writeToFile(filename, format, quality)
+function BB_mt.__index:writeToFile(filename, format, quality, grayscale)
     format = format or "jpg" -- set default format
     format = format:lower()
     if format == "png" then
         return pcall(self.writePNG, self, filename)
     elseif format == "bmp" then
-        return pcall(self.writeBMP, self, filename)
+        return pcall(self.writeBMP, self, filename, grayscale)
     else -- default all other extensions to jpg
         return pcall(self.writeJPG, self, filename, quality)
     end

--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -98,7 +98,7 @@ end
 -- convert rgb to grayscale
 -- gray = 0.299 R + 0.587 G + 0.114 B
 -- https://www.dynamsoft.com/blog/insights/image-processing/image-processing-101-color-space-conversion/
-function Jpeg.convertToGray(source_ptr, w, stride, h)
+function Jpeg.convertToGray(source_ptr, stride, h)
     for y = 0, h - 1 do
         local offs = y * stride
         local offs_8bit = offs
@@ -119,7 +119,7 @@ function Jpeg.writeBMP(filename, source_ptr, w, stride, h, grayscale)
     local pixel_format
     if grayscale then
         pixel_format = turbojpeg.TJPF_GRAY
-        Jpeg.convertToGray(source_ptr, w, stride, h)
+        Jpeg.convertToGray(source_ptr, stride, h)
     else
         pixel_format = turbojpeg.TJPF_RGB
     end

--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -100,10 +100,9 @@ end
 -- https://www.dynamsoft.com/blog/insights/image-processing/image-processing-101-color-space-conversion/
 function Jpeg.convertToGray(source_ptr, w, stride, h)
     for y = 0, h-1 do
-        local x_8bit = 0
         local offs = y * stride
         local offs_8bit = offs
-        for x = 0, tonumber(stride), 3 do
+        for _ = 0, tonumber(stride), 3 do
             local r = .299 * source_ptr[offs]
             offs = offs + 1
             local g = .587 * source_ptr[offs]
@@ -117,21 +116,21 @@ function Jpeg.convertToGray(source_ptr, w, stride, h)
 end
 
 function Jpeg.writeBMP(filename, source_ptr, w, stride, h, grayscale)
-    local color
+    local pixel_format
     if grayscale then
-        color = turbojpeg.TJPF_GRAY
+        pixel_format = turbojpeg.TJPF_GRAY
         Jpeg.convertToGray(source_ptr, w, stride, h)
     else
-        color = turbojpeg.TJPF_RGB
+        pixel_format = turbojpeg.TJPF_RGB
     end
 
     -- if file extension is not ".bmp" tjSaveImage uses netpbm format!
     if filename:sub(-#".bmp") == ".bmp" then
-        turbojpeg.tjSaveImage(filename, source_ptr, w, stride, h, color, 0)
+        turbojpeg.tjSaveImage(filename, source_ptr, w, stride, h, pixel_format, 0)
     else
         os.remove(filename)
         local tmp_filename = filename .. ".tmp.bmp"
-        turbojpeg.tjSaveImage(tmp_filename, source_ptr, w, stride, h, color, 0)
+        turbojpeg.tjSaveImage(tmp_filename, source_ptr, w, stride, h, pixel_format, 0)
         os.rename(tmp_filename, filename)
     end
 end

--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -96,10 +96,10 @@ function Jpeg.encodeToFile(filename, source_ptr, w, stride, h, quality, color_ty
 end
 
 -- convert rgb to grayscale
--- gray = 0.299R+0.587G+0.114B
+-- gray = 0.299 R + 0.587 G + 0.114 B
 -- https://www.dynamsoft.com/blog/insights/image-processing/image-processing-101-color-space-conversion/
 function Jpeg.convertToGray(source_ptr, w, stride, h)
-    for y = 0, h-1 do
+    for y = 0, h - 1 do
         local offs = y * stride
         local offs_8bit = offs
         for _ = 0, tonumber(stride), 3 do


### PR DESCRIPTION
Allows to save a BMP in 8 bit grayscale.
See https://github.com/koreader/koreader/issues/8046

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1396)
<!-- Reviewable:end -->
