### PR TITLE
win32: change CHOST to x86_64-w64-mingw32

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -142,7 +142,7 @@ else ifeq ($(TARGET), android)
 	# Needed for OpenSSL, c.f., NOTES.ANDROID
 	export ANDROID_NDK_HOME=$(ANDROID_TOOLCHAIN)
 else ifeq ($(TARGET), win32)
-	CHOST?=i686-w64-mingw32
+	CHOST?=x86_64-w64-mingw32
 	export WIN32=1
 	export SDL=1
 else ifeq ($(TARGET), pocketbook)


### PR DESCRIPTION
It's probably more relevant/easier that way in 2021?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1402)
<!-- Reviewable:end -->
