### PR TITLE
MµPDF: Don't accumulate rounding errors when computing page dimensions

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -373,9 +373,11 @@ function page_mt.__index:getSize(draw_context)
 
     -- NOTE: fz_bound_page returns an internal representation computed @ 72dpi...
     --       It is often superbly mysterious, even for images,
-    --       so we do *NOT* want to round it right now:
-    --       we're using it to compute our scaling factor,
-    --       so we do not want to introduce rounding errors this early...
+    --       so we do *NOT* want to round it right now,
+    --       as it would introduce rounding errors much too early in the pipeline...
+    -- NOTE: ReaderZooming uses it to compute the scale factor, where accuracy matters!
+    -- NOTE: This is also used in conjunction with getUsedBBox,
+    --       which also returns precise, floating point rectangles!
     --[[
     M.fz_round_rect(bbox, bounds)
     return bbox[0].x1-bbox[0].x0, bbox[0].y1-bbox[0].y0

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -212,6 +212,7 @@ function document_mt.__index:isDocumentReflowable()
 end
 
 function document_mt.__index:layoutDocument(width, height, em)
+    print("layoutDocument", width, height, em)
     -- Reset the cache.
     self.number_of_pages = nil
 
@@ -365,14 +366,29 @@ function page_mt.__index:getSize(draw_context)
     local bbox = ffi.new("fz_irect[1]")
     local ctm = ffi.new("fz_matrix")
 
+    print("zoom:", draw_context.zoom)
+    print("rotate:", draw_context.rotate)
+
     M.fz_scale(ctm, draw_context.zoom, draw_context.zoom)
     M.fz_pre_rotate(ctm, draw_context.rotate)
 
     M.fz_bound_page(context(), self.page, bounds)
+
+    print("bounds:", bounds[0].x0, bounds[0].x1, bounds[0].y0, bounds[0].y1)
+
     M.fz_transform_rect(bounds, ctm)
+
+    print("post tr bounds:", bounds[0].x0, bounds[0].x1, bounds[0].y0, bounds[0].y1)
+
+    --[[
     M.fz_round_rect(bbox, bounds)
 
+    print("bbox:", bbox[0].x0, bbox[0].x1, bbox[0].y0, bbox[0].y1)
+
     return bbox[0].x1-bbox[0].x0, bbox[0].y1-bbox[0].y0
+    --]]
+
+    return bounds[0].x1 - bounds[0].x0, bounds[0].y1 - bounds[0].y0
 end
 
 --[[
@@ -387,6 +403,8 @@ function page_mt.__index:getUsedBBox()
     M.fz_close_device(context(), dev)
     M.fz_drop_device(context(), dev)
     if ok == nil then merror("cannot calculate bbox for page") end
+
+    print("getUsedBBox:", result[0].x0, result[0].x1, result[0].y0, result[0].y1)
 
     return result[0].x0, result[0].y0, result[0].x1, result[0].y1
 end


### PR DESCRIPTION
The `getSize` methods of a page -- much like the various BBox methods -- all return an internal representation of rectangles, with floating point precision, for a fixed render DPI of 72.

Trying to round that to integer this early in the pipeline risks cascading large rounding errors after scaling back to the actual screen size & scale factor.

Noticed with a random CBZ where this returned weirdly tiny rectangles (still don't know why), but, most importantly, ones that featured meaningful decimals.

This lead to computing a scale factor that was slightly off, which meant we actually scaled it to a slightly unexpected size (here, bigger), while the images were actually perfectly screen sized.

So, extra scaling pass: bad!
Extra-scaling pass that breaks page mode + fit-to because it no longer actually fits on a single screen: *very* bad!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1407)
<!-- Reviewable:end -->
