### PR TITLE
bump crengine: CSS: minor parsing fixes

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1577,7 +1577,7 @@ static int setStyleSheet(lua_State *L) {
 		css << "\r\n" << lString8(css_content);
 	}
 
-	doc->text_view->setStyleSheet(css);
+	doc->text_view->setStyleSheet(css, false); // Skip crengine substituteCssMacros()
 	return 0;
 }
 


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/463 :
- setStyleSheet(): allow disabling CoolReader macro processing
- epubfmt.cpp: fix initial parsing of CSS files

cre.cpp: request no macro processing when providing our stylesheet and style tweaks