### PR TITLE
utf8proc: add utf8proc_NFC normalisation wrapper

### DIFF
--- a/ffi/utf8proc.lua
+++ b/ffi/utf8proc.lua
@@ -30,4 +30,11 @@ function Utf8Proc.lowercase(str)
     return folded_str
 end
 
+function Utf8Proc.normalize_NFC(str)
+    local normalized_strz = libutf8proc.utf8proc_NFC(str)
+    local normalized_str = ffi.string(normalized_strz)
+    C.free(normalized_strz)
+    return normalized_str
+end
+
 return Utf8Proc


### PR DESCRIPTION
Useful since Lua doesn't do this natively, and KOReader plugins might
need to be able to operate on utf8 strings using Lua's built in string
matching which won't match un-normalised strings.

Useful for koreader/koreader#8312.
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1420)
<!-- Reviewable:end -->
