### PR TITLE
Handle HW nightmode with inkview

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -9,6 +9,33 @@ local framebuffer = {
 
 }
 
+local function _toggleNightModeWhenEnabled(fb, x, y, w, h)
+    if fb.night_mode and fb.device:canHWInvert() then
+        inkview.InvertArea(x, y, w, h);
+    end
+end
+
+local function _updatePartial(fb, x, y, w, h)
+    fb.debug("refresh: inkview partial", x, y, w, h)
+
+    _toggleNightModeWhenEnabled(fb, x, y, w, h)
+    inkview.PartialUpdate(x, y, w, h)
+end
+
+local function _updateFull(fb, x, y, w, h)
+    fb.debug("refresh: inkview full", x, y, w, h)
+
+    _toggleNightModeWhenEnabled(fb, x, y, w, h)
+    inkview.FullUpdate()
+end
+
+local function _updateFast(fb, x, y, w, h)
+    fb.debug("refresh: inkview fast", x, y, w, h)
+
+    _toggleNightModeWhenEnabled(fb, x, y, w, h)
+    inkview.DynamicUpdate(x, y, w, h)
+end
+
 function framebuffer:init()
     self._finfo = ffi.new("struct fb_fix_screeninfo")
     self._vinfo = ffi.new("struct fb_var_screeninfo")
@@ -71,33 +98,27 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshUIImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.FullUpdate()
+    _updateFull(self, x, y, w, h)
 end
 
 function framebuffer:refreshFastImp(x, y, w, h, dither)
-    self.debug("refresh: inkview dynamic", x, y, w, h)
-    inkview.DynamicUpdate(x, y, w, h)
+    _updateFast(self, x, y, w, h)
 end
 
 function framebuffer:refreshWaitForLastImp()


### PR DESCRIPTION
This implementation enables night mode with inkview. Opening pictures in night mode will result in inverted pictures. But reading works fine.

![IMG_20220212_192513](https://user-images.githubusercontent.com/160743/153723555-7faa0fef-51b9-48ab-91b1-5ce131b1badf.jpg)
![IMG_20220212_192523](https://user-images.githubusercontent.com/160743/153723558-8fe22321-48a1-43bb-bb7c-4dfc7e10cf8c.jpg)
![IMG_20220212_192546](https://user-images.githubusercontent.com/160743/153723566-ef7c04d7-1d1e-405d-bf60-ca0a383d034d.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1453)
<!-- Reviewable:end -->
