### PR TITLE
Rollback to HarfBuzz 3.0.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -44,7 +44,7 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
-set(HB_VER 3.1.1)
+set(HB_VER 3.0.0)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
* 3.1.0 is broken on ARM
* 3.1.1 requires GCC >= 5

Our Android TCs haven't moved to Clang, so we're stuck on GCC 4.9 there,
and 3.1.1 also apparently ICEs on Ubuntu's GCC 8.4.0, which one of the
CI bots uses...

Let's see how things shakes out in the next minor release, and if it
becomes too annoying, we'll possibly consider making the version
being built different depending on the target...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1434)
<!-- Reviewable:end -->
