### PR TITLE
[CI] Github Action for lint, build and tests

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -10,7 +10,6 @@ if [ "$TARGET" = "android" ]; then
         exit 1
     fi
 elif [ "$EMULATE_READER" = "1" ]; then
-    cp build/*/luajit "${HOME}/.luarocks/bin"
     # install tesseract trained language data for testing OCR functionality
     travis_retry wget https://src.fedoraproject.org/repo/pkgs/tesseract/tesseract-ocr-3.02.eng.tar.gz/3562250fe6f4e76229a329166b8ae853/tesseract-ocr-3.02.eng.tar.gz
     tar zxf tesseract-ocr-3.02.eng.tar.gz

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,14 @@
-name: test
+name: macos
 
 on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [macos-latest]
+    runs-on: macos-11
 
     steps:
-      - name: setup-xcode
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 11.3.1 # Use Xcode 11.3.1, because 11.4, 11.5, and 11.6 have a segfaulting clang.
+      - name: XCode version
+        run: xcode-select -p
 
       - name: Check out Git repository
         uses: actions/checkout@v2
@@ -33,7 +27,10 @@ jobs:
 
       - name: Homebrew install dependencies
         # Compared to the README, adds ccache for faster compilation times and removes sh5sum to prevent some conflict with coreutils, and gnu-getopt because we're not using kodev
-        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend sdl2 lua@5.1 luarocks gettext pkg-config wget bison
+        run: brew install ccache nasm ragel binutils coreutils libtool autoconf automake cmake makedepend sdl2 lua@5.1 luarocks gettext pkg-config wget gnu-getopt grep bison
 
       - name: Building in progress…
-        run: export MACOSX_DEPLOYMENT_TARGET=10.14 PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/bison/bin:${PATH}" && make fetchthirdparty && make
+        run: |
+          export MACOSX_DEPLOYMENT_TARGET=11;
+          export PATH="$(brew --prefix)/opt/gettext/bin:$(brew --prefix)/opt/gnu-getopt/bin:$(brew --prefix)/opt/bison/bin:$(brew --prefix)/opt/grep/libexec/gnubin:${PATH}";
+          make fetchthirdparty && make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,123 @@
+name: CI tests
+
+defaults:
+  run:
+    shell: bash
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Path: ~/local/bin"
+        run: echo ~/local/bin >> $GITHUB_PATH
+
+      - name: Install luarocks
+        run:  curl -sSL "https://raw.githubusercontent.com/koreader/virdevenv/master/docker/ubuntu/baseimage/install_luarocks.sh" | sudo bash
+
+      - name: Install Lint
+        run:  curl -sSL "https://raw.githubusercontent.com/koreader/virdevenv/master/docker/ubuntu/baseimage/install_lint.sh" | bash -s ~
+
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: lint
+        run: source .ci/lint_script.sh
+
+  emulator:
+    name: ${{ matrix.name }} ${{ (contains(matrix.os, 'ubuntu-18.04') && '(ubuntu-18.04)') || '' }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    env:
+      EMULATE_READER: "1"
+      CC: ${{ matrix.CC }}
+      CXX: ${{ matrix.CXX }}
+
+    steps:
+      - name: KODEBUG
+        if: contains(matrix.name, 'debug')
+        run: echo "KODEBUG=1" >> $GITHUB_ENV
+
+      - name: USE_MAKE
+        if: contains(matrix.name, 'make')
+        run: echo "USE_MAKE=1" >> $GITHUB_ENV
+
+      - name: CLANG
+        if: contains(matrix.name, 'clang')
+        run: echo "CC=clang-12" >> $GITHUB_ENV && echo "Cxx=clang++-12" >> $GITHUB_ENV
+
+      - name: Install deps
+        run:  sudo apt-get install gettext ccache ninja-build libtool-bin
+
+      - name: Install luarocks
+        run:  curl -sSL "https://raw.githubusercontent.com/koreader/virdevenv/master/docker/ubuntu/baseimage/install_luarocks.sh" | sudo bash
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{ matrix.os }}-build-${{ matrix.name }}
+
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: fetchthirdparty
+        run: make fetchthirdparty
+
+      - name: Build
+        run: make all
+
+      - name: Test
+        run: source .ci/test_script.sh
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        name: [ emu_gcc_ninja, emu_gcc_ninja_debug, emu_gcc_make, emu_clang_ninja]
+        # The test currently segfault on ubuntu 18.04. If fixed this can be enabled.
+        #include:
+        #  - name: emu_gcc_ninja
+        #    os: ubuntu-18.04
+
+  xcompile:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Download toolchain
+        run: wget -q https://github.com/koreader/koxtoolchain/releases/latest/download/${{ matrix.name }}.zip && unzip -p ${{ matrix.name }}.zip | tar -C ~ -xz
+
+      - name: export toolchain
+        run: echo ~/x-tools/arm-${{ matrix.name }}-linux-gnueabi${{ matrix.toolchain }}/bin >> $GITHUB_PATH
+
+      - name: Install deps
+        run:  sudo apt-get install gettext ccache ninja-build gcc-multilib luarocks
+
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-build-${{ matrix.name }}
+
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: fetchthirdparty
+        run: make fetchthirdparty
+
+      - name: Build
+        run: make TARGET=${{ matrix.target || matrix.name }} all
+    strategy:
+      fail-fast: false
+      matrix:
+        name: [ cervantes, kindlepw2, pocketbook]
+        include:
+          - name: kindle
+            target: kindle-legacy
+          - name: kindle5
+            target: kindle
+          - name: kobo
+            toolchain: hf
+          - name: remarkable
+            toolchain: hf
+

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ $(OUTPUT_DIR)/spec/base:
 
 test: $(OUTPUT_DIR)/spec $(OUTPUT_DIR)/.busted
 	cd $(OUTPUT_DIR) && \
-		./luajit $(shell which busted) \
+		$(shell which busted) --lua=./luajit \
 		--exclude-tags=notest \
 		-o gtest ./spec/base/unit
 


### PR DESCRIPTION
There is a job for linters, a matrix for the emulator builds, and a matrix for cross compile

Fix macos build based on koreader/koreader#8525

Android Builds have not be implemented yet. (I still have to figure out what the toolchain requirements are vs what GHA provides)

~~This still has some work to be done to deduplicate the dependency install scripts with front and virdevenv~~
Requires: koreader/virdevenv#71

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1442)
<!-- Reviewable:end -->
