### PR TITLE
Clobbering of MT slots

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -150,7 +150,7 @@ static int openInputDevice(lua_State* L)
 
     // We're done w/ inputdevice, pop it
     lua_settop(L, 0);
-		lua_pushnumber(L,inputfds[fd_idx]);
+    lua_pushnumber(L, inputfds[fd_idx]);
 
     // Compute select's nfds argument.
     // That's not the actual number of fds in the set, like poll(),
@@ -204,8 +204,8 @@ static int closeInputDevices(lua_State* L __attribute__((unused)))
 static int fakeTapInput(lua_State* L)
 {
     const char* restrict inputdevice = luaL_checkstring(L, 1);
-    int                  x           = luaL_checkint(L, 2);
-    int                  y           = luaL_checkint(L, 3);
+    int x                            = luaL_checkint(L, 2);
+    int y                            = luaL_checkint(L, 3);
 
     int inputfd = open(inputdevice, O_WRONLY | O_NONBLOCK);
     if (inputfd == -1) {
@@ -288,8 +288,8 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
     lua_rawset(L, -3);                 // ev.value = input.value
 
     lua_pushstring(L, "fd");
-    lua_pushinteger(L, fd);						 //	int 
-    lua_rawset(L, -3);                 // ev.fd = fd
+    lua_pushinteger(L, fd);  //	int
+    lua_rawset(L, -3);       // ev.fd = fd
 
     lua_pushstring(L, "time");
     // NOTE: This is TimeVal-like, but it doesn't feature its metatable!
@@ -317,7 +317,7 @@ static inline size_t drain_input_queue(lua_State* L, struct input_event* input_q
 
     // Iterate over every input event in the queue buffer
     for (const struct input_event* event = input_queue; event < input_queue + ev_count; event++) {
-        set_event_table(L, event,fd);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
+        set_event_table(L, event, fd);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
         // NOTE: Here, rawseti basically inserts -1 in -2 @ [j]. We ensure that j always points at the tail.
         lua_rawseti(L, -2, ++j);  // table.insert(ev_array, ev) [, j]
     }
@@ -411,7 +411,7 @@ static int waitForInput(lua_State* L)
 
                 if ((size_t) len == queue_available_size) {
                     // If we're out of buffer space in the queue, drain it *now*
-                    j = drain_input_queue(L, input_queue, ev_count,inputfds[i], j);
+                    j = drain_input_queue(L, input_queue, ev_count, inputfds[i], j);
                     // Rewind to the start of the queue to recycle the buffer
                     queue_pos            = input_queue;
                     queue_available_size = sizeof(input_queue);
@@ -423,7 +423,7 @@ static int waitForInput(lua_State* L)
                 }
             }
             // We've drained the kernel's input queue, now drain our buffer
-            j = drain_input_queue(L, input_queue, ev_count, inputfds[i],j);
+            j = drain_input_queue(L, input_queue, ev_count, inputfds[i], j);
             return 2;  // true, ev_array
         }
     }

--- a/input/input.c
+++ b/input/input.c
@@ -150,6 +150,7 @@ static int openInputDevice(lua_State* L)
 
     // We're done w/ inputdevice, pop it
     lua_settop(L, 0);
+		lua_pushnumber(L,inputfds[fd_idx]);
 
     // Compute select's nfds argument.
     // That's not the actual number of fds in the set, like poll(),
@@ -161,7 +162,7 @@ static int openInputDevice(lua_State* L)
     // That, on the other hand, *is* the number of open fds ;).
     fd_idx++;
 
-    return 0;
+    return 1;
 }
 
 static int closeInputDevices(lua_State* L __attribute__((unused)))
@@ -271,9 +272,9 @@ static int fakeTapInput(lua_State* L)
     return 0;
 }
 
-static inline void set_event_table(lua_State* L, const struct input_event* input)
+static inline void set_event_table(lua_State* L, const struct input_event* input, int fd)
 {
-    lua_createtable(L, 0, 4);  // ev = {} (pre-allocated for its four fields)
+    lua_createtable(L, 0, 5);  // ev = {} (pre-allocated for its five fields)
     lua_pushstring(L, "type");
     lua_pushinteger(L, input->type);  // uint16_t
     // NOTE: rawset does t[k] = v, with v @ -1, k @ -2 and t at the specified index, here, that's ev @ -3.
@@ -285,6 +286,10 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
     lua_pushstring(L, "value");
     lua_pushinteger(L, input->value);  // int32_t
     lua_rawset(L, -3);                 // ev.value = input.value
+
+    lua_pushstring(L, "fd");
+    lua_pushinteger(L, fd);						 //	int 
+    lua_rawset(L, -3);                 // ev.fd = fd
 
     lua_pushstring(L, "time");
     // NOTE: This is TimeVal-like, but it doesn't feature its metatable!
@@ -299,7 +304,7 @@ static inline void set_event_table(lua_State* L, const struct input_event* input
     lua_rawset(L, -3);                        // ev.time = time
 }
 
-static inline size_t drain_input_queue(lua_State* L, struct input_event* input_queue, size_t ev_count, size_t j)
+static inline size_t drain_input_queue(lua_State* L, struct input_event* input_queue, size_t ev_count, int fd, size_t j)
 {
     if (lua_gettop(L) == 1) {
         // Only a single element in the stack? (that would be our `true` bool)?
@@ -312,7 +317,7 @@ static inline size_t drain_input_queue(lua_State* L, struct input_event* input_q
 
     // Iterate over every input event in the queue buffer
     for (const struct input_event* event = input_queue; event < input_queue + ev_count; event++) {
-        set_event_table(L, event);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
+        set_event_table(L, event,fd);  // Pushed a new ev table all filled up at the top of the stack (that's -1)
         // NOTE: Here, rawseti basically inserts -1 in -2 @ [j]. We ensure that j always points at the tail.
         lua_rawseti(L, -2, ++j);  // table.insert(ev_array, ev) [, j]
     }
@@ -406,7 +411,7 @@ static int waitForInput(lua_State* L)
 
                 if ((size_t) len == queue_available_size) {
                     // If we're out of buffer space in the queue, drain it *now*
-                    j = drain_input_queue(L, input_queue, ev_count, j);
+                    j = drain_input_queue(L, input_queue, ev_count,inputfds[i], j);
                     // Rewind to the start of the queue to recycle the buffer
                     queue_pos            = input_queue;
                     queue_available_size = sizeof(input_queue);
@@ -418,7 +423,7 @@ static int waitForInput(lua_State* L)
                 }
             }
             // We've drained the kernel's input queue, now drain our buffer
-            j = drain_input_queue(L, input_queue, ev_count, j);
+            j = drain_input_queue(L, input_queue, ev_count, inputfds[i],j);
             return 2;  // true, ev_array
         }
     }


### PR DESCRIPTION
As per discussion on #1437.

I have made changes to return an fd on device open and to pass the fd that generated the event as part of the lua table returned.

Having made these changes I think it probably is unnecessary to pass the fd with EVERY event as ultimately the [main loop in waitForInput](https://github.com/koreader/koreader-base/blob/1432b9298e8a2ab00aaa2cc52ca14fa90665c70f/input/input.c#L360-L424) only returns a table of event tables for one device at a time, so could have waitForInput return a triple instead. hypothetically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1439)
<!-- Reviewable:end -->
