### PR TITLE
bump crengine: avoid re-renderings, hanging punctuation tweaks

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1413,7 +1413,6 @@ static int setViewDimen(lua_State *L) {
 	int h = luaL_checkint(L, 3);
 
 	doc->text_view->Resize(w, h);
-	doc->text_view->Render();
 
 	return 0;
 }


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/461 : 
- setStatusFontSize/Face(): avoid spurious re-rendering
- Hanging punctuation: include it in native highlighting
- Hanging punctuation: tweak hanging ratios again

cre.cpp: don't Render() in setViewDimen(), we'll do that in a more controlled fashion in frontend (https://github.com/koreader/koreader/pull/8501#issuecomment-986965082).

These tweaks and fixes will allow to contain any crengine re-renderings in `ReaderRolling:onUpdatePos()` where https://github.com/koreader/koreader/pull/8501 can plug Device:setIgnoreInput() to avoid ANR on Android.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1438)
<!-- Reviewable:end -->
