### PR TITLE
cre: support native text selection with getTextFromXPointers

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1817,7 +1817,19 @@ static int getTextFromXPointers(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	const char* pos0 = luaL_checkstring(L, 2);
 	const char* pos1 = luaL_checkstring(L, 3);
+	// Default to no text selection for backwards compatibility (most callers
+	// just want to extract the text, not create a new selection) but if
+	// drawSelection is enabled default to enabling segmented selection.
+	bool drawSelection = false;
+	if (lua_isboolean(L, 4)) {
+		drawSelection = lua_toboolean(L, 4);
+	}
+	bool drawSegmentedSelection = drawSelection;
+	if (lua_isboolean(L, 5)) {
+		drawSegmentedSelection = lua_toboolean(L, 5);
+	}
 
+	LVDocView *tv = doc->text_view;
 	ldomDocument *dv = doc->dom_doc;
 
 	ldomXPointer startp = dv->createXPointer(lString32(pos0));
@@ -1837,7 +1849,13 @@ static int getTextFromXPointers(lua_State *L) {
 				r.getEnd().setOffset(offset + 1);
 		}
 
-		lString32 selText = r.getRangeText( '\n', 8192 );
+		if (drawSelection) {
+			int rangeFlags = drawSegmentedSelection ? 0x11 : 0x01;
+			r.setFlags(rangeFlags);
+			tv->selectRange(r);
+		}
+
+		lString32 selText = r.getRangeText('\n', 8192);
 		lua_pushstring(L, UnicodeToLocal(selText).c_str());
         return 1;
     }


### PR DESCRIPTION
```
This is necessary for the Language Support feature in KOReader.

Before this patch, the only way to get crengine to natively highlight a
string of text was to use getTextFromPositions but this far from ideal
for two reasons:

1. crengine has some special handling of <ruby> text to try to make it
   harder to select, but the result is that if you try to convert
   XPointers to screen positions and then using getTextFromPositions
   you end up with a selection that doesn't match the XPointers you
   started with. Since the caller already has the XPointers it'd be
   much nicer to not have to go through any conversion at all.
2. getTextFromPositions cannot create highlights that cross page
   boundaries because the screen position you get from
   getPosFromXpointer is physically not on the screen and thus you end
   up getting nothing from getTextFromPositions.

Being able to optionally have native highlighting from a set of
XPointers would allow the Language Support feature in KOReader much more
smoothly create selections and manage text highlighting when plugins
request the word selection be expanded.

In order to avoid breaking any other callers of getTextFromXPointers, we
default to disabling native selection (after all, most callers probably
aren't interested in selecting the text they're trying to extract).
```

Needed by koreader/koreader#8312.
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1418)
<!-- Reviewable:end -->
