### PR TITLE
thirdparty: sdcv: update to better support multi-word lookups

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -81,7 +81,7 @@ set(PATCH_CMD1 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-locale-hack.patc
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/Dushistov/sdcv.git
-    3963e358cd8f6e24e59916ead97bc47a1d932c8d
+    3d15ce3b0712cd4f7f466e26d1357d3347c260d5
     ${SOURCE_DIR}
 )
 
@@ -90,7 +90,7 @@ download_project(
     GIT_REPOSITORY
     https://github.com/Dushistov/sdcv.git
     GIT_TAG
-    4ae420734990ab9f5ccc038262368256b9323f4a
+    3d15ce3b0712cd4f7f466e26d1357d3347c260d5
     #DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     PATCH_COMMAND COMMAND ${PATCH_CMD1}
 )


### PR DESCRIPTION
Current sdcv doesn't support multi-word lookups in the most ideal way.
In particular, as soon as any word specified in the command-line is
found to not have any dictionary results, it immediately bails. This
makes sdcv quite hard to use for Japanese deinflection and results in
less efficient batching when you have to look up many word candiates.

The patch applied is fairly trivial and was already submitted upstream
as a PR, so this patch can be dropped once it's merged upstream.

Ref: https://github.com/Dushistov/sdcv/pull/77
Needed by koreader/koreader#8312.
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1419)
<!-- Reviewable:end -->
