### PR TITLE
bump crengine: support for 'box-sizing', and various other fixes

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1724,6 +1724,7 @@ static int setEmbeddedFonts(lua_State *L) {
 	return 0;
 }
 
+/*
 static int cursorRight(lua_State *L) {
 	//CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 
@@ -1749,6 +1750,7 @@ static int cursorRight(lua_State *L) {
 
 	return 0;
 }
+*/
 
 static int getLinkFromPosition(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
@@ -3272,13 +3274,14 @@ static int drawCurrentPage(lua_State *L) {
 	return 2;
 }
 
+/*
 static int drawCoverPage(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	BlitBuffer *bb = (BlitBuffer*) lua_topointer(L, 2);
 
 	int w = bb->w,
 		h = bb->h;
-	/* Set DrawBuf to 8bpp */
+	// Set DrawBuf to 8bpp
 	LVGrayDrawBuf drawBuf(w, h, 8, bb->data);
 
 	LVImageSourceRef cover = doc->text_view->getCoverPageImage();
@@ -3286,11 +3289,12 @@ static int drawCoverPage(lua_State *L) {
 		printf("cover size:%d,%d\n", cover->GetWidth(), cover->GetHeight());
 	else
 		printf("cover page is null.\n");
-	LVDrawBookCover(drawBuf, cover, lString8("Droid Sans Mono"),
+	LVDrawBookCover(drawBuf, cover, true, lString8("Droid Sans Mono"),
 			lString32("test"), lString32("test"), lString32("test"), 0);
 
 	return 0;
 }
+*/
 
 static int getCoverPageImageData(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");


### PR DESCRIPTION
Includes among others:

- https://github.com/koreader/crengine/pull/450
   - Various CHM handling fixes, and others
- https://github.com/koreader/crengine/pull/451
- https://github.com/koreader/crengine/pull/452)
- https://github.com/koreader/crengine/pull/453
   - HTML documents: rebuild TOC from headings after load
   - Font: use metrics for underline offset and thickness
   - epub.css, html5.css: tweak ruby styling
   - CSS: fix EPUB's head>style content encoding
   - CSS: add support for 'box-sizing: content-box/border-box'
   - CSS: support for styling the `<html>` element

cre.cpp: comment out some unused functions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1406)
<!-- Reviewable:end -->
