### PR TITLE
Fix screen being partially refreshed when screen was rotated 90deg.

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -9,6 +9,32 @@ local framebuffer = {
 
 }
 
+local function _getPhysicalRect(fb, x, y, w, h)
+    local bb = fb.full_bb or fb.bb
+    w, x = BB.checkBounds(w or bb:getWidth(), x or 0, 0, bb:getWidth(), 0xFFFF)
+    h, y = BB.checkBounds(h or bb:getHeight(), y or 0, 0, bb:getHeight(), 0xFFFF)
+    return bb:getPhysicalRect(x, y, w, h)
+end
+
+local function _updatePartial(fb, x, y, w, h)
+    x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
+
+    fb.debug("refresh: inkview partial", x, y, w, h)
+    inkview.PartialUpdate(x, y, w, h)
+end
+
+local function _updateFull(fb, x, y, w, h)
+    fb.debug("refresh: inkview full", x, y, w, h)
+    inkview.FullUpdate()
+end
+
+local function _updateFast(fb, x, y, w, h)
+    x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
+
+    fb.debug("refresh: inkview fast", x, y, w, h)
+    inkview.DynamicUpdate(x, y, w, h)
+end
+
 function framebuffer:init()
     self._finfo = ffi.new("struct fb_fix_screeninfo")
     self._vinfo = ffi.new("struct fb_var_screeninfo")
@@ -71,33 +97,27 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshUIImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.PartialUpdate(x, y, w, h)
+    _updatePartial(self, x, y, w, h)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h, dither)
-    self.debug("refresh: inkview partial", x, y, w, h)
-    inkview.FullUpdate()
+    _updateFull(self, x, y, w, h)
 end
 
 function framebuffer:refreshFastImp(x, y, w, h, dither)
-    self.debug("refresh: inkview dynamic", x, y, w, h)
-    inkview.DynamicUpdate(x, y, w, h)
+    _updateFast(self, x, y, w, h)
 end
 
 function framebuffer:refreshWaitForLastImp()


### PR DESCRIPTION
Fixes: https://github.com/koreader/koreader/issues/8773

When the screen was rotated 90deg. The screen was only updated
partially.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1454)
<!-- Reviewable:end -->
