### PR TITLE
mupdf: strikeout highlight style, line thickness

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -665,7 +665,7 @@ end
 
 mupdf.STRIKE_HEIGHT = 0.375
 mupdf.UNDERLINE_HEIGHT = 0.075
-mupdf.LINE_THICKNESS = 0.07
+mupdf.LINE_THICKNESS = 0.05
 
 function page_mt.__index:addMarkupAnnotation(points, n, type)
     local color = ffi.new("float[3]")
@@ -683,7 +683,7 @@ function page_mt.__index:addMarkupAnnotation(points, n, type)
         color[2] = 1.0
         line_thickness = mupdf.LINE_THICKNESS
         line_height = mupdf.UNDERLINE_HEIGHT
-    elseif type == M.PDF_ANNOT_STRIKEOUT then
+    elseif type == M.PDF_ANNOT_STRIKE_OUT then
         color[0] = 1.0
         color[1] = 0.0
         color[2] = 0.0

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -664,7 +664,7 @@ function page_mt.__index:draw_new(draw_context, width, height, offset_x, offset_
 end
 
 mupdf.STRIKE_HEIGHT = 0.375
-mupdf.UNDERLINE_HEIGHT = 0.01
+mupdf.UNDERLINE_HEIGHT = 0
 mupdf.LINE_THICKNESS = 0.05
 
 function page_mt.__index:addMarkupAnnotation(points, n, type)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -664,7 +664,7 @@ function page_mt.__index:draw_new(draw_context, width, height, offset_x, offset_
 end
 
 mupdf.STRIKE_HEIGHT = 0.375
-mupdf.UNDERLINE_HEIGHT = 0.075
+mupdf.UNDERLINE_HEIGHT = 0.01
 mupdf.LINE_THICKNESS = 0.05
 
 function page_mt.__index:addMarkupAnnotation(points, n, type)


### PR DESCRIPTION
Unlock new strikeout highlight style.
Reduce underline/strikeout line thickness, to look similar to KOReader highlight style.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1450)
<!-- Reviewable:end -->
