### PR TITLE
Implement MTK support on Kindle

### DIFF
--- a/ffi-cdecl/include/einkfb.h
+++ b/ffi-cdecl/include/einkfb.h
@@ -3,430 +3,412 @@
 #ifndef _EINKFB_H
 #define _EINKFB_H
 
-#define EINK_1BPP               1
-#define EINK_2BPP               2
-#define EINK_4BPP               4
-#define EINK_8BPP               8
-#define EINK_BPP_MAX            EINK_8BPP
+#ifndef __KERNEL__
+#	include <stdint.h>
+#endif
 
-#define EINK_WHITE              0x00    // For whacking all the pixels in a...
-#define EINK_BLACK              0xFF    // ...byte (8, 4, 2, or 1) at once.
+#define EINK_1BPP    1
+#define EINK_2BPP    2
+#define EINK_4BPP    4
+#define EINK_8BPP    8
+#define EINK_BPP_MAX EINK_8BPP
+
+#define EINK_WHITE 0x00    // For whacking all the pixels in a...
+#define EINK_BLACK 0xFF    // ...byte (8, 4, 2, or 1) at once.
 
 // Replace EINK_WHITE & EINK_BLACK with the following macros.
 //
-#define eink_white(b)           EINK_WHITE
-#define eink_black(b)           EINK_BLACK
+#define eink_white(b) EINK_WHITE
+#define eink_black(b) EINK_BLACK
 
 // For pixels (at bytes at a time) other than white/black, the following holds.
 //
-#define eink_pixels(b, p)       (p)
+#define eink_pixels(b, p) (p)
 
-#define EINK_ORIENT_LANDSCAPE   1
-#define EINK_ORIENT_PORTRAIT    0
+#define EINK_ORIENT_LANDSCAPE 1
+#define EINK_ORIENT_PORTRAIT  0
 
-#define BPP_SIZE(r, b)          (((r)*(b))/8)
-#define BPP_MAX(b)              (1 << (b))
+#define BPP_SIZE(r, b) (((r) * (b)) / 8)
+#define BPP_MAX(b)     (1 << (b))
 
-#define U_IN_RANGE(n, m, M)     ((((n) == 0) && ((m) == 0)) || (((n) > (m)) && ((n) <= (M))))
-#define IN_RANGE(n, m, M)       (((n) >= (m)) && ((n) <= (M)))
+#define U_IN_RANGE(n, m, M) ((((n) == 0) && ((m) == 0)) || (((n) > (m)) && ((n) <= (M))))
+#define IN_RANGE(n, m, M)   (((n) >= (m)) && ((n) <= (M)))
 
-#define ORIENTATION(x, y)       (((y) > (x)) ? EINK_ORIENT_PORTRAIT : EINK_ORIENT_LANDSCAPE)
+#define ORIENTATION(x, y) (((y) > (x)) ? EINK_ORIENT_PORTRAIT : EINK_ORIENT_LANDSCAPE)
 
 struct raw_image_t
 {
-    int xres,		// image's width, in pixels
-        yres,		// image's height
-        bpp;		// image's pixel (bit) depth
+	int xres,    // image's width, in pixels
+	    yres,    // image's height
+	    bpp;     // image's pixel (bit) depth
 
-    __u8  start[]; 	// actual start of image
+	uint8_t start[];    // actual start of image
 };
 typedef struct raw_image_t raw_image_t;
 
 struct image_t
 {
-    int xres,       // image's visual width, in pixels
-        xlen,       // image's actual width, used for rowbyte & memory size calculations
-        yres,       // image's height
-        bpp;        // image's pixel (bit) depth
+	int xres,    // image's visual width, in pixels
+	    xlen,    // image's actual width, used for rowbyte & memory size calculations
+	    yres,    // image's height
+	    bpp;     // image's pixel (bit) depth
 
-    __u8  *start;     // pointer to start of image
+	uint8_t* start;    // pointer to start of image
 };
 typedef struct image_t image_t;
 
-#define INIT_IMAGE_T() { 0, 0, 0, 0, NULL }
+#define INIT_IMAGE_T()                                                                                                   \
+	{                                                                                                                \
+		0, 0, 0, 0, NULL                                                                                         \
+	}
 
 enum splash_screen_type
 {
-    // Simple (non-composite) splash screens.
-    //
-    //splash_screen_powering_off = 0,        // Deprecated.
-    //splash_screen_powering_on,             // Deprecated.
+	// Simple (non-composite) splash screens.
+	//
+	//splash_screen_powering_off = 0,        // Deprecated.
+	//splash_screen_powering_on,             // Deprecated.
 
-    //splash_screen_powering_off_wireless,   // Deprecated.
-    //splash_screen_powering_on_wireless,    // Deprecated.
+	//splash_screen_powering_off_wireless,   // Deprecated.
+	//splash_screen_powering_on_wireless,    // Deprecated.
 
-    //splash_screen_exit,                    // Deprecated.
-    splash_screen_logo = 5,
+	//splash_screen_exit,                    // Deprecated.
+	splash_screen_logo = 5,
 
-    //splash_screen_usb_internal,            // Deprecated.
-    //splash_screen_usb_external,            // Deprecated.
-    //splash_screen_usb,                     // Deprecated.
+	//splash_screen_usb_internal,            // Deprecated.
+	//splash_screen_usb_external,            // Deprecated.
+	//splash_screen_usb,                     // Deprecated.
 
-    //splash_screen_sleep,                   // Deprecated.
-    //splash_screen_update,                  // Deprecated.
+	//splash_screen_sleep,                   // Deprecated.
+	//splash_screen_update,                  // Deprecated.
 
-    //num_splash_screens,                    // Deprecated.
+	//num_splash_screens,                    // Deprecated.
 
-    // Composite splash screens & messages.
-    //
-    //splash_screen_drivemode_0,              // Deprecated.
-    //splash_screen_drivemode_1,              // Deprecated.
-    //splash_screen_drivemode_2,              // Deprecated.
-    //splash_screen_drivemode_3,              // Deprecated.
+	// Composite splash screens & messages.
+	//
+	//splash_screen_drivemode_0,              // Deprecated.
+	//splash_screen_drivemode_1,              // Deprecated.
+	//splash_screen_drivemode_2,              // Deprecated.
+	//splash_screen_drivemode_3,              // Deprecated.
 
-    splash_screen_power_off_clear_screen = 16,// Message: clear screen and power down controller.
-    //splash_screen_screen_saver_picture,     // Deprecated.
+	splash_screen_power_off_clear_screen = 16,    // Message: clear screen and power down controller.
+	//splash_screen_screen_saver_picture,     // Deprecated.
 
-    splash_screen_shim_picture = 18,          // Message: shim wants a picture displayed.
+	splash_screen_shim_picture = 18,    // Message: shim wants a picture displayed.
 
-    splash_screen_lowbatt,                    // Picture: Not composite, post-legacy ordering (Mario only).
-    splash_screen_reboot,                     // Picture: Composite (not used on Fiona).
+	splash_screen_lowbatt,    // Picture: Not composite, post-legacy ordering (Mario only).
+	splash_screen_reboot,     // Picture: Composite (not used on Fiona).
 
-    splash_screen_update_initial,             // Composite software-update screens.
-    splash_screen_update_success,             //
-    splash_screen_update_failure,             //
-    splash_screen_update_failure_no_wait,     //
+	splash_screen_update_initial,            // Composite software-update screens.
+	splash_screen_update_success,            //
+	splash_screen_update_failure,            //
+	splash_screen_update_failure_no_wait,    //
 
-    splash_screen_repair_needed,              // More composite screens.
-    splash_screen_boot,                       //
+	splash_screen_repair_needed,    // More composite screens.
+	splash_screen_boot,             //
 
-    splash_screen_invalid = -1
+	splash_screen_invalid = -1
 };
 typedef enum splash_screen_type splash_screen_type;
 
 // Alias some of the legacy enumerations for Mario.
 //
-#define splash_screen_usb_recovery_util ((splash_screen_type)8) // splash_screen_usb
+#define splash_screen_usb_recovery_util ((splash_screen_type) 8)    // splash_screen_usb
 
 struct power_override_t
 {
-    u_int   cmd;
-    u_long  arg;
+	unsigned int  cmd;
+	unsigned long arg;
 };
 typedef struct power_override_t power_override_t;
 
 enum fx_type
 {
-    // Deprecated from the HAL, but still supported by the Shim.
-    //
-    fx_mask = 11,                           // Only for use with update_area_t's non-NULL buffer which_fx.
-    fx_buf_is_mask = 14,                    // Same as fx_mask, but doesn't require a doubling (i.e., the buffer & mask are the same).
+	// Deprecated from the HAL, but still supported by the Shim.
+	//
+	fx_mask        = 11,    // Only for use with update_area_t's non-NULL buffer which_fx.
+	fx_buf_is_mask = 14,    // Same as fx_mask, but doesn't require a doubling (i.e., the buffer & mask are the same).
 
-    fx_none = -1,                           // No legacy-FX to apply.
+	fx_none = -1,    // No legacy-FX to apply.
 
-    // Screen-update FX, supported by HAL.
-    //
-    fx_flash = 20,                          // Only for use with update_area_t (for faking a flashing update).
-    fx_invert = 21,                         // Only for use with update_area_t (only inverts output data).
+	// Screen-update FX, supported by HAL.
+	//
+	fx_flash  = 20,    // Only for use with update_area_t (for faking a flashing update).
+	fx_invert = 21,    // Only for use with update_area_t (only inverts output data).
 
-    fx_update_partial = 0,                  // Higher-speed, lower-fidelity update at bit depth's number of grays (aka non-flashing).
-    fx_update_full = 1,                     // Higher-fidelity, lower speed update at bit depth's number of grays (aka flashing).
+	fx_update_partial =
+	    0,                 // Higher-speed, lower-fidelity update at bit depth's number of grays (aka non-flashing).
+	fx_update_full = 1,    // Higher-fidelity, lower speed update at bit depth's number of grays (aka flashing).
 
-    fx_update_fast = 2,                     // Sacrifices all fidelity for speed (will be non-flashing).
-    fx_update_slow = 3,                     // Sacrifices any speed for fidelity (will be flashing).
+	fx_update_fast = 2,    // Sacrifices all fidelity for speed (will be non-flashing).
+	fx_update_slow = 3,    // Sacrifices any speed for fidelity (will be flashing).
 
-    fx_buffer_load = 99,                    // Just load the hardware buffer; don't update the display.
-    fx_buffer_display_partial = 100,        // Display whatever's in the hardware's buffer, non-flashing style.
-    fx_buffer_display_full = 101            // Display whatever's in the hardware's buffer, flashing style.
+	fx_buffer_load            = 99,     // Just load the hardware buffer; don't update the display.
+	fx_buffer_display_partial = 100,    // Display whatever's in the hardware's buffer, non-flashing style.
+	fx_buffer_display_full    = 101     // Display whatever's in the hardware's buffer, flashing style.
 };
 typedef enum fx_type fx_type;
 
 // The only valid legacy-FX types for area updates are fx_mask and fx_buf_is_mask.
 //
-#define UPDATE_AREA_FX(f)                   \
-    ((fx_mask == (f))                   ||  \
-     (fx_buf_is_mask == (f)))
+#define UPDATE_AREA_FX(f) ((fx_mask == (f)) || (fx_buf_is_mask == (f)))
 
 // Fast page turns consists of both fast updates to begin with, which are low fidelity, and then a
 // slow update at the end of the fast-update sequence to restore fidelity to the display.
 //
-#define UPDATE_FAST_PAGE_TURN(f)            \
-    ((fx_update_fast == (f))            ||  \
-     (fx_update_slow == (f)))
+#define UPDATE_FAST_PAGE_TURN(f) ((fx_update_fast == (f)) || (fx_update_slow == (f)))
 
 // The default ("none") for area updates is partial (non-flashing); full (flashing) updates
 // are for FX and such (i.e., explicit completion is desired).
 //
-#define UPDATE_AREA_PART(f)                 \
-    ((fx_none == (f))                   ||  \
-     (fx_buffer_display_partial == (f)) ||  \
-     (fx_update_partial == (f))         ||  \
-     (fx_update_fast == (f)))
+#define UPDATE_AREA_PART(f)                                                                                              \
+	((fx_none == (f)) || (fx_buffer_display_partial == (f)) || (fx_update_partial == (f)) || (fx_update_fast == (f)))
 
-#define UPDATE_AREA_FULL(f)                 \
-    (UPDATE_AREA_FX(f)                  ||  \
-     (fx_buffer_display_full == (f))    ||  \
-     (fx_update_full == (f))            ||  \
-     (fx_update_slow == (f)))
+#define UPDATE_AREA_FULL(f)                                                                                              \
+	(UPDATE_AREA_FX(f) || (fx_buffer_display_full == (f)) || (fx_update_full == (f)) || (fx_update_slow == (f)))
 
-#define UPDATE_AREA_MODE(f)                 \
-    (UPDATE_AREA_FULL(f) ? fx_update_full   \
-                         : fx_update_partial)
+#define UPDATE_AREA_MODE(f) (UPDATE_AREA_FULL(f) ? fx_update_full : fx_update_partial)
 
 // For use with the FBIO_EINK_UPDATE_DISPLAY ioctl.
 //
-#define UPDATE_PART(f)                      \
-    ((fx_buffer_display_partial == (f)) ||  \
-     (fx_update_partial == (f))         ||  \
-     (fx_update_fast == (f)))
+#define UPDATE_PART(f) ((fx_buffer_display_partial == (f)) || (fx_update_partial == (f)) || (fx_update_fast == (f)))
 
-#define UPDATE_FULL(f)                      \
-    ((fx_buffer_display_full == (f))    ||  \
-     (fx_update_full == (f))            ||  \
-     (fx_update_slow == (f)))
+#define UPDATE_FULL(f) ((fx_buffer_display_full == (f)) || (fx_update_full == (f)) || (fx_update_slow == (f)))
 
-#define UPDATE_MODE(f)                      \
-    (UPDATE_FULL(f) ? fx_update_full        \
-                    : fx_update_partial)
+#define UPDATE_MODE(f) (UPDATE_FULL(f) ? fx_update_full : fx_update_partial)
 
-#define UPDATE_MODE_BUFFER(f)               \
-    ((fx_buffer_load == (f))            ||  \
-     (fx_buffer_display_partial == (f)) ||  \
-     (fx_buffer_display_full == (f)))
+#define UPDATE_MODE_BUFFER(f)                                                                                            \
+	((fx_buffer_load == (f)) || (fx_buffer_display_partial == (f)) || (fx_buffer_display_full == (f)))
 
-#define SKIP_BUFFERS_EQUAL(f, c)            \
-    (UPDATE_MODE_BUFFER(f)              ||  \
-     (fx_update_slow == (f))            ||  \
-     (contrast_off != (c)))
+#define SKIP_BUFFERS_EQUAL(f, c) (UPDATE_MODE_BUFFER(f) || (fx_update_slow == (f)) || (contrast_off != (c)))
 
 struct rect_t
 {
-    // Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
-    //        are xres and yres, respectively, when normally xres and yres would be
-    //        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
-    //
-    int x1, y1, x2, y2;
+	// Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
+	//        are xres and yres, respectively, when normally xres and yres would be
+	//        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
+	//
+	int x1, y1, x2, y2;
 };
 typedef struct rect_t rect_t;
 
-#define INIT_RECT_T() { 0, 0, 0, 0 }
+#define INIT_RECT_T()                                                                                                    \
+	{                                                                                                                \
+		0, 0, 0, 0                                                                                               \
+	}
 #define MAX_EXCLUDE_RECTS 8
 
 struct fx_t
 {
-    fx_type     update_mode,                // Screen-update FX:  fx_update_full | fx_update_partial.
-                which_fx;                   // Shim (legacy) FX.
+	fx_type update_mode,    // Screen-update FX:  fx_update_full | fx_update_partial.
+	    which_fx;           // Shim (legacy) FX.
 
-    int         num_exclude_rects;          // 0..MAX_EXCLUDE_RECTS.
-    rect_t      exclude_rects[MAX_EXCLUDE_RECTS];
+	int    num_exclude_rects;    // 0..MAX_EXCLUDE_RECTS.
+	rect_t exclude_rects[MAX_EXCLUDE_RECTS];
 };
 typedef struct fx_t fx_t;
 
-#define INIT_FX_T()                     \
-    { fx_update_partial, fx_none, 0, {  \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T(),                    \
-      INIT_RECT_T()} }
+#define INIT_FX_T()                                                                                                      \
+	{                                                                                                                \
+		fx_update_partial, fx_none, 0,                                                                           \
+		{                                                                                                        \
+			INIT_RECT_T(), INIT_RECT_T(), INIT_RECT_T(), INIT_RECT_T(), INIT_RECT_T(), INIT_RECT_T(),        \
+			    INIT_RECT_T(), INIT_RECT_T()                                                                 \
+		}                                                                                                        \
+	}
 
 struct update_area_t
 {
-    // Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
-    //        are xres and yres, respectively, when normally xres and yres would be
-    //        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
-    //
-    int         x1, y1,                     // Top-left...
-                x2, y2;                     // ...bottom-right.
+	// Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
+	//        are xres and yres, respectively, when normally xres and yres would be
+	//        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
+	//
+	int x1, y1,    // Top-left...
+	    x2, y2;    // ...bottom-right.
 
-    fx_type     which_fx;                   // FX to use.
+	fx_type which_fx;    // FX to use.
 
-    __u8        *buffer;                    // If NULL, extract from framebuffer, top-left to bottom-right, by rowbytes.
+	uint8_t* buffer;    // If NULL, extract from framebuffer, top-left to bottom-right, by rowbytes.
 };
 typedef struct update_area_t update_area_t;
 
-#define INIT_UPDATE_AREA_T() { 0, 0, 0, 0, fx_none, NULL }
+#define INIT_UPDATE_AREA_T()                                                                                             \
+	{                                                                                                                \
+		0, 0, 0, 0, fx_none, NULL                                                                                \
+	}
 
 struct progressbar_xy_t
 {
-    int         x, y;                       // Top-left corner of progressbar's position (ignores x for now).
+	int x, y;    // Top-left corner of progressbar's position (ignores x for now).
 };
 typedef struct progressbar_xy_t progressbar_xy_t;
 
 enum screen_saver_t
 {
-    screen_saver_invalid = 0,
-    screen_saver_valid
+	screen_saver_invalid = 0,
+	screen_saver_valid
 };
 typedef enum screen_saver_t screen_saver_t;
 
 enum orientation_t
 {
-    orientation_portrait,
-    orientation_portrait_upside_down,
-    orientation_landscape,
-    orientation_landscape_upside_down
+	orientation_portrait,
+	orientation_portrait_upside_down,
+	orientation_landscape,
+	orientation_landscape_upside_down
 };
 typedef enum orientation_t orientation_t;
 
 #define num_orientations (orientation_landscape_upside_down + 1)
 
-#define ORIENTATION_PORTRAIT(o)     \
-    ((orientation_portrait == (o))  || (orientation_portrait_upside_down == (o)))
+#define ORIENTATION_PORTRAIT(o) ((orientation_portrait == (o)) || (orientation_portrait_upside_down == (o)))
 
-#define ORIENTATION_LANDSCAPE(o)    \
-    ((orientation_landscape == (o)) || (orientation_landscape_upside_down == (o)))
+#define ORIENTATION_LANDSCAPE(o) ((orientation_landscape == (o)) || (orientation_landscape_upside_down == (o)))
 
-#define ORIENTATION_SAME(o1, o2)    \
-    ((ORIENTATION_PORTRAIT(o1)  && ORIENTATION_PORTRAIT(o2)) || \
-     (ORIENTATION_LANDSCAPE(o1) && ORIENTATION_LANDSCAPE(o2)))
+#define ORIENTATION_SAME(o1, o2)                                                                                         \
+	((ORIENTATION_PORTRAIT(o1) && ORIENTATION_PORTRAIT(o2)) ||                                                       \
+	 (ORIENTATION_LANDSCAPE(o1) && ORIENTATION_LANDSCAPE(o2)))
 
 enum einkfb_events_t
 {
-    einkfb_event_update_display = 0,        // FBIO_EINK_UPDATE_DISPLAY
-    einkfb_event_update_display_area,       // FBIO_EINK_UPDATE_DISPLAY_AREA
+	einkfb_event_update_display = 0,     // FBIO_EINK_UPDATE_DISPLAY
+	einkfb_event_update_display_area,    // FBIO_EINK_UPDATE_DISPLAY_AREA
 
-    einkfb_event_blank_display,             // FBIOBLANK (fb.h)
-    einkfb_event_rotate_display,            // FBIO_EINK_SET_DISPLAY_ORIENTATION
+	einkfb_event_blank_display,     // FBIOBLANK (fb.h)
+	einkfb_event_rotate_display,    // FBIO_EINK_SET_DISPLAY_ORIENTATION
 
-    einkfb_event_null = -1
+	einkfb_event_null = -1
 };
 typedef enum einkfb_events_t einkfb_events_t;
 
 struct einkfb_event_t
 {
-    einkfb_events_t event;                  // Not all einkfb_events_t use all of the einkfb_event_t fields.
+	einkfb_events_t event;    // Not all einkfb_events_t use all of the einkfb_event_t fields.
 
-    fx_type         update_mode;            // Screen-update FX:  fx_update_full | fx_update_partial.
+	fx_type update_mode;    // Screen-update FX:  fx_update_full | fx_update_partial.
 
-    // Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
-    //        are xres and yres, respectively, when normally xres and yres would be
-    //        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
-    //
-    int             x1, y1,                 // Top-left...
-                    x2, y2;                 // ...bottom-right.
+	// Note:  The bottom-right (x2, y2) coordinate is actually such that (x2 - x1) and (y2 - y1)
+	//        are xres and yres, respectively, when normally xres and yres would be
+	//        (x2 - x1) + 1 and (y2 - y1) + 1, respectively.
+	//
+	int x1, y1,    // Top-left...
+	    x2, y2;    // ...bottom-right.
 
-    orientation_t   orientation;            // Display rotated into this orientation.
+	orientation_t orientation;    // Display rotated into this orientation.
 };
 typedef struct einkfb_event_t einkfb_event_t;
 
 enum reboot_behavior_t
 {
-    reboot_screen_asis,
-    reboot_screen_clear,
-    reboot_screen_splash
+	reboot_screen_asis,
+	reboot_screen_clear,
+	reboot_screen_splash
 };
 typedef enum reboot_behavior_t reboot_behavior_t;
 
 enum progressbar_badge_t
 {
-    progressbar_badge_success,
-    progressbar_badge_failure,
+	progressbar_badge_success,
+	progressbar_badge_failure,
 
-    progressbar_badge_none
+	progressbar_badge_none
 };
 typedef enum progressbar_badge_t progressbar_badge_t;
 
 enum sleep_behavior_t
 {
-    sleep_behavior_allow_sleep,
-    sleep_behavior_prevent_sleep
+	sleep_behavior_allow_sleep,
+	sleep_behavior_prevent_sleep
 };
 typedef enum sleep_behavior_t sleep_behavior_t;
 
 enum contrast_t
 {
-    contrast_off,
+	contrast_off,
 
-    contrast_light,
-    contrast_medium,
-    contrast_dark,
+	contrast_light,
+	contrast_medium,
+	contrast_dark,
 
-    contrast_lighter,
-    contrast_lightest,
+	contrast_lighter,
+	contrast_lightest,
 
-    contrast_darker,
-    contrast_darkest
+	contrast_darker,
+	contrast_darkest
 };
 typedef enum contrast_t contrast_t;
 
-#define EINK_FRAME_BUFFER                   "/dev/fb/0"
+#define EINK_FRAME_BUFFER "/dev/fb/0"
 
-#define SIZEOF_EINK_EVENT                   sizeof(einkfb_event_t)
-#define EINK_EVENTS                         "/dev/misc/eink_events"
+#define SIZEOF_EINK_EVENT sizeof(einkfb_event_t)
+#define EINK_EVENTS       "/dev/misc/eink_events"
 
-#define EINK_ROTATE_FILE                    "/sys/devices/platform/eink_fb.0/send_fake_rotate"
-#define EINK_ROTATE_FILE_LEN                1
-#define ORIENT_PORTRAIT                     orientation_portrait
-#define ORIENT_PORTRAIT_UPSIDE_DOWN         orientation_portrait_upside_down
-#define ORIENT_LANDSCAPE                    orientation_landscape
-#define ORIENT_LANDSCAPE_UPSIDE_DOWN        orientation_landscape_upside_down
-#define ORIENT_ASIS                         (-1)
+#define EINK_ROTATE_FILE             "/sys/devices/platform/eink_fb.0/send_fake_rotate"
+#define EINK_ROTATE_FILE_LEN         1
+#define ORIENT_PORTRAIT              orientation_portrait
+#define ORIENT_PORTRAIT_UPSIDE_DOWN  orientation_portrait_upside_down
+#define ORIENT_LANDSCAPE             orientation_landscape
+#define ORIENT_LANDSCAPE_UPSIDE_DOWN orientation_landscape_upside_down
+#define ORIENT_ASIS                  (-1)
 
-#define EINK_USID_FILE                      "/var/local/eink/usid"
+#define EINK_USID_FILE "/var/local/eink/usid"
 
-#define EINK_CLEAR_SCREEN                   0
-#define EINK_CLEAR_BUFFER                   1
-#define EINK_CLEAR_SCREEN_NOT_BUFFER        2
+#define EINK_CLEAR_SCREEN            0
+#define EINK_CLEAR_BUFFER            1
+#define EINK_CLEAR_SCREEN_NOT_BUFFER 2
 
-#define FBIO_EINK_SCREEN_CLEAR              FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_SCREEN
-#define FBIO_EINK_BUFFER_CLEAR              FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_BUFFER
-#define FBIO_EINK_SCREEN_CLEAR_ONLY         FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_SCREEN_NOT_BUFFER
+#define FBIO_EINK_SCREEN_CLEAR      FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_SCREEN
+#define FBIO_EINK_BUFFER_CLEAR      FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_BUFFER
+#define FBIO_EINK_SCREEN_CLEAR_ONLY FBIO_EINK_CLEAR_SCREEN, EINK_CLEAR_SCREEN_NOT_BUFFER
 
-#define FBIO_MIN_SCREEN                     splash_screen_powering_off
-#define FBIO_MAX_SCREEN                     num_splash_screens
-#define FBIO_SCREEN_IN_RANGE(s)             \
-    ((FBIO_MIN_SCREEN <= (s)) && (FBIO_MAX_SCREEN > (s)))
+#define FBIO_MIN_SCREEN         splash_screen_powering_off
+#define FBIO_MAX_SCREEN         num_splash_screens
+#define FBIO_SCREEN_IN_RANGE(s) ((FBIO_MIN_SCREEN <= (s)) && (FBIO_MAX_SCREEN > (s)))
 
-#define FBIO_MAGIC_NUMBER                   'F'
+#define FBIO_MAGIC_NUMBER 'F'
 
 // Implemented in the eInk HAL.
 //
-#define FBIO_EINK_UPDATE_DISPLAY            _IO(FBIO_MAGIC_NUMBER, 0xdb) // 0x46db (fx_type)
-#define FBIO_EINK_UPDATE_DISPLAY_AREA       _IO(FBIO_MAGIC_NUMBER, 0xdd) // 0x46dd (update_area_t *)
+#define FBIO_EINK_UPDATE_DISPLAY      _IO(FBIO_MAGIC_NUMBER, 0xdb)    // 0x46db (fx_type)
+#define FBIO_EINK_UPDATE_DISPLAY_AREA _IO(FBIO_MAGIC_NUMBER, 0xdd)    // 0x46dd (update_area_t *)
 
-#define FBIO_EINK_RESTORE_DISPLAY           _IO(FBIO_MAGIC_NUMBER, 0xef) // 0x46ef (UPDATE_MODE(fx_type))
+#define FBIO_EINK_RESTORE_DISPLAY _IO(FBIO_MAGIC_NUMBER, 0xef)    // 0x46ef (UPDATE_MODE(fx_type))
 
-#define FBIO_EINK_SET_REBOOT_BEHAVIOR       _IO(FBIO_MAGIC_NUMBER, 0xe9) // 0x46e9 (reboot_behavior_t)
-#define FBIO_EINK_GET_REBOOT_BEHAVIOR       _IO(FBIO_MAGIC_NUMBER, 0xed) // 0x46ed (reboot_behavior_t *)
+#define FBIO_EINK_SET_REBOOT_BEHAVIOR _IO(FBIO_MAGIC_NUMBER, 0xe9)    // 0x46e9 (reboot_behavior_t)
+#define FBIO_EINK_GET_REBOOT_BEHAVIOR _IO(FBIO_MAGIC_NUMBER, 0xed)    // 0x46ed (reboot_behavior_t *)
 
-#define FBIO_EINK_SET_DISPLAY_ORIENTATION   _IO(FBIO_MAGIC_NUMBER, 0xf0) // 0x46f0 (orientation_t)
-#define FBIO_EINK_GET_DISPLAY_ORIENTATION   _IO(FBIO_MAGIC_NUMBER, 0xf1) // 0x46f1 (orientation_t *)
+#define FBIO_EINK_SET_DISPLAY_ORIENTATION _IO(FBIO_MAGIC_NUMBER, 0xf0)    // 0x46f0 (orientation_t)
+#define FBIO_EINK_GET_DISPLAY_ORIENTATION _IO(FBIO_MAGIC_NUMBER, 0xf1)    // 0x46f1 (orientation_t *)
 
-#define FBIO_EINK_SET_SLEEP_BEHAVIOR        _IO(FBIO_MAGIC_NUMBER, 0xf2) // 0x46f2 (sleep_behavior_t)
-#define FBIO_EINK_GET_SLEEP_BEHAVIOR        _IO(FBIO_MAGIC_NUMBER, 0xf3) // 0x46f3 (sleep_behavior_t *)
+#define FBIO_EINK_SET_SLEEP_BEHAVIOR _IO(FBIO_MAGIC_NUMBER, 0xf2)    // 0x46f2 (sleep_behavior_t)
+#define FBIO_EINK_GET_SLEEP_BEHAVIOR _IO(FBIO_MAGIC_NUMBER, 0xf3)    // 0x46f3 (sleep_behavior_t *)
 
-#define FBIO_EINK_SET_CONTRAST              _IO(FBIO_MAGIC_NUMBER, 0xf5) // 0x46f5 (contrast_t)
+#define FBIO_EINK_SET_CONTRAST _IO(FBIO_MAGIC_NUMBER, 0xf5)    // 0x46f5 (contrast_t)
 
 // Implemented in the eInk Shim.
 //
-#define FBIO_EINK_UPDATE_DISPLAY_FX         _IO(FBIO_MAGIC_NUMBER, 0xe4) // 0x46e4 (fx_t *)
-#define FBIO_EINK_SPLASH_SCREEN             _IO(FBIO_MAGIC_NUMBER, 0xdc) // 0x46dc (splash_screen_type)
-#define FBIO_EINK_SPLASH_SCREEN_SLEEP       _IO(FBIO_MAGIC_NUMBER, 0xe0) // 0x46e0 (splash_screen_type)
-#define FBIO_EINK_OFF_CLEAR_SCREEN          _IO(FBIO_MAGIC_NUMBER, 0xdf) // 0x46df (no args)
-#define FBIO_EINK_CLEAR_SCREEN              _IO(FBIO_MAGIC_NUMBER, 0xe1) // 0x46e1 (EINK_CLEAR_SCREEN || EINK_CLEAR_BUFFER || EINK_CLEAR_SCREEN_NOT_BUFFER)
-#define FBIO_EINK_POWER_OVERRIDE            _IO(FBIO_MAGIC_NUMBER, 0xe3) // 0x46e3 (power_override_t *)
+#define FBIO_EINK_UPDATE_DISPLAY_FX   _IO(FBIO_MAGIC_NUMBER, 0xe4)    // 0x46e4 (fx_t *)
+#define FBIO_EINK_SPLASH_SCREEN       _IO(FBIO_MAGIC_NUMBER, 0xdc)    // 0x46dc (splash_screen_type)
+#define FBIO_EINK_SPLASH_SCREEN_SLEEP _IO(FBIO_MAGIC_NUMBER, 0xe0)    // 0x46e0 (splash_screen_type)
+#define FBIO_EINK_OFF_CLEAR_SCREEN    _IO(FBIO_MAGIC_NUMBER, 0xdf)    // 0x46df (no args)
+#define FBIO_EINK_CLEAR_SCREEN                                                                                           \
+	_IO(FBIO_MAGIC_NUMBER, 0xe1)    // 0x46e1 (EINK_CLEAR_SCREEN || EINK_CLEAR_BUFFER || EINK_CLEAR_SCREEN_NOT_BUFFER)
+#define FBIO_EINK_POWER_OVERRIDE _IO(FBIO_MAGIC_NUMBER, 0xe3)    // 0x46e3 (power_override_t *)
 
-#define FBIO_EINK_PROGRESSBAR               _IO(FBIO_MAGIC_NUMBER, 0xea) // 0x46ea (int: 0..100 -> draw progressbar || !(0..100) -> clear progressbar)
-#define FBIO_EINK_PROGRESSBAR_SET_XY        _IO(FBIO_MAGIC_NUMBER, 0xeb) // 0x46eb (progressbar_xy_t *)
-#define FBIO_EINK_PROGRESSBAR_BADGE         _IO(FBIO_MAGIC_NUMBER, 0xec) // 0x46ec (progressbar_badge_t);
-#define FBIO_EINK_PROGRESSBAR_BACKGROUND    _IO(FBIO_MAGIC_NUMBER, 0xf4) // 0x46f4 (int: EINKFB_WHITE || EINKFB_BLACK)
+#define FBIO_EINK_PROGRESSBAR                                                                                            \
+	_IO(FBIO_MAGIC_NUMBER, 0xea)    // 0x46ea (int: 0..100 -> draw progressbar || !(0..100) -> clear progressbar)
+#define FBIO_EINK_PROGRESSBAR_SET_XY     _IO(FBIO_MAGIC_NUMBER, 0xeb)    // 0x46eb (progressbar_xy_t *)
+#define FBIO_EINK_PROGRESSBAR_BADGE      _IO(FBIO_MAGIC_NUMBER, 0xec)    // 0x46ec (progressbar_badge_t);
+#define FBIO_EINK_PROGRESSBAR_BACKGROUND _IO(FBIO_MAGIC_NUMBER, 0xf4)    // 0x46f4 (int: EINKFB_WHITE || EINKFB_BLACK)
 
-#define IS_UPDATE_DISPLAY_CMD(c)                \
-    ((FBIO_EINK_UPDATE_DISPLAY == (c))      ||  \
-     (FBIO_EINK_UPDATE_DISPLAY_FX == (c))   ||  \
-     (FBIO_EINK_UPDATE_DISPLAY_AREA == (c)) ||  \
-     (FBIO_EINK_RESTORE_DISPLAY == (c))     ||  \
-     (FBIO_EINK_CLEAR_SCREEN == (c)))
+#define IS_UPDATE_DISPLAY_CMD(c)                                                                                         \
+	((FBIO_EINK_UPDATE_DISPLAY == (c)) || (FBIO_EINK_UPDATE_DISPLAY_FX == (c)) ||                                    \
+	 (FBIO_EINK_UPDATE_DISPLAY_AREA == (c)) || (FBIO_EINK_RESTORE_DISPLAY == (c)) ||                                 \
+	 (FBIO_EINK_CLEAR_SCREEN == (c)))
 
-#define IS_PROGRESSBAR_CMD(c)                   \
-    ((FBIO_EINK_PROGRESSBAR == (c))         ||  \
-     (FBIO_EINK_PROGRESSBAR_SET_XY == (c))  ||  \
-     (FBIO_EINK_PROGRESSBAR_BADGE == (c))   ||  \
-     (FBIO_EINK_PROGRESSBAR_BACKGROUND == (c)))
+#define IS_PROGRESSBAR_CMD(c)                                                                                            \
+	((FBIO_EINK_PROGRESSBAR == (c)) || (FBIO_EINK_PROGRESSBAR_SET_XY == (c)) ||                                      \
+	 (FBIO_EINK_PROGRESSBAR_BADGE == (c)) || (FBIO_EINK_PROGRESSBAR_BACKGROUND == (c)))
 
 // Deprecated from the HAL & Shim.
 //
@@ -435,35 +417,36 @@ typedef enum contrast_t contrast_t;
 
 // For use with /proc/eink_fb/update_display.
 //
-#define PROC_EINK_UPDATE_DISPLAY_CLS        0   // FBIO_EINK_CLEAR_SCREEN
-#define PROC_EINK_UPDATE_DISPLAY_PART       1   // FBIO_EINK_UPDATE_DISPLAY(fx_update_partial)
-#define PROC_EINK_UPDATE_DISPLAY_FULL       2   // FBIO_EINK_UPDATE_DISPLAY(fx_update_full)
-#define PROC_EINK_UPDATE_DISPLAY_AREA       3   // FBIO_EINK_UPDATE_DISPLAY_AREA
+#define PROC_EINK_UPDATE_DISPLAY_CLS      0    // FBIO_EINK_CLEAR_SCREEN
+#define PROC_EINK_UPDATE_DISPLAY_PART     1    // FBIO_EINK_UPDATE_DISPLAY(fx_update_partial)
+#define PROC_EINK_UPDATE_DISPLAY_FULL     2    // FBIO_EINK_UPDATE_DISPLAY(fx_update_full)
+#define PROC_EINK_UPDATE_DISPLAY_AREA     3    // FBIO_EINK_UPDATE_DISPLAY_AREA
 //#define PROC_EINK_UPDATE_DISPLAY_REST     4   // FBIO_EINK_RESTORE_SCREEN
-#define PROC_EINK_UPDATE_DISPLAY_SCRN       5   // FBIO_EINK_SPLASH_SCREEN
-#define PROC_EINK_UPDATE_DISPLAY_OVRD       6   // FBIO_EINK_FPOW_OVERRIDE
-#define PROC_EINK_UPDATE_DISPLAY_FX         7   // FBIO_EINK_UPDATE_DISPLAY_FX
+#define PROC_EINK_UPDATE_DISPLAY_SCRN     5    // FBIO_EINK_SPLASH_SCREEN
+#define PROC_EINK_UPDATE_DISPLAY_OVRD     6    // FBIO_EINK_FPOW_OVERRIDE
+#define PROC_EINK_UPDATE_DISPLAY_FX       7    // FBIO_EINK_UPDATE_DISPLAY_FX
 //#define PROC_EINK_UPDATE_DISPLAY_SYNC     8   // FBIO_EINK_SYNC_BUFFERS
 //#define PROC_EINK_UPDATE_DISPLAY_PNLCD    9   // FBIO_EINK_FAKE_PNLCD
-#define PROC_EINK_SET_REBOOT_BEHAVIOR      10   // FBIO_EINK_SET_REBOOT_BEHAVIOR
-#define PROC_EINK_SET_PROGRESSBAR_XY       11   // FBIO_EINK_PROGRESSBAR_SET_XY
-#define PROC_EINK_UPDATE_DISPLAY_SCRN_SLP  12   // FBIO_EINK_SPLASH_SCREEN_SLEEP
-#define PROC_EINK_PROGRESSBAR_BADGE        13   // FBIO_EINK_PROGRESSBAR_BADGE
-#define PROC_EINK_SET_DISPLAY_ORIENTATION  14   // FBIO_EINK_SET_DISPLAY_ORIENTATION
-#define PROC_EINK_RESTORE_DISPLAY          15   // FBIO_EINK_RESTORE_DISPLAY
-#define PROC_EINK_SET_SLEEP_BEHAVIOR       16   // FBIO_EINK_SET_SLEEP_BEHAVIOR
-#define PROC_EINK_PROGRESSBAR_BACKGROUND   17   // FBIO_EINK_PROGRESSBAR_BACKGROUND
-#define PROC_EINK_UPDATE_DISPLAY_WHICH     18   // FBIO_EINK_UPDATE_DISPLAY
-#define PROC_EINK_SET_CONTRAST             19   // FBIO_EINK_SET_CONTRAST
+#define PROC_EINK_SET_REBOOT_BEHAVIOR     10    // FBIO_EINK_SET_REBOOT_BEHAVIOR
+#define PROC_EINK_SET_PROGRESSBAR_XY      11    // FBIO_EINK_PROGRESSBAR_SET_XY
+#define PROC_EINK_UPDATE_DISPLAY_SCRN_SLP 12    // FBIO_EINK_SPLASH_SCREEN_SLEEP
+#define PROC_EINK_PROGRESSBAR_BADGE       13    // FBIO_EINK_PROGRESSBAR_BADGE
+#define PROC_EINK_SET_DISPLAY_ORIENTATION 14    // FBIO_EINK_SET_DISPLAY_ORIENTATION
+#define PROC_EINK_RESTORE_DISPLAY         15    // FBIO_EINK_RESTORE_DISPLAY
+#define PROC_EINK_SET_SLEEP_BEHAVIOR      16    // FBIO_EINK_SET_SLEEP_BEHAVIOR
+#define PROC_EINK_PROGRESSBAR_BACKGROUND  17    // FBIO_EINK_PROGRESSBAR_BACKGROUND
+#define PROC_EINK_UPDATE_DISPLAY_WHICH    18    // FBIO_EINK_UPDATE_DISPLAY
+#define PROC_EINK_SET_CONTRAST            19    // FBIO_EINK_SET_CONTRAST
 
 //#define PROC_EINK_FAKE_PNLCD_TEST       100   // Programmatically drive FBIO_EINK_FAKE_PNLCD (not implemented).
-#define PROC_EINK_GRAYSCALE_TEST          101   // Fills display with white-to-black ramp at current bit depth.
+#define PROC_EINK_GRAYSCALE_TEST 101    // Fills display with white-to-black ramp at current bit depth.
 
 // Inter-module/inter-driver eink ioctl access.
 //
 extern int fiona_eink_ioctl_stub(unsigned int cmd, unsigned long arg);
 
-#define eink_sys_ioctl(cmd, arg)            (get_fb_ioctl() ? (*get_fb_ioctl())((unsigned int)cmd, (unsigned long)arg)      \
-                                                            : fiona_eink_ioctl_stub((unsigned int)cmd, (unsigned long)arg))
+#define eink_sys_ioctl(cmd, arg)                                                                                         \
+	(get_fb_ioctl() ? (*get_fb_ioctl())((unsigned int) cmd, (unsigned long) arg)                                     \
+			: fiona_eink_ioctl_stub((unsigned int) cmd, (unsigned long) arg))
 
-#endif // _EINKFB_H
+#endif    // _EINKFB_H

--- a/ffi-cdecl/include/frontlight-kindle.h
+++ b/ffi-cdecl/include/frontlight-kindle.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * ----
+ *
+ * This is <linux/frontlight.h>, last updated from the PW5 kernel for FW 5.14.1.1
+ *
+ * NOTE: Upstream kernels available here: https://www.amazon.com/gp/help/customer/display.html?nodeId=200203720
+ *
+ * - Trimmed down to avoid pulling in other non-standard kernel headers -- NiLuJe
+ *
+ * ----
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See http://www.gnu.org/licenses/gpl-2.0.html for more details.
+ *
+ * Accelerometer Sensor Driver
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ */
+#ifndef __LINUX_FRONTLIGHT_H
+#define __LINUX_FRONTLIGHT_H
+
+#include <linux/ioctl.h>
+
+#define FL_DEV_FILE "/dev/frontlight"
+
+#define FL_MAGIC_NUMBER 'L'
+
+#define FL_IOCTL_SET_INTENSITY                _IOW(FL_MAGIC_NUMBER, 0x01, int)
+#define FL_IOCTL_GET_INTENSITY                _IOR(FL_MAGIC_NUMBER, 0x02, int)
+#define FL_IOCTL_GET_RANGE_MAX                _IOR(FL_MAGIC_NUMBER, 0x03, int)
+#define FL_IOCTL_SET_INTENSITY_FORCED         _IOW(FL_MAGIC_NUMBER, 0x04, int)
+#define FL_IOCTL_SET_INTENSITY_AMBER_1        _IOW(FL_MAGIC_NUMBER, 0x05, int)
+#define FL_IOCTL_GET_INTENSITY_AMBER_1        _IOR(FL_MAGIC_NUMBER, 0x06, int)
+#define FL_IOCTL_GET_RANGE_MAX_AMBER_1        _IOR(FL_MAGIC_NUMBER, 0x07, int)
+#define FL_IOCTL_SET_INTENSITY_FORCED_AMBER_1 _IOW(FL_MAGIC_NUMBER, 0x08, int)
+#define FL_IOCTL_SET_INTENSITY_AMBER_2        _IOW(FL_MAGIC_NUMBER, 0x09, int)
+#define FL_IOCTL_GET_INTENSITY_AMBER_2        _IOR(FL_MAGIC_NUMBER, 0x0a, int)
+#define FL_IOCTL_GET_RANGE_MAX_AMBER_2        _IOR(FL_MAGIC_NUMBER, 0x0b, int)
+#define FL_IOCTL_SET_INTENSITY_FORCED_AMBER_2 _IOW(FL_MAGIC_NUMBER, 0x0c, int)
+#define FL_IOCTL_SET_INTENSITY_AMBER          _IOW(FL_MAGIC_NUMBER, 0x0d, int)
+#define FL_IOCTL_GET_INTENSITY_AMBER          _IOR(FL_MAGIC_NUMBER, 0x0e, int)
+#define FL_IOCTL_GET_RANGE_MAX_AMBER          _IOR(FL_MAGIC_NUMBER, 0x0f, int)
+#define FL_IOCTL_SET_INTENSITY_FORCED_AMBER   _IOW(FL_MAGIC_NUMBER, 0x10, int)
+
+#define WARIO_FL_LEVEL0              0
+#define WARIO_FL_LEVEL12_MID         512
+#define DUET_FL_LEVEL12_MID          240
+#define WARIO_FL_LO_TRANSITION_LEVEL 42
+#define WARIO_FL_LO_GRP_HOP_LEVEL    1
+#define WARIO_FL_MED_GRP_HOP_LEVEL   10
+#define WARIO_FL_LO_GRP_DELAY_US     1000
+
+#endif

--- a/ffi-cdecl/include/ion-kobo.h
+++ b/ffi-cdecl/include/ion-kobo.h
@@ -17,8 +17,10 @@
 #ifndef _UAPI_LINUX_ION_H
 #define _UAPI_LINUX_ION_H
 
-#include <stddef.h>
-#include <stdint.h>
+#ifndef __KERNEL__
+#	include <stddef.h>
+#	include <stdint.h>
+#endif
 
 #include <linux/ioctl.h>
 
@@ -261,7 +263,7 @@ typedef struct
 #define ION_IOC_SUNXI_TEE_ADDR    17
 
 //
-// And, much like the actual ioctl handler, shove that in an union to make our life easier.
+// And, much like the actual ioctl handler, shove that in a union to make our life easier.
 //
 
 union ion_ioctl_arg

--- a/ffi-cdecl/include/mtk-kindle.h
+++ b/ffi-cdecl/include/mtk-kindle.h
@@ -1,0 +1,479 @@
+/*****************************************************************************
+ * Copyright (C) 2016 MediaTek Inc.
+ *
+ * ----
+ *
+ * This is <linux/hwtcon_ioctl_cmd.h>, last updated from the PW5 kernel for FW 5.14.1.1
+ *
+ * NOTE: Upstream kernels available here: https://www.amazon.com/gp/help/customer/display.html?nodeId=200203720
+ *
+ * - Frankensteined to play nice w/ MXCFB constants -- NiLuJe
+ *
+ * ----
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See http://www.gnu.org/licenses/gpl-2.0.html for more details.
+ *
+ * Accelerometer Sensor Driver
+ *
+ * This software is licensed under the terms of the GNU General Public
+ * License version 2, as published by the Free Software Foundation, and
+ * may be copied, distributed, and modified under those terms.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ *
+ *****************************************************************************/
+
+#ifndef __HWTCON_IOCTL_CMD_H__
+#define __HWTCON_IOCTL_CMD_H__
+
+#ifndef __KERNEL__
+#	include <stdint.h>
+#endif
+
+// Pull in the mxcfb stuff, as a lot of stuff hasn't actually changed (kudos, lab126!)
+#include "mxcfb-kindle.h"
+
+/* EPDC_FLAG_xx */
+// What's not new matches Zelda
+// NOTE: Night mode relies on switching to GRAYSCALE_8BIT_INVERTED instead of the flag,
+//       as it allows various other in-kernel tidbits to easily detect it ;).
+/*
+#define EPDC_FLAG_ENABLE_INVERSION     0x01
+#define EPDC_FLAG_FORCE_MONOCHROME     0x02
+#define EPDC_FLAG_USE_CMAP             0x04
+#define EPDC_FLAG_USE_ALT_BUFFER       0x100
+#define EPDC_FLAG_TEST_COLLISION       0x200
+#define EPDC_FLAG_GROUP_UPDATE         0x400
+#define EPDC_FLAG_USE_DITHERING_Y1     0x2000
+*/
+#define MTK_EPDC_FLAG_USE_DITHERING_Y4 0x4000
+#define MTK_EPDC_FLAG_USE_REGAL        0x8000
+#define MTK_EPDC_FLAG_ENABLE_SWIPE     0x10000
+
+/* temperature use sensor. */
+/*
+#define TEMP_USE_AMBIENT 0x1000
+#define TEMP_USE_AUTO    TEMP_USE_AMBIENT
+*/
+
+/*
+#define UPDATE_MODE_PARTIAL 0x0
+#define UPDATE_MODE_FULL    0x1
+*/
+
+/*
+#define AUTO_UPDATE_MODE_REGION_MODE    0
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE 1
+*/
+
+/* gray scale */
+/*
+#define GRAYSCALE_8BIT          0x1
+#define GRAYSCALE_8BIT_INVERTED 0x2
+#define GRAYSCALE_4BIT          0x3
+#define GRAYSCALE_4BIT_INVERTED 0x4
+*/
+
+enum MTK_WAVEFORM_MODE_ENUM
+{
+	// Matches Zelda
+	MTK_WAVEFORM_MODE_INIT          = 0,
+	MTK_WAVEFORM_MODE_DU            = 1,
+	MTK_WAVEFORM_MODE_GC16          = 2,
+	MTK_WAVEFORM_MODE_GC16_FAST     = 2,
+	MTK_WAVEFORM_MODE_GL16          = 3,
+	MTK_WAVEFORM_MODE_GL16_FAST     = 3,
+	MTK_WAVEFORM_MODE_GL4           = 3,
+	MTK_WAVEFORM_MODE_GL16_INV      = 3,
+	MTK_WAVEFORM_MODE_GLR16         = 4,
+	MTK_WAVEFORM_MODE_REAGL         = 4,
+	MTK_WAVEFORM_MODE_GLD16         = 5,
+	MTK_WAVEFORM_MODE_REAGLD        = 5,
+	MTK_WAVEFORM_MODE_A2            = 6,
+	MTK_WAVEFORM_MODE_DU4           = 7,
+	MTK_WAVEFORM_MODE_LAST          = 7,
+	MTK_WAVEFORM_MODE_GCK16         = 8,
+	MTK_WAVEFORM_MODE_GLKW16        = 9,
+	// New with MTK
+	MTK_WAVEFORM_MODE_GC16_PARTIAL  = 10,
+	MTK_WAVEFORM_MODE_GCK16_PARTIAL = 11,
+	MTK_WAVEFORM_MODE_DUNM          = 12,
+	MTK_WAVEFORM_MODE_P2SW          = 13,
+	// Matches MXCFB
+	MTK_WAVEFORM_MODE_AUTO          = 257,
+};
+
+// Matches MXCFB
+/*
+enum hwtcon_update_scheme
+{
+	MTK_UPDATE_SCHEME_QUEUE           = 1,
+	MTK_UPDATE_SCHEME_QUEUE_AND_MERGE = 2,
+};
+*/
+
+/*
+#define WAVEFORM_TYPE_4BIT 0x1
+#define WAVEFORM_TYPE_5BIT (WAVEFORM_TYPE_4BIT << 1)
+*/
+
+/*
+enum mxcfb_dithering_mode
+{
+	EPDC_FLAG_USE_DITHERING_PASSTHROUGH = 0x0,
+	EPDC_FLAG_USE_DITHERING_FLOYD_STEINBERG,
+	EPDC_FLAG_USE_DITHERING_ATKINSON,
+	EPDC_FLAG_USE_DITHERING_ORDERED,
+	EPDC_FLAG_USE_DITHERING_QUANT_ONLY,
+	EPDC_FLAG_USE_DITHERING_MAX,
+};
+*/
+
+// From "drivers/misc/mediatek/hwtcon_v2/hal/hwtcon_pipeline_config.h"
+enum MTK_SWIPE_DIRECTION_ENUM
+{
+	MTK_SWIPE_DOWN  = 0,
+	MTK_SWIPE_UP    = 1,
+	MTK_SWIPE_LEFT  = 2,
+	MTK_SWIPE_RIGHT = 3,
+	MTK_SWIPE_MAX,
+};
+
+/*
+ * SWIPE_DOWN = 0,
+ * SWIPE_UP = 1,
+ * SWIPE_LEFT = 2,
+ * SWIPE_RIGHT = 3,
+*/
+struct mxcfb_swipe_data
+{
+	uint32_t direction; /* UP, DOWN, LEFT or RIGHT */
+	uint32_t steps;     /* number of swipe steps */
+};
+
+// Matches !Zelda
+/*
+struct mxcfb_waveform_modes
+{
+	// waveform mode index for WAVEFORM_MODE_INIT
+	int mode_init;
+	// waveform mode index for WAVEFORM_MODE_DU
+	int mode_du;
+	// waveform mode index for WAVEFORM_MODE_GC4
+	int mode_gc4;
+	// waveform mode index for WAVEFORM_MODE_GC8
+	int mode_gc8;
+	// waveform mode index for WAVEFORM_MODE_GC16
+	int mode_gc16;
+	// waveform mode index for WAVEFORM_MODE_GC16_FAST
+	int mode_gc16_fast;
+	// waveform mode index for WAVEFORM_MODE_GC32
+	int mode_gc32;
+	// waveform mode index for WAVEFORM_MODE_GL16
+	int mode_gl16;
+	// waveform mode index for WAVEFORM_MODE_GL16_FAST
+	int mode_gl16_fast;
+	// waveform mode index for WAVEFORM_MODE_A2
+	int mode_a2;
+	// waveform mode index for WAVEFORM_MODE_DU4
+	int mode_du4;
+	// waveform mode index for WAVEFORM_MODE_REAGL
+	int mode_reagl;
+	// waveform mode index for WAVEFORM_MODE_REAGLD
+	int mode_reagld;
+	// waveform mode index for WAVEFORM_MODE_GL16_INV
+	int mode_gl16_inv;
+	// waveform mode index for WAVEFORM_MODE_GL4
+	int mode_gl4;
+};
+*/
+
+/*
+struct mxcfb_rect
+{
+	uint32_t top;
+	uint32_t left;
+	uint32_t width;
+	uint32_t height;
+};
+*/
+
+/*
+struct mxcfb_update_marker_data
+{
+	uint32_t update_marker;
+	uint32_t collision_test;
+};
+*/
+
+/*
+struct mxcfb_alt_buffer_data
+{
+	uint32_t             phys_addr;
+	uint32_t             width;  // width of entire buffer
+	uint32_t             height; // height of entire buffer
+	// region within buffer to update
+	struct mxcfb_rect alt_update_region;
+};
+*/
+
+struct mxcfb_update_data_mtk
+{
+	struct mxcfb_rect            update_region;
+	/* which waveform to use for the update, du, gc4, gc8 gc16 etc */
+	uint32_t                     waveform_mode;
+	uint32_t                     update_mode; /* full update or partial update */
+	/* Unique number used by both application
+	 * and driver to identify an update
+	 */
+	uint32_t                     update_marker;
+	int                          temp;        /* For testing only, currently not use */
+	unsigned int                 flags;       /* one or more EPDC_FLAGs defined above */
+	int                          dither_mode; /* one of the dither modes defined above */
+	int                          quant_bit;   /* number of quantization bits for dithering */
+	/* alternative buffer for update
+	 * if the current frame buffer is not used.
+	 * Flag EPDC_FLAG_USE_ALT_BUFFER should be set in this case
+	 */
+	struct mxcfb_alt_buffer_data alt_buffer_data;
+	struct mxcfb_swipe_data      swipe_data;
+#if 1
+	/* start: lab126 added for backward compatible */
+	/*Lab126: Def bw waveform for hist analysis*/
+	uint32_t hist_bw_waveform_mode;
+	/*Lab126: Def gray waveform for hist analysis*/
+	uint32_t hist_gray_waveform_mode;
+	uint32_t ts_pxp;  /*debugging purpose: pxp starting time*/
+	uint32_t ts_epdc; /*debugging purpose: EPDC starting time*/
+			  /* end: lab126 added */
+#endif
+};
+
+/*
+struct mxcfb_nightmode_ctrl
+{
+	int disable;       // 1: disable; 0, enable
+	int start;         // reduced to level for gck16
+	int stride;        // back to original level gradually: default
+	int current_level; // current brighness setting
+};
+*/
+
+struct mxcfb_panel_info
+{
+	char wf_file_name[100];
+	int  vcom_value;
+	/* temperature */
+	int  temp;
+	/* temperature zone */
+	int  temp_zone;
+};
+
+/* ioctl commds */
+#define HWTCON_IOCTL_MAGIC_NUMBER 'F'
+
+/* Set the mapping between waveform types and waveform mode index */
+// Matches !Zelda w/ FW >= 5.5
+/*
+#define MXCFB_SET_WAVEFORM_MODES _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x2B, struct mxcfb_waveform_modes)
+*/
+
+/* Set the temperature for screen updates.
+ * If temperature specified is TEMP_USE_AMBIENT,
+ * use the temperature read from the temperature sensor.
+ * Otherwise use the temperature specified
+ */
+/*
+#define MXCFB_SET_TEMPERATURE _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x2C, int32_t)
+*/
+
+/*
+#define MXCFB_SET_AUTO_UPDATE_MODE _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x2D, uint32_t)
+*/
+
+/* Get the temperature currently used for screen updates.
+ * If the temperature set by command FB_SET_TEMPERATURE
+ * is not equal to TEMP_USE_AMBIENT,
+ * return that temperature value.
+ * Otherwise, return the temperature read from the temperature sensor
+ */
+/*
+#define MXCFB_GET_TEMPERATURE _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x38, int32_t)
+*/
+
+/* Send update info to update the Eink panel display */
+#define MXCFB_SEND_UPDATE_MTK _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x2E, struct mxcfb_update_data_mtk)
+
+/* Set the scheme that the FB driver should use in handling the FB_SEND_UPDATE.
+ * If the scheme is set to UPDATE_SCHEME_QUEUE,
+ * all FB_SEND_UPDATE requests should be queued up
+ * and processed indiviually in FIFO order.
+ * If the scheme is set to UPDATE_SCHEME_QUEUE_AND_MERGE,
+ * the driver should try to merge as many as possible
+ * those requests before sending them
+ * to IMGSYS or MMSYS
+ * if the flags in the mxcfb_update_data_mtk
+ * structure of those requests are identical.
+ */
+/*
+#define MXCFB_SET_UPDATE_SCHEME _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x32, uint32_t)
+*/
+
+/* Wait until the specified send_update request
+ * (specified by mxcfb_update_marker_data) is
+ * submitted to HWTCON to display or timeout (5 seconds)
+ */
+/*
+#define MXCFB_WAIT_FOR_UPDATE_SUBMISSION _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x37, uint32_t)
+*/
+
+/* Wait until the specified send_update request
+ * (specified by mxcfb_update_marker_data) is
+ * already completed (Eink panel updated) or timeout (5 seconds)
+ */
+/*
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE _IOWR(HWTCON_IOCTL_MAGIC_NUMBER, 0x2F, struct mxcfb_update_marker_data)
+*/
+
+/* Copy the content of the working buffer to user space */
+// Matches Zelda
+/*
+#define MXCFB_GET_WORK_BUFFER _IOWR(HWTCON_IOCTL_MAGIC_NUMBER, 0x34, unsigned long)
+*/
+
+/* Check if the waveform supports advanced algorithms.
+ * If yes, return WAVEFORM_TYPE_5BIT
+ * Otherwise WAVEFORM_TYPE_4BIT
+ */
+/*
+#define MXCFB_GET_WAVEFORM_TYPE _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x39, uint32_t)
+*/
+
+/* get EPD material type from dts */
+/*
+#define MXCFB_GET_MATERIAL_TYPE _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x3A, uint32_t)
+*/
+
+/* Set the front light control data for night mode.
+ * For each screen update in night mode,
+ * the front light needs to be set to the "start"
+ * brightness level before the update,
+ * and then raised back to the "current_level" gradually
+ * with increment of "stride" every milli second.
+ */
+// NOTE: Currently a NOP on MTK (and, indeed, unused by the framework).
+#define MXCFB_SET_NIGHTMODE_MTK _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x4A, struct mxcfb_nightmode_ctrl)
+
+/* Set the power down delay so the driver won't shut down the HWTCON immediately
+ * after all the updates are done.
+ * Instead it will wait until the "DELAY" time has elapsed to skip the
+ * powerdown and powerup sequences if an update comes before that.
+ */
+// Matches pre-KOA2
+/*
+#define MXCFB_SET_PWRDOWN_DELAY _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x30, int32_t)
+*/
+
+/* Get the power down delay set in MXCFB_SET_PWRDOWN_DELAY command */
+// Matches pre-KOA2
+/*
+#define MXCFB_GET_PWRDOWN_DELAY _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x31, int32_t)
+*/
+
+/* Pause updating the screen.
+ * Any MXCFB_SEND_UPDATE request will be discarded.
+ */
+/*
+#define MXCFB_SET_PAUSE _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x33, uint32_t)
+*/
+
+/* Resume updating the screen. */
+/*
+#define MXCFB_SET_RESUME _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x35, uint32_t)
+*/
+
+/* Get the screen updating flag set by MXCFB_SET_PAUSE or MXCFB_SET_RESUME */
+/*
+#define MXCFB_GET_PAUSE _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x34, uint32_t)
+*/
+
+#define MXCFB_GET_PANEL_INFO_MTK _IOR(HWTCON_IOCTL_MAGIC_NUMBER, 0x130, struct mxcfb_panel_info)
+
+/* Lightbox (aka halftone pattern) feature */
+// NOTE: Both of the regions control which parts of the screen will *not* be checkered!
+//       (i.e., for a top or bottom menu, you only need to set the first one).
+#define MXCFB_SET_HALFTONE_MTK _IOW('F', 0x4B, struct mxcfb_halftone_data)
+#define MAX_HALFTONE_REGION    2
+struct mxcfb_halftone_data
+{
+	struct mxcfb_rect region[MAX_HALFTONE_REGION];
+	/* Lightbox (aka Halftone Pattern) Mode: 0:None, */
+	/* 1:Turn on and change to default checker size */
+	/* Others: Custom, checker size = mode - 1 */
+	int               halftone_mode;
+};
+
+// NOTE: May write up to MAX_NUM_PENDING_UPDATES uint32_t starting at the address passed as the ioctl arg!
+//       On success, the return value is the amount of *bytes* actually written.
+//       i.e., pass it an uint32_t array of MAX_NUM_PENDING_UPDATES elements,
+//       and use the first element for the feature check if necessary ;).
+#define MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE_MTK _IOWR(HWTCON_IOCTL_MAGIC_NUMBER, 0x37, uint32_t)
+#define MAX_NUM_PENDING_UPDATES                64
+
+// So, create a custom union to make usage less confusing ;).
+typedef union
+{
+	uint32_t flag;
+	uint32_t markers[MAX_NUM_PENDING_UPDATES];
+} mxcfb_markers_data;
+
+/* Flag used in MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE. Caller of ioctl MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE
+    can set the first element of the u32 array to this value to query if the command is supported by the FB
+   driver. If supported, the return value will be 0, otherwise, -EINVAL */
+
+/*  Expand definition:
+          Return 0 to indicate REAGL_FEATURE_0 is supported
+          MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE is supported and and engne can apply REAGL waveform in case of collision,
+          return 3, indicate REAGL_FEATURE_1 is supported, Number 3 also means 3rd generation platform, Bellatrix, which can do REAGL with collision ,
+          otherwise, -EINVAL
+  */
+#define FLAG_NONE       0x00
+#define FLAG_CHECK      0xffffffff
+#define REAGL_FEATURE_0 0x00
+#define REAGL_FEATURE_1 0x01
+
+#define MXCFB_SET_UPDATE_FLAGS_MTK _IOW(HWTCON_IOCTL_MAGIC_NUMBER, 0x3B, uint32_t)
+#define MXCFB_GET_UPDATE_FLAGS_MTK _IOWR(HWTCON_IOCTL_MAGIC_NUMBER, 0x3C, uint32_t)
+
+/* fast mode flags */
+#define UPDATE_FLAGS_MASK_PARAM (0xFF << 24)
+
+// NOTE: This allows bypassing a waveform mode selection heuristic that will try to switch
+//       large enough DU/GL16/GC16_PARTIAL to REAGL.
+//       c.f., auto_waveform_replacement @ drivers/misc/mediatek/hwtcon_v2/hwtcon_extra_feature.c
+
+// This appears to be the default, and it *allows* the REAGL upgrades.
+#define UPDATE_FLAGS_FAST_MODE (0x80 << 24)
+
+#define UPDATE_FLAGS_FAST_MODE_PARAM     (0xFF)
+#define UPDATE_FLAGS_MODE_FAST_FLAG      1                                  /*< 0b0000000000000001 */
+#define UPDATE_FLAGS_MODE_FAST_FLAG_INIT (UPDATE_FLAGS_MODE_FAST_FLAG << 1) /*< 0b0000000000000010 */
+#define UPDATE_FLAGS_MODE_FAST_FLAG_STOP (UPDATE_FLAGS_MODE_FAST_FLAG << 2) /*< 0b0000000000000100 */
+#define UPDATE_FLAGS_MODE_FAST_FLAG_PAN  (UPDATE_FLAGS_MODE_FAST_FLAG << 3) /*< 0b0000000000001000 */
+#define UPDATE_FLAGS_MODE_FAST_FLAG_KB   (UPDATE_FLAGS_MODE_FAST_FLAG << 4) /*< 0b0000000000010000 */
+#define UPDATE_FLAGS_MODE_FAST_FLAG_HL   (UPDATE_FLAGS_MODE_FAST_FLAG << 5) /*< 0b0000000000100000 */
+
+#define MXC_UPDATE_FAST_MODE_FLAG 0x1
+
+#endif /* __HWTCON_IOCTL_CMD_H__ */

--- a/ffi-cdecl/include/mxcfb-kindle.h
+++ b/ffi-cdecl/include/mxcfb-kindle.h
@@ -58,183 +58,193 @@
 #ifndef __ASM_ARCH_MXCFB_H__
 #define __ASM_ARCH_MXCFB_H__
 
-//#include <linux/fb.h>
+#ifndef __KERNEL__
+#	include <stdint.h>
+#endif
 
-#define FB_SYNC_OE_LOW_ACT	0x80000000
-#define FB_SYNC_CLK_LAT_FALL	0x40000000
-#define FB_SYNC_DATA_INVERT	0x20000000
-#define FB_SYNC_CLK_IDLE_EN	0x10000000
-#define FB_SYNC_SHARP_MODE	0x08000000
-#define FB_SYNC_SWAP_RGB	0x04000000
+#include <linux/fb.h>
+
+#define FB_SYNC_OE_LOW_ACT   0x80000000
+#define FB_SYNC_CLK_LAT_FALL 0x40000000
+#define FB_SYNC_DATA_INVERT  0x20000000
+#define FB_SYNC_CLK_IDLE_EN  0x10000000
+#define FB_SYNC_SHARP_MODE   0x08000000
+#define FB_SYNC_SWAP_RGB     0x04000000
 /* PW2 */
-#define FB_ACCEL_TRIPLE_FLAG	0x00000000
-#define FB_ACCEL_DOUBLE_FLAG	0x00000001
+#define FB_ACCEL_TRIPLE_FLAG 0x00000000
+#define FB_ACCEL_DOUBLE_FLAG 0x00000001
 
-struct mxcfb_gbl_alpha {
+struct mxcfb_gbl_alpha
+{
 	int enable;
 	int alpha;
 };
 
-struct mxcfb_loc_alpha {
-	int enable;
-	int alpha_in_pixel;
+struct mxcfb_loc_alpha
+{
+	int           enable;
+	int           alpha_in_pixel;
 	unsigned long alpha_phy_addr0;
 	unsigned long alpha_phy_addr1;
 };
 
-struct mxcfb_color_key {
-	int enable;
-	__u32 color_key;
+struct mxcfb_color_key
+{
+	int      enable;
+	uint32_t color_key;
 };
 
-struct mxcfb_pos {
-	__u16 x;
-	__u16 y;
+struct mxcfb_pos
+{
+	uint16_t x;
+	uint16_t y;
 };
 
-struct mxcfb_gamma {
+struct mxcfb_gamma
+{
 	int enable;
 	int constk[16];
 	int slopek[16];
 };
 
 /* KOA2 */
-struct mxcfb_gpu_split_fmt {
+struct mxcfb_gpu_split_fmt
+{
 	struct fb_var_screeninfo var;
-	unsigned long offset;
+	unsigned long            offset;
 };
 
-struct mxcfb_rect {
-	__u32 top;
-	__u32 left;
-	__u32 width;
-	__u32 height;
+struct mxcfb_rect
+{
+	uint32_t top;
+	uint32_t left;
+	uint32_t width;
+	uint32_t height;
 };
 
-#define GRAYSCALE_8BIT				0x1
-#define GRAYSCALE_8BIT_INVERTED			0x2
+#define GRAYSCALE_8BIT          0x1
+#define GRAYSCALE_8BIT_INVERTED 0x2
 
 /* PW2 */
-#define GRAYSCALE_4BIT				0x3
-#define GRAYSCALE_4BIT_INVERTED			0x4
+#define GRAYSCALE_4BIT          0x3
+#define GRAYSCALE_4BIT_INVERTED 0x4
 
-#define AUTO_UPDATE_MODE_REGION_MODE		0
-#define AUTO_UPDATE_MODE_AUTOMATIC_MODE		1
+#define AUTO_UPDATE_MODE_REGION_MODE    0
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE 1
 
 /* Touch/PW1, Gone w/ KOA2 */
-#define AUTO_UPDATE_MODE_AUTOMATIC_MODE_FULL	AUTO_UPDATE_MODE_AUTOMATIC_MODE /* Lab126 */
-#define AUTO_UPDATE_MODE_AUTOMATIC_MODE_PART	2 /* Lab126 */
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE_FULL AUTO_UPDATE_MODE_AUTOMATIC_MODE /* Lab126 */
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE_PART 2                               /* Lab126 */
 
-#define UPDATE_SCHEME_SNAPSHOT			0
-#define UPDATE_SCHEME_QUEUE			1
-#define UPDATE_SCHEME_QUEUE_AND_MERGE		2
+#define UPDATE_SCHEME_SNAPSHOT        0
+#define UPDATE_SCHEME_QUEUE           1
+#define UPDATE_SCHEME_QUEUE_AND_MERGE 2
 
-#define UPDATE_MODE_PARTIAL			0x0
-#define UPDATE_MODE_FULL			0x1
+#define UPDATE_MODE_PARTIAL 0x0
+#define UPDATE_MODE_FULL    0x1
 
 /* Supported waveform modes */
-#define WAVEFORM_MODE_INIT			0x0	/* Screen goes to white (clears) */
-#define WAVEFORM_MODE_DU			0x1	/* Grey->white/grey->black */
-#define WAVEFORM_MODE_GC16			0x2	/* High fidelity (flashing) */
-#define WAVEFORM_MODE_GC4			WAVEFORM_MODE_GC16 /* For compatibility */
-#define WAVEFORM_MODE_GC16_FAST			0x3	/* Medium fidelity */
-#define WAVEFORM_MODE_A2			0x4	/* Faster but even lower fidelity */
-#define WAVEFORM_MODE_GL16			0x5	/* High fidelity from white transition */
-#define WAVEFORM_MODE_GL16_FAST			0x6	/* Medium fidelity from white transition */
+#define WAVEFORM_MODE_INIT      0x0                /* Screen goes to white (clears) */
+#define WAVEFORM_MODE_DU        0x1                /* Grey->white/grey->black */
+#define WAVEFORM_MODE_GC16      0x2                /* High fidelity (flashing) */
+#define WAVEFORM_MODE_GC4       WAVEFORM_MODE_GC16 /* For compatibility */
+#define WAVEFORM_MODE_GC16_FAST 0x3                /* Medium fidelity */
+#define WAVEFORM_MODE_A2        0x4                /* Faster but even lower fidelity */
+#define WAVEFORM_MODE_GL16      0x5                /* High fidelity from white transition */
+#define WAVEFORM_MODE_GL16_FAST 0x6                /* Medium fidelity from white transition */
 
 /* FW >= 5.3 */
-#define WAVEFORM_MODE_DU4			0x7	/* Medium fidelity 4 level of gray direct update */
+#define WAVEFORM_MODE_DU4 0x7 /* Medium fidelity 4 level of gray direct update */
 
 /* PW2/KT2/KV */
-#define WAVEFORM_MODE_REAGL			0x8	/* Ghost compensation waveform */
-#define WAVEFORM_MODE_REAGLD			0x9	/* Ghost compensation waveform with dithering */
+#define WAVEFORM_MODE_REAGL  0x8 /* Ghost compensation waveform */
+#define WAVEFORM_MODE_REAGLD 0x9 /* Ghost compensation waveform with dithering */
 
 /* KT2/KV */
-#define WAVEFORM_MODE_GL4			0xA	/* 2-bit from white transition */
-#define WAVEFORM_MODE_GL16_INV			0xB	/* High fidelity for black transition */
+#define WAVEFORM_MODE_GL4      0xA /* 2-bit from white transition */
+#define WAVEFORM_MODE_GL16_INV 0xB /* High fidelity for black transition */
 
 /* KOA2... Which wonderfully broke backward compatibility. Yay. */
 //#define WAVEFORM_MODE_INIT			0x0
 //#define WAVEFORM_MODE_DU			0x1
 //#define WAVEFORM_MODE_GC16			0x2
-#define WAVEFORM_MODE_ZELDA_GL16		0x3
+#define WAVEFORM_MODE_ZELDA_GL16 0x3
 
-#define WAVEFORM_MODE_ZELDA_A2			0x6
+#define WAVEFORM_MODE_ZELDA_A2   0x6
 //#define WAVEFORM_MODE_ZELDA_DU4			0x7
-#define WAVEFORM_MODE_ZELDA_LAST			0x7
+#define WAVEFORM_MODE_ZELDA_LAST 0x7
 
-#define WAVEFORM_MODE_ZELDA_REAGL		WAVEFORM_MODE_ZELDA_GLR16
-#define WAVEFORM_MODE_ZELDA_REAGLD		WAVEFORM_MODE_ZELDA_GLD16
+#define WAVEFORM_MODE_ZELDA_REAGL  WAVEFORM_MODE_ZELDA_GLR16
+#define WAVEFORM_MODE_ZELDA_REAGLD WAVEFORM_MODE_ZELDA_GLD16
 
-#define WAVEFORM_MODE_ZELDA_GC16_FAST		WAVEFORM_MODE_GC16
-#define WAVEFORM_MODE_ZELDA_GL16_FAST		WAVEFORM_MODE_ZELDA_GL16
-#define WAVEFORM_MODE_ZELDA_GLR16		4
-#define WAVEFORM_MODE_ZELDA_GLD16		5
-#define WAVEFORM_MODE_ZELDA_GCK16		8
-#define WAVEFORM_MODE_ZELDA_GLKW16		9
+#define WAVEFORM_MODE_ZELDA_GC16_FAST WAVEFORM_MODE_GC16
+#define WAVEFORM_MODE_ZELDA_GL16_FAST WAVEFORM_MODE_ZELDA_GL16
+#define WAVEFORM_MODE_ZELDA_GLR16     4
+#define WAVEFORM_MODE_ZELDA_GLD16     5
+#define WAVEFORM_MODE_ZELDA_GCK16     8
+#define WAVEFORM_MODE_ZELDA_GLKW16    9
 
 /* for backward compatible */
-#define WAVEFORM_MODE_ZELDA_GL4			WAVEFORM_MODE_ZELDA_GL16
-#define WAVEFORM_MODE_ZELDA_GL16_INV		WAVEFORM_MODE_ZELDA_GL16
+#define WAVEFORM_MODE_ZELDA_GL4      WAVEFORM_MODE_ZELDA_GL16
+#define WAVEFORM_MODE_ZELDA_GL16_INV WAVEFORM_MODE_ZELDA_GL16
 
-
-#define WAVEFORM_MODE_AUTO			257
+#define WAVEFORM_MODE_AUTO 257
 
 /* Display temperature */
-#define TEMP_USE_AMBIENT			0x1000
+#define TEMP_USE_AMBIENT 0x1000
 /* Gone w/ KOA2 */
-#define TEMP_USE_PAPYRUS			0x1001
+#define TEMP_USE_PAPYRUS 0x1001
 
 /* PW2, Gone w/ KOA2 */
-#define TEMP_USE_AUTO				0x1001
+#define TEMP_USE_AUTO 0x1001
 
 /* KOA2... Once again breaking backward compat... (NOTE: TEMP_USE_AMBIENT hasn't budged, though) */
-#define TEMP_USE_ZELDA_AUTO			TEMP_USE_AMBIENT
+#define TEMP_USE_ZELDA_AUTO TEMP_USE_AMBIENT
 
 /* PXP Operations */
-#define EPDC_FLAG_ENABLE_INVERSION		0x01
-#define EPDC_FLAG_FORCE_MONOCHROME		0x02
-#define EPDC_FLAG_USE_CMAP			0x04
-#define EPDC_FLAG_USE_ALT_BUFFER		0x100
+#define EPDC_FLAG_ENABLE_INVERSION 0x01
+#define EPDC_FLAG_FORCE_MONOCHROME 0x02
+#define EPDC_FLAG_USE_CMAP         0x04
+#define EPDC_FLAG_USE_ALT_BUFFER   0x100
 
 /* PW2 */
-#define EPDC_FLAG_TEST_COLLISION		0x200
-#define EPDC_FLAG_GROUP_UPDATE			0x400
+#define EPDC_FLAG_TEST_COLLISION 0x200
+#define EPDC_FLAG_GROUP_UPDATE   0x400
 
 /* Gone w/ KOA2 */
-#define EPDC_FLAG_FORCE_Y2			0x800
-#define EPDC_FLAG_USE_REAGLD			0x1000
+#define EPDC_FLAG_FORCE_Y2   0x800
+#define EPDC_FLAG_USE_REAGLD 0x1000
 
-#define EPDC_FLAG_USE_DITHERING_Y1		0x2000
+#define EPDC_FLAG_USE_DITHERING_Y1 0x2000
 
 /* Renamed w/ KOA2, see next block */
-#define EPDC_FLAG_USE_DITHERING_Y2		0x4000
-#define EPDC_FLAG_USE_DITHERING_Y4		0x8000
+#define EPDC_FLAG_USE_DITHERING_Y2 0x4000
+#define EPDC_FLAG_USE_DITHERING_Y4 0x8000
 
 /* KOA2... Once again breaking backward compat... */
-#define EPDC_FLAG_USE_ZELDA_DITHERING_Y4	0x4000
-#define EPDC_FLAG_USE_ZELDA_REGAL		0x8000
-
+#define EPDC_FLAG_USE_ZELDA_DITHERING_Y4 0x4000
+#define EPDC_FLAG_USE_ZELDA_REGAL        0x8000
 
 /* PW2 */
 /* Waveform type as return by MXCFB_GET_WAVEFORM_TYPE ioctl */
 /* This indicates to user-space what is supported by the waveform */
-#define WAVEFORM_TYPE_4BIT			0x1
-#define WAVEFORM_TYPE_5BIT			(WAVEFORM_TYPE_4BIT << 1)
+#define WAVEFORM_TYPE_4BIT 0x1
+#define WAVEFORM_TYPE_5BIT (WAVEFORM_TYPE_4BIT << 1)
 
 /* KT2/KV */
 /* Display material */
-#define EPD_MATERIAL_V220			0x00
-#define EPD_MATERIAL_V320			0x01
+#define EPD_MATERIAL_V220 0x00
+#define EPD_MATERIAL_V320 0x01
 
 /* KOA2 */
-#define EPD_MATERIAL_CARTA_1_2			0x02
+#define EPD_MATERIAL_CARTA_1_2 0x02
 
 /* KOA3 */
-#define EPD_MATERIAL_V400			0x03
+#define EPD_MATERIAL_V400 0x03
 
 /* KOA2 */
-enum mxcfb_dithering_mode {
+enum mxcfb_dithering_mode
+{
 	EPDC_FLAG_USE_DITHERING_PASSTHROUGH = 0x0,
 	EPDC_FLAG_USE_DITHERING_FLOYD_STEINBERG,
 	EPDC_FLAG_USE_DITHERING_ATKINSON,
@@ -243,81 +253,87 @@ enum mxcfb_dithering_mode {
 	EPDC_FLAG_USE_DITHERING_MAX,
 };
 
-#define FB_POWERDOWN_DISABLE			-1
+#define FB_POWERDOWN_DISABLE      -1
 /* PW4 */
-#define FB_POWERDOWN_DELAY_MIN_MS		0
+#define FB_POWERDOWN_DELAY_MIN_MS 0
 
-struct mxcfb_alt_buffer_data {
-	__u32 phys_addr;
-	__u32 width;	/* width of entire buffer */
-	__u32 height;	/* height of entire buffer */
-	struct mxcfb_rect alt_update_region;	/* region within buffer to update */
+struct mxcfb_alt_buffer_data
+{
+	uint32_t          phys_addr;
+	uint32_t          width;             /* width of entire buffer */
+	uint32_t          height;            /* height of entire buffer */
+	struct mxcfb_rect alt_update_region; /* region within buffer to update */
 };
 
-struct mxcfb_update_data {
-	struct mxcfb_rect update_region;
-	__u32 waveform_mode;
-	__u32 update_mode;
-	__u32 update_marker;
-	__u32 hist_bw_waveform_mode;    /*Lab126: Def bw waveform for hist analysis*/
-	__u32 hist_gray_waveform_mode;  /*Lab126: Def gray waveform for hist analysis*/
-	int temp;
-	unsigned int flags;
+struct mxcfb_update_data
+{
+	struct mxcfb_rect            update_region;
+	uint32_t                     waveform_mode;
+	uint32_t                     update_mode;
+	uint32_t                     update_marker;
+	uint32_t                     hist_bw_waveform_mode;   /*Lab126: Def bw waveform for hist analysis*/
+	uint32_t                     hist_gray_waveform_mode; /*Lab126: Def gray waveform for hist analysis*/
+	int                          temp;
+	unsigned int                 flags;
 	struct mxcfb_alt_buffer_data alt_buffer_data;
 };
 
 /* KOA2... Once again breaking backward compat. */
-struct mxcfb_update_data_zelda {
-	struct mxcfb_rect update_region;
-	__u32 waveform_mode;
-	__u32 update_mode;
-	__u32 update_marker;
-	int temp;
-	unsigned int flags;
-	int dither_mode;
-	int quant_bit;
+struct mxcfb_update_data_zelda
+{
+	struct mxcfb_rect            update_region;
+	uint32_t                     waveform_mode;
+	uint32_t                     update_mode;
+	uint32_t                     update_marker;
+	int                          temp;
+	unsigned int                 flags;
+	int                          dither_mode;
+	int                          quant_bit;
 	struct mxcfb_alt_buffer_data alt_buffer_data;
 	/* start: lab126 added for backward compatible */
-	__u32 hist_bw_waveform_mode;    /*Lab126: Def bw waveform for hist analysis*/
-	__u32 hist_gray_waveform_mode;  /*Lab126: Def gray waveform for hist analysis*/
-	__u32 ts_pxp;   /*debugging purpose: pxp starting time*/
-	__u32 ts_epdc;  /*debugging purpose: EPDC starting time*/
-	/* end: lab126 added */
+	uint32_t                     hist_bw_waveform_mode;   /*Lab126: Def bw waveform for hist analysis*/
+	uint32_t                     hist_gray_waveform_mode; /*Lab126: Def gray waveform for hist analysis*/
+	uint32_t                     ts_pxp;                  /*debugging purpose: pxp starting time*/
+	uint32_t                     ts_epdc;                 /*debugging purpose: EPDC starting time*/
+							      /* end: lab126 added */
 };
 
 /* PW4... Guess what? :D */
-struct mxcfb_update_data_rex {
-	struct mxcfb_rect update_region;
-	__u32 waveform_mode;
-	__u32 update_mode;
-	__u32 update_marker;
-	int temp;
-	unsigned int flags;
-	int dither_mode;
-	int quant_bit;
+struct mxcfb_update_data_rex
+{
+	struct mxcfb_rect            update_region;
+	uint32_t                     waveform_mode;
+	uint32_t                     update_mode;
+	uint32_t                     update_marker;
+	int                          temp;
+	unsigned int                 flags;
+	int                          dither_mode;
+	int                          quant_bit;
 	struct mxcfb_alt_buffer_data alt_buffer_data;
 	/* start: lab126 added for backward compatible */
-	__u32 hist_bw_waveform_mode;    /*Lab126: Def bw waveform for hist analysis*/
-	__u32 hist_gray_waveform_mode;  /*Lab126: Def gray waveform for hist analysis*/
-	/* end: lab126 added */
+	uint32_t                     hist_bw_waveform_mode;   /*Lab126: Def bw waveform for hist analysis*/
+	uint32_t                     hist_gray_waveform_mode; /*Lab126: Def gray waveform for hist analysis*/
+							      /* end: lab126 added */
 };
 
 /* PW2 */
-struct mxcfb_update_marker_data {
-	__u32 update_marker;
-	__u32 collision_test;
+struct mxcfb_update_marker_data
+{
+	uint32_t update_marker;
+	uint32_t collision_test;
 };
 
 /* This is only used in kindle firmware 5.0, later version (5.1) has changed
  * the struct to mxcfb_update_data (see above).
  * We don't actually support this, it's just kept here for shit'n giggles ;) */
-struct mxcfb_update_data_50x {
-	struct mxcfb_rect update_region;
-	__u32 waveform_mode;
-	__u32 update_mode;
-	__u32 update_marker;
-	int temp;
-	unsigned int flags;
+struct mxcfb_update_data_50x
+{
+	struct mxcfb_rect            update_region;
+	uint32_t                     waveform_mode;
+	uint32_t                     update_mode;
+	uint32_t                     update_marker;
+	int                          temp;
+	unsigned int                 flags;
 	struct mxcfb_alt_buffer_data alt_buffer_data;
 };
 
@@ -325,9 +341,63 @@ struct mxcfb_update_data_50x {
  * Structure used to define waveform modes for driver
  * Needed for driver to perform auto-waveform selection
  */
-/* NOTE: Trimmed down w/ KOA2, see next block */
+/* NOTE: Trimmed down w/ KOA2, see the _zelda struct */
 /* NOTE: PW4 got 'em back by default... */
-struct mxcfb_waveform_modes {
+/* Was mxcfb_waveform_modes, we've split it into each variant for strace's benefit. */
+struct mxcfb_waveform_modes
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc16_fast;
+	int mode_gc32;
+	int mode_gl16;
+	int mode_gl16_fast;
+	int mode_a2;
+};
+
+struct mxcfb_waveform_modes_fw53
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc16_fast;
+	int mode_gc32;
+	int mode_gl16;
+	int mode_gl16_fast;
+	int mode_a2;
+
+	int mode_du4;
+};
+
+struct mxcfb_waveform_modes_fw54
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc16_fast;
+	int mode_gc32;
+	int mode_gl16;
+	int mode_gl16_fast;
+	int mode_a2;
+
+	int mode_du4;
+
+	/*
+	 * reagl_flow
+	 */
+	int mode_reagl;
+	int mode_reagld;
+};
+
+struct mxcfb_waveform_modes_fw55
+{
 	int mode_init;
 	int mode_du;
 	int mode_gc4;
@@ -342,9 +412,6 @@ struct mxcfb_waveform_modes {
 	int mode_du4;
 
 	/* PW2 */
-	/*
-	 * reagl_flow
-	 */
 	int mode_reagl;
 	int mode_reagld;
 
@@ -354,7 +421,8 @@ struct mxcfb_waveform_modes {
 };
 
 /* KOA2... Breaking backward compat. */
-struct mxcfb_waveform_modes_zelda {
+struct mxcfb_waveform_modes_zelda
+{
 	int mode_init;
 	int mode_du;
 	int mode_gc4;
@@ -368,80 +436,84 @@ struct mxcfb_waveform_modes_zelda {
  * Structure used to define a 5*3 matrix of parameters for
  * setting IPU DP CSC module related to this framebuffer.
  */
-struct mxcfb_csc_matrix {
+struct mxcfb_csc_matrix
+{
 	int param[5][3];
 };
 
-#define MXCFB_WAIT_FOR_VSYNC			_IOW('F', 0x20, u_int32_t)
-#define MXCFB_SET_GBL_ALPHA			_IOW('F', 0x21, struct mxcfb_gbl_alpha)
-#define MXCFB_SET_CLR_KEY			_IOW('F', 0x22, struct mxcfb_color_key)
-#define MXCFB_SET_OVERLAY_POS			_IOWR('F', 0x24, struct mxcfb_pos)
-#define MXCFB_GET_FB_IPU_CHAN			_IOR('F', 0x25, u_int32_t)
-#define MXCFB_SET_LOC_ALPHA			_IOWR('F', 0x26, struct mxcfb_loc_alpha)
-#define MXCFB_SET_LOC_ALP_BUF			_IOW('F', 0x27, unsigned long)
-#define MXCFB_SET_GAMMA				_IOW('F', 0x28, struct mxcfb_gamma)
-#define MXCFB_GET_FB_IPU_DI			_IOR('F', 0x29, u_int32_t)
-#define MXCFB_GET_DIFMT				_IOR('F', 0x2A, u_int32_t)
-#define MXCFB_GET_FB_BLANK			_IOR('F', 0x2B, u_int32_t)
-#define MXCFB_SET_DIFMT				_IOW('F', 0x2C, u_int32_t)
+#define MXCFB_WAIT_FOR_VSYNC  _IOW('F', 0x20, uint32_t)
+#define MXCFB_SET_GBL_ALPHA   _IOW('F', 0x21, struct mxcfb_gbl_alpha)
+#define MXCFB_SET_CLR_KEY     _IOW('F', 0x22, struct mxcfb_color_key)
+#define MXCFB_SET_OVERLAY_POS _IOWR('F', 0x24, struct mxcfb_pos)
+#define MXCFB_GET_FB_IPU_CHAN _IOR('F', 0x25, uint32_t)
+#define MXCFB_SET_LOC_ALPHA   _IOWR('F', 0x26, struct mxcfb_loc_alpha)
+#define MXCFB_SET_LOC_ALP_BUF _IOW('F', 0x27, unsigned long)
+#define MXCFB_SET_GAMMA       _IOW('F', 0x28, struct mxcfb_gamma)
+#define MXCFB_GET_FB_IPU_DI   _IOR('F', 0x29, uint32_t)
+#define MXCFB_GET_DIFMT       _IOR('F', 0x2A, uint32_t)
+#define MXCFB_GET_FB_BLANK    _IOR('F', 0x2B, uint32_t)
+#define MXCFB_SET_DIFMT       _IOW('F', 0x2C, uint32_t)
 
 /* PW2 */
-#define MXCFB_CSC_UPDATE			_IOW('F', 0x2D, struct mxcfb_csc_matrix)
+#define MXCFB_CSC_UPDATE _IOW('F', 0x2D, struct mxcfb_csc_matrix)
 
 /* KOA2 */
-#define MXCFB_SET_GPU_SPLIT_FMT        _IOW('F', 0x2F, struct mxcfb_gpu_split_fmt)
-#define MXCFB_SET_PREFETCH     _IOW('F', 0x30, int)
-#define MXCFB_GET_PREFETCH     _IOR('F', 0x31, int)
+#define MXCFB_SET_GPU_SPLIT_FMT _IOW('F', 0x2F, struct mxcfb_gpu_split_fmt)
+#define MXCFB_SET_PREFETCH      _IOW('F', 0x30, int)
+#define MXCFB_GET_PREFETCH      _IOR('F', 0x31, int)
 
 /* IOCTLs for E-ink panel updates */
-#define MXCFB_SET_WAVEFORM_MODES		_IOW('F', 0x2B, struct mxcfb_waveform_modes)
-#define MXCFB_SET_TEMPERATURE			_IOW('F', 0x2C, int32_t)
-#define MXCFB_SET_AUTO_UPDATE_MODE		_IOW('F', 0x2D, __u32)
-#define MXCFB_SEND_UPDATE			_IOW('F', 0x2E, struct mxcfb_update_data)
+#define MXCFB_SET_WAVEFORM_MODES       _IOW('F', 0x2B, struct mxcfb_waveform_modes)
+#define MXCFB_SET_WAVEFORM_MODES_FW53  _IOW('F', 0x2B, struct mxcfb_waveform_modes_fw53)
+#define MXCFB_SET_WAVEFORM_MODES_FW54  _IOW('F', 0x2B, struct mxcfb_waveform_modes_fw54)
+#define MXCFB_SET_WAVEFORM_MODES_FW55  _IOW('F', 0x2B, struct mxcfb_waveform_modes_fw55)
+#define MXCFB_SET_WAVEFORM_MODES_ZELDA _IOW('F', 0x2B, struct mxcfb_waveform_modes_zelda)
+
+#define MXCFB_SET_TEMPERATURE      _IOW('F', 0x2C, int32_t)
+#define MXCFB_SET_AUTO_UPDATE_MODE _IOW('F', 0x2D, uint32_t)
+#define MXCFB_SEND_UPDATE          _IOW('F', 0x2E, struct mxcfb_update_data)
 
 /* KOA2, because backward compat went kablooey */
-#define MXCFB_SET_WAVEFORM_MODES_ZELDA		_IOW('F', 0x2B, struct mxcfb_waveform_modes_zelda)
-#define MXCFB_SEND_UPDATE_ZELDA			_IOW('F', 0x2E, struct mxcfb_update_data_zelda)
+#define MXCFB_SEND_UPDATE_ZELDA _IOW('F', 0x2E, struct mxcfb_update_data_zelda)
 
 /* PW4, same dealio... */
-#define MXCFB_SEND_UPDATE_REX			_IOW('F', 0x2E, struct mxcfb_update_data_rex)
-
+#define MXCFB_SEND_UPDATE_REX _IOW('F', 0x2E, struct mxcfb_update_data_rex)
 
 /* This evolved on the PW2... Rename the Touch/PW1 constant to differentiate the two. */
-#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PEARL	_IOW('F', 0x2F, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PEARL _IOW('F', 0x2F, uint32_t)
 /* PW2 */
-#define MXCFB_WAIT_FOR_UPDATE_COMPLETE		_IOWR('F', 0x2F, struct mxcfb_update_marker_data)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE       _IOWR('F', 0x2F, struct mxcfb_update_marker_data)
 
-#define MXCFB_SET_PWRDOWN_DELAY			_IOW('F', 0x30, int32_t)
-#define MXCFB_GET_PWRDOWN_DELAY			_IOR('F', 0x31, int32_t)
-#define MXCFB_SET_UPDATE_SCHEME			_IOW('F', 0x32, __u32)
-#define MXCFB_SET_PAUSE				_IOW('F', 0x33, __u32)
-#define MXCFB_GET_PAUSE				_IOW('F', 0x34, __u32)
-#define MXCFB_SET_RESUME			_IOW('F', 0x35, __u32)
+#define MXCFB_SET_PWRDOWN_DELAY _IOW('F', 0x30, int32_t)
+#define MXCFB_GET_PWRDOWN_DELAY _IOR('F', 0x31, int32_t)
+#define MXCFB_SET_UPDATE_SCHEME _IOW('F', 0x32, uint32_t)
+#define MXCFB_SET_PAUSE         _IOW('F', 0x33, uint32_t)
+#define MXCFB_GET_PAUSE         _IOW('F', 0x34, uint32_t)
+#define MXCFB_SET_RESUME        _IOW('F', 0x35, uint32_t)
 
 /* KOA2 */
-#define MXCFB_GET_WORK_BUFFER_ZELDA		_IOWR('F', 0x34, unsigned long)
-#define MXCFB_DISABLE_EPDC_ACCESS		_IO('F', 0x35)
-#define MXCFB_ENABLE_EPDC_ACCESS		_IO('F', 0x36)
+#define MXCFB_GET_WORK_BUFFER_ZELDA _IOWR('F', 0x34, unsigned long)
+#define MXCFB_DISABLE_EPDC_ACCESS   _IO('F', 0x35)
+#define MXCFB_ENABLE_EPDC_ACCESS    _IO('F', 0x36)
 
 /* Touch/PW1 */
-#define MXCFB_CLEAR_UPDATE_QUEUE		_IOW('F', 0x36, __u32)
+#define MXCFB_CLEAR_UPDATE_QUEUE _IOW('F', 0x36, uint32_t)
 /* PW2 */
-#define MXCFB_GET_WORK_BUFFER			_IOWR('F', 0x36, unsigned long)
+#define MXCFB_GET_WORK_BUFFER    _IOWR('F', 0x36, unsigned long)
 
-#define MXCFB_WAIT_FOR_UPDATE_SUBMISSION	_IOW('F', 0x37, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_SUBMISSION _IOW('F', 0x37, uint32_t)
 
 /* FW >= 5.3 */
-#define MXCFB_GET_TEMPERATURE			_IOR('F', 0x38, int32_t)
+#define MXCFB_GET_TEMPERATURE _IOR('F', 0x38, int32_t)
 
 /* PW2 */
-#define MXCFB_GET_WAVEFORM_TYPE			_IOR('F', 0x39, __u32)
+#define MXCFB_GET_WAVEFORM_TYPE _IOR('F', 0x39, uint32_t)
 
 /* KT2/KV */
-#define MXCFB_GET_MATERIAL_TYPE			_IOR('F', 0x3A, __u32)
+#define MXCFB_GET_MATERIAL_TYPE _IOR('F', 0x3A, uint32_t)
 
 /* Deprecated IOCTL for E-ink panel updates, kindle firmware version == 5.0 */
-#define MXCFB_SEND_UPDATE_50X			_IOW('F', 0x2E, struct mxcfb_update_data_50x)
+#define MXCFB_SEND_UPDATE_50X _IOW('F', 0x2E, struct mxcfb_update_data_50x)
 
 /* KOA2 & PW4 */
 /* before update with gck16, reduce bl to zero and turn back to original after */
@@ -449,30 +521,34 @@ struct mxcfb_csc_matrix {
 /* cognac              4               112             16              (112-4)/16=6.75 */
 /* moonshine   217             1153    (1153-217)/6.75=138     6.75*/
 /* Use same steps as Cognac */
-#define NIGHTMODE_STRIDE_DEFAULT 16  /*default*/
+#define NIGHTMODE_STRIDE_DEFAULT     16 /*default*/
 /* PW4 */
-#define NIGHTMODE_STRIDE_DEFAULT_REX 138  /*default*/
-struct mxcfb_nightmode_ctrl {
-	int disable; /*1: disable; 0, enable */
-	int start; /* reduced to level for gck16 */
-	int stride; /* back to original level gradually: default */
+#define NIGHTMODE_STRIDE_DEFAULT_REX 138 /*default*/
+struct mxcfb_nightmode_ctrl
+{
+	int disable;       /* 1: disable; 0, enable */
+	int start;         /* reduced to level for gck16 */
+	int stride;        /* back to original level gradually: default */
 	int current_level; /* current brighness setting */
 };
 
-#define MXCFB_SET_NIGHTMODE			_IOR('F', 0x4A, __u32)
-
+// NOTE: Should most likely be a pointer to an mxcfb_nightmode_ctrl struct, like on MTK...
+//       I don't *think* anything uses this in practice, though...
+#define MXCFB_SET_NIGHTMODE _IOR('F', 0x4A, uint32_t)
 
 #ifdef __KERNEL__
 
 /* PW2 */
-#define EHWFAULT 901
+#	define EHWFAULT 901
 
 extern struct fb_videomode mxcfb_modedb[];
-extern int mxcfb_modedb_sz;
+extern int                 mxcfb_modedb_sz;
 
 /* PW2 */
-enum panel_modes {
-	PANEL_MODE_E60_PINOT = 0,	// NOTE: Was PANEL_MODE_E60_CELESTE in PW2 kernels, appropriately switched to PINOT in 5.6.0.1
+enum panel_modes
+{
+	PANEL_MODE_E60_PINOT =
+	    0,    // NOTE: Was PANEL_MODE_E60_CELESTE in PW2 kernels, appropriately switched to PINOT in 5.6.0.1
 	PANEL_MODE_EN060OC1_3CE_225,
 	PANEL_MODE_ED060TC1_3CE,
 
@@ -484,24 +560,24 @@ enum panel_modes {
 };
 
 /* PW2 */
-enum {
+enum
+{
 	MXC_DISP_SPEC_DEV = 0,
-	MXC_DISP_DDC_DEV = 1,
+	MXC_DISP_DDC_DEV  = 1,
 };
 
-enum {
+enum
+{
 	MXCFB_REFRESH_OFF,
 	MXCFB_REFRESH_AUTO,
 	MXCFB_REFRESH_PARTIAL,
 };
 
-int mxcfb_set_refresh_mode(struct fb_info *fbi, int mode,
-			   struct mxcfb_rect *update_region);
+int mxcfb_set_refresh_mode(struct fb_info* fbi, int mode, struct mxcfb_rect* update_region);
 int mxc_elcdif_frame_addr_setup(dma_addr_t phys);
 
 /* PW2 */
-void mxcfb_elcdif_register_mode(const struct fb_videomode *modedb,
-		int num_modes, int dev_mode);
+void mxcfb_elcdif_register_mode(const struct fb_videomode* modedb, int num_modes, int dev_mode);
 
-#endif				/* __KERNEL__ */
+#endif /* __KERNEL__ */
 #endif

--- a/ffi-cdecl/include/mxcfb-kobo.h
+++ b/ffi-cdecl/include/mxcfb-kobo.h
@@ -301,30 +301,9 @@ struct mxcfb_update_marker_data
  */
 /*
  * NOTE: Once again, Mark 7 renamed some stuff
- *       Was mxcfb_waveform_modes
+ *       Was mxcfb_waveform_modes,
+ *       we've split it into each variant for strace's benefit.
  */
-struct mxcfb_waveform_modes_ntx
-{
-	int mode_init;
-	int mode_du;
-	int mode_gc4;
-	int mode_gc8;
-	int mode_gc16;
-	int mode_gc32;
-	/* Aura */
-	int mode_gl16;
-	int mode_a2;
-
-	int mode_aa;
-	int mode_aad;
-
-	/* Mark 9 */
-	int mode_du4;
-	int mode_gck16;
-	int mode_glkw16;
-};
-
-/* Mark 7 */
 struct mxcfb_waveform_modes
 {
 	int mode_init;
@@ -333,6 +312,59 @@ struct mxcfb_waveform_modes
 	int mode_gc8;
 	int mode_gc16;
 	int mode_gc32;
+};
+
+struct mxcfb_waveform_modes_mk5
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+
+	int mode_a2;
+	int mode_gl16;
+	/*
+         * reagl_flow
+         */
+	int mode_aa;
+	int mode_aad;
+};
+
+// NOTE: Same total size as the mk5 variant,
+//       but gl16 & a2 are inverted... -_-".
+struct mxcfb_waveform_modes_mk7
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+	int mode_gl16;
+	int mode_a2;
+
+	int mode_aa;
+	int mode_aad;
+};
+
+struct mxcfb_waveform_modes_mk9
+{
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+	int mode_gl16;
+	int mode_a2;
+
+	int mode_aa;
+	int mode_aad;
+	int mode_du4;
+	int mode_gck16;
+	int mode_glkw16;
 };
 
 /* Mark 7 */
@@ -365,10 +397,10 @@ struct mxcfb_csc_matrix
 #define MXCFB_GET_PREFETCH      _IOR('F', 0x31, int)
 
 /* IOCTLs for E-ink panel updates */
-#define MXCFB_SET_WAVEFORM_MODES _IOW('F', 0x2B, struct mxcfb_waveform_modes)
-
-/* Mark 7 */
-#define MXCFB_SET_WAVEFORM_MODES_NTX _IOW('F', 0x2B, struct mxcfb_waveform_modes_ntx)
+#define MXCFB_SET_WAVEFORM_MODES     _IOW('F', 0x2B, struct mxcfb_waveform_modes)
+#define MXCFB_SET_WAVEFORM_MODES_MK5 _IOW('F', 0x2B, struct mxcfb_waveform_modes_mk5)
+#define MXCFB_SET_WAVEFORM_MODES_MK7 _IOW('F', 0x2B, struct mxcfb_waveform_modes_mk7)
+#define MXCFB_SET_WAVEFORM_MODES_MK9 _IOW('F', 0x2B, struct mxcfb_waveform_modes_mk9)
 
 #define MXCFB_SET_TEMPERATURE      _IOW('F', 0x2C, int32_t)
 #define MXCFB_SET_AUTO_UPDATE_MODE _IOW('F', 0x2D, uint32_t)

--- a/ffi-cdecl/include/mxcfb-pocketbook.h
+++ b/ffi-cdecl/include/mxcfb-pocketbook.h
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2004-2013 Freescale Semiconductor, Inc. All Rights Reserved.
+ */
+
+/*
+ * The code contained herein is licensed under the GNU Lesser General
+ * Public License.  You may obtain a copy of the GNU Lesser General
+ * Public License Version 2.1 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/lgpl-license.html
+ * http://www.gnu.org/copyleft/lgpl.html
+ */
+
+/*
+ * NOTE: Upstream kernels available here: https://github.com/pocketbook/Platform_MX6
+ * - slightly modified (commented out include of fb.h) for Lua integration
+ * - Attempted to frankenstein the two variants together like we do on other platforms...
+*/
+
+/*
+ * @file arch-mxc/   mxcfb.h
+ *
+ * @brief Global header file for the MXC Frame buffer
+ *
+ * @ingroup Framebuffer
+ */
+#ifndef __ASM_ARCH_MXCFB_H__
+#define __ASM_ARCH_MXCFB_H__
+
+//#include <linux/fb.h>
+
+// NOTE: PB631
+#if defined(CONFIG_ANDROID) || defined(ANDROID) //[
+#else //][ !CONFIG_ANDROID||!ANDROID
+	#define MX50_IOCTL_IF	1
+#endif //] !CONFIG_ANDROID
+
+#define FB_SYNC_OE_LOW_ACT	0x80000000
+#define FB_SYNC_CLK_LAT_FALL	0x40000000
+#define FB_SYNC_DATA_INVERT	0x20000000
+#define FB_SYNC_CLK_IDLE_EN	0x10000000
+#define FB_SYNC_SHARP_MODE	0x08000000
+#define FB_SYNC_SWAP_RGB	0x04000000
+#define FB_ACCEL_TRIPLE_FLAG	0x00000000
+#define FB_ACCEL_DOUBLE_FLAG	0x00000001
+
+struct mxcfb_gbl_alpha {
+	int enable;
+	int alpha;
+};
+
+struct mxcfb_loc_alpha {
+	int enable;
+	int alpha_in_pixel;
+	unsigned long alpha_phy_addr0;
+	unsigned long alpha_phy_addr1;
+};
+
+struct mxcfb_color_key {
+	int enable;
+	__u32 color_key;
+};
+
+struct mxcfb_pos {
+	__u16 x;
+	__u16 y;
+};
+
+struct mxcfb_gamma {
+	int enable;
+	int constk[16];
+	int slopek[16];
+};
+
+struct mxcfb_rect {
+	__u32 top;
+	__u32 left;
+	__u32 width;
+	__u32 height;
+};
+
+#define GRAYSCALE_8BIT				0x1
+#define GRAYSCALE_8BIT_INVERTED			0x2
+#define GRAYSCALE_4BIT                          0x3
+#define GRAYSCALE_4BIT_INVERTED                 0x4
+
+#define AUTO_UPDATE_MODE_REGION_MODE		0
+#define AUTO_UPDATE_MODE_AUTOMATIC_MODE		1
+
+#define UPDATE_SCHEME_SNAPSHOT			0
+#define UPDATE_SCHEME_QUEUE			1
+#define UPDATE_SCHEME_QUEUE_AND_MERGE		2
+
+#define UPDATE_MODE_PARTIAL			0x0
+#define UPDATE_MODE_FULL			0x1
+
+// NOTE: PB631
+#define UPDATE_MODE_PARTIALHQ			0x2
+// PARTIALHQ || PARTIAL + GC16HQ => FULL + AA
+#define UPDATE_MODE_FULLHQ			0x3
+// FULLHQ || FULL + GC16HQ => FULL + AAD
+
+// NOTE: Buried in drivers/video/mxc/mxc_epdc_fb.c
+//       PB only defines DU, A2, A2IN & A2OUT
+#define EPDC_WFTYPE_INIT			0
+#define EPDC_WFTYPE_DU				1
+#define EPDC_WFTYPE_GC16			2
+#define EPDC_WFTYPE_GC4				3
+#define EPDC_WFTYPE_A2				4
+#define EPDC_WFTYPE_GL16			5  // On B288 this is very fast, but flickers, interferes with HWROT.
+#define EPDC_WFTYPE_A2IN			6
+#define EPDC_WFTYPE_A2OUT			7
+#define EPDC_WFTYPE_DU4				8  // !B888
+#define EPDC_WFTYPE_AA				9  // !B288
+#define EPDC_WFTYPE_AAD				10 // !B288
+#define EPDC_WFTYPE_GS16			14  // B288 only. Should sit between GC16 and GL16.
+#define EPDC_WFTYPE_GC16HQ			15  // !B288
+// NOTE: Alias that to our usual constant names...
+#define WAVEFORM_MODE_INIT			EPDC_WFTYPE_INIT
+#define WAVEFORM_MODE_DU			EPDC_WFTYPE_DU
+#define WAVEFORM_MODE_GC16			EPDC_WFTYPE_GC16
+#define WAVEFORM_MODE_GC4			EPDC_WFTYPE_GC4
+#define WAVEFORM_MODE_A2			EPDC_WFTYPE_A2
+#define WAVEFORM_MODE_GL16			EPDC_WFTYPE_GL16
+#define WAVEFORM_MODE_A2IN			EPDC_WFTYPE_A2IN
+#define WAVEFORM_MODE_A2OUT			EPDC_WFTYPE_A2OUT
+#define WAVEFORM_MODE_DU4			EPDC_WFTYPE_DU4
+#define WAVEFORM_MODE_REAGL			EPDC_WFTYPE_AA
+#define WAVEFORM_MODE_REAGLD			EPDC_WFTYPE_AAD
+#define WAVEFORM_MODE_GS16			EPDC_WFTYPE_GS16
+#define WAVEFORM_MODE_GC16HQ			EPDC_WFTYPE_GC16HQ
+
+#define WAVEFORM_MODE_AUTO			257 // !B288 (Ouch. That one hurts.)
+
+#define TEMP_USE_AMBIENT			0x1000
+
+#define EPDC_FLAG_ENABLE_INVERSION		0x01
+#define EPDC_FLAG_FORCE_MONOCHROME		0x02
+#define EPDC_FLAG_USE_CMAP			0x04
+#define EPDC_FLAG_USE_ALT_BUFFER		0x100
+#define EPDC_FLAG_TEST_COLLISION		0x200
+#define EPDC_FLAG_GROUP_UPDATE			0x400
+
+// NOTE: PB631
+#define EPDC_FLAG_USE_AAD			0x1000
+
+#define EPDC_FLAG_USE_DITHERING_Y1		0x2000
+#define EPDC_FLAG_USE_DITHERING_Y4		0x4000
+
+// NOTE: PB631
+#define EPDC_FLAG_USE_DITHERING_NTX_D8		0x100000
+
+#define FB_POWERDOWN_DISABLE			-1
+
+// NOTE: The virt_addr mess that we mercifully don't have to deal with is from PB631
+struct mxcfb_alt_buffer_data {
+//#if defined(CONFIG_ANDROID) || defined (ANDROID)//[
+//#else//][!CONFIG_ANDROID
+//	void *virt_addr;
+//#endif//]!CONFIG_ANDROID
+	__u32 phys_addr;
+	__u32 width;	/* width of entire buffer */
+	__u32 height;	/* height of entire buffer */
+	struct mxcfb_rect alt_update_region;	/* region within buffer to update */
+};
+
+struct mxcfb_update_data {
+	struct mxcfb_rect update_region;
+	__u32 waveform_mode;
+	__u32 update_mode;
+	__u32 update_marker;
+	int temp;
+	unsigned int flags;
+	struct mxcfb_alt_buffer_data alt_buffer_data;
+};
+
+struct mxcfb_update_marker_data {
+	__u32 update_marker;
+	__u32 collision_test;
+};
+
+/*
+ * Structure used to define waveform modes for driver
+ * Needed for driver to perform auto-waveform selection
+ */
+struct mxcfb_waveform_modes {
+	int mode_init;
+	int mode_du;
+	int mode_gc4;
+	int mode_gc8;
+	int mode_gc16;
+	int mode_gc32;
+	// NOTE: PB631
+	int mode_aa;
+	int mode_aad;
+	int mode_gl16;
+	int mode_a2;
+	int mode_a2in;
+	int mode_a2out;
+};
+
+/*
+ * Structure used to define a 5*3 matrix of parameters for
+ * setting IPU DP CSC module related to this framebuffer.
+ */
+struct mxcfb_csc_matrix {
+	int param[5][3];
+};
+
+#define MXCFB_WAIT_FOR_VSYNC	_IOW('F', 0x20, u_int32_t)
+#define MXCFB_SET_GBL_ALPHA     _IOW('F', 0x21, struct mxcfb_gbl_alpha)
+#define MXCFB_SET_CLR_KEY       _IOW('F', 0x22, struct mxcfb_color_key)
+#define MXCFB_SET_OVERLAY_POS   _IOWR('F', 0x24, struct mxcfb_pos)
+#define MXCFB_GET_FB_IPU_CHAN 	_IOR('F', 0x25, u_int32_t)
+#define MXCFB_SET_LOC_ALPHA     _IOWR('F', 0x26, struct mxcfb_loc_alpha)
+#define MXCFB_SET_LOC_ALP_BUF    _IOW('F', 0x27, unsigned long)
+#define MXCFB_SET_GAMMA	       _IOW('F', 0x28, struct mxcfb_gamma)
+#define MXCFB_GET_FB_IPU_DI 	_IOR('F', 0x29, u_int32_t)
+#define MXCFB_GET_DIFMT	       _IOR('F', 0x2A, u_int32_t)
+#define MXCFB_GET_FB_BLANK     _IOR('F', 0x2B, u_int32_t)
+#define MXCFB_SET_DIFMT		_IOW('F', 0x2C, u_int32_t)
+
+// NOTE: PB631
+#define MXCFB_ENABLE_VSYNC_EVENT	_IOW('F', 0x33, int32_t)
+
+#define MXCFB_CSC_UPDATE	_IOW('F', 0x2D, struct mxcfb_csc_matrix)
+
+/* IOCTLs for E-ink panel updates */
+#define MXCFB_SET_WAVEFORM_MODES	_IOW('F', 0x2B, struct mxcfb_waveform_modes)
+#define MXCFB_SET_TEMPERATURE		_IOW('F', 0x2C, int32_t)
+#define MXCFB_SET_AUTO_UPDATE_MODE	_IOW('F', 0x2D, __u32)
+#define MXCFB_SEND_UPDATE		_IOW('F', 0x2E, struct mxcfb_update_data)
+
+// NOTE: PB
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE _IOWR('F', 0x2F, struct mxcfb_update_marker_data)
+
+// NOTE: PB631
+#ifdef MX50_IOCTL_IF//[
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB	_IOW('F', 0x2F, __u32)
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB631_V2 _IOWR('F', 0x35, struct mxcfb_update_marker_data)
+#else //][!MX50_IOCTL_IF
+#define MXCFB_WAIT_FOR_UPDATE_COMPLETE_ANDROID _IOWR('F', 0x35, struct mxcfb_update_marker_data)
+#endif//] MX50_IOCTL_IF
+
+// NOTE: Apparently, everything is terrible, and, while kernels appear to always expect the MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB
+//       command, *some* kernels will apparently try to write back as if it were MXCFB_WAIT_FOR_UPDATE_COMPLETE...
+//       The workaround is to actually setup a mxcfb_update_marker_data struct but use MXCFB_WAIT_FOR_UPDATE_COMPLETE_PB.
+//       >_<".
+//       c.f., https://github.com/koreader/koreader-base/pull/1188 & https://github.com/koreader/koreader/pull/6669
+
+// NOTE: This only probes whether the EPDC is busy, we use this to detect B288.
+#define EPDC_GET_UPDATE_STATE		_IOR('F', 0x55, __u32)
+
+#define MXCFB_SET_PWRDOWN_DELAY		_IOW('F', 0x30, int32_t)
+#define MXCFB_GET_PWRDOWN_DELAY		_IOR('F', 0x31, int32_t)
+#define MXCFB_SET_UPDATE_SCHEME		_IOW('F', 0x32, __u32)
+#define MXCFB_GET_WORK_BUFFER		_IOWR('F', 0x34, unsigned long)
+
+#ifdef __KERNEL__
+
+extern struct fb_videomode mxcfb_modedb[];
+extern int mxcfb_modedb_sz;
+
+enum {
+	MXC_DISP_SPEC_DEV = 0,
+	MXC_DISP_DDC_DEV = 1,
+};
+
+enum {
+	MXCFB_REFRESH_OFF,
+	MXCFB_REFRESH_AUTO,
+	MXCFB_REFRESH_PARTIAL,
+};
+
+int mxcfb_set_refresh_mode(struct fb_info *fbi, int mode,
+			   struct mxcfb_rect *update_region);
+int mxc_elcdif_frame_addr_setup(dma_addr_t phys);
+void mxcfb_elcdif_register_mode(const struct fb_videomode *modedb,
+		int num_modes, int dev_mode);
+
+#endif				/* __KERNEL__ */
+#endif

--- a/ffi-cdecl/mxcfb_kindle_decl.c
+++ b/ffi-cdecl/mxcfb_kindle_decl.c
@@ -4,6 +4,7 @@
 #include <linux/ioctl.h>
 // specialized eink framebuffer headers
 #include "include/mxcfb-kindle.h"
+#include "include/mtk-kindle.h"
 
 #include "ffi-cdecl.h"
 
@@ -87,3 +88,47 @@ cdecl_const(NIGHTMODE_STRIDE_DEFAULT)
 cdecl_const(NIGHTMODE_STRIDE_DEFAULT_REX)
 cdecl_struct(mxcfb_nightmode_ctrl)
 cdecl_const(MXCFB_SET_NIGHTMODE)
+
+// And now for MTK stuff
+cdecl_const(MTK_EPDC_FLAG_USE_DITHERING_Y4)
+cdecl_const(MTK_EPDC_FLAG_USE_REGAL)
+cdecl_const(MTK_EPDC_FLAG_ENABLE_SWIPE)
+
+cdecl_const(MTK_WAVEFORM_MODE_INIT)
+cdecl_const(MTK_WAVEFORM_MODE_DU)
+cdecl_const(MTK_WAVEFORM_MODE_GC16)
+cdecl_const(MTK_WAVEFORM_MODE_GC16_FAST)
+cdecl_const(MTK_WAVEFORM_MODE_GL16)
+cdecl_const(MTK_WAVEFORM_MODE_GL16_FAST)
+cdecl_const(MTK_WAVEFORM_MODE_GL4)
+cdecl_const(MTK_WAVEFORM_MODE_GL16_INV)
+cdecl_const(MTK_WAVEFORM_MODE_GLR16)
+cdecl_const(MTK_WAVEFORM_MODE_REAGL)
+cdecl_const(MTK_WAVEFORM_MODE_GLD16)
+cdecl_const(MTK_WAVEFORM_MODE_REAGLD)
+cdecl_const(MTK_WAVEFORM_MODE_A2)
+cdecl_const(MTK_WAVEFORM_MODE_DU4)
+cdecl_const(MTK_WAVEFORM_MODE_LAST)
+cdecl_const(MTK_WAVEFORM_MODE_GCK16)
+cdecl_const(MTK_WAVEFORM_MODE_GLKW16)
+cdecl_const(MTK_WAVEFORM_MODE_GC16_PARTIAL)
+cdecl_const(MTK_WAVEFORM_MODE_GCK16_PARTIAL)
+cdecl_const(MTK_WAVEFORM_MODE_DUNM)
+cdecl_const(MTK_WAVEFORM_MODE_P2SW)
+
+cdecl_enum(MTK_SWIPE_DIRECTION_ENUM)
+cdecl_struct(mxcfb_swipe_data)
+
+cdecl_struct(mxcfb_update_data_mtk)
+cdecl_struct(mxcfb_halftone_data)
+cdecl_type(mxcfb_markers_data)
+
+cdecl_const(UPDATE_FLAGS_FAST_MODE)
+cdecl_const(UPDATE_FLAGS_MODE_FAST_FLAG)
+
+cdecl_const(MXCFB_SEND_UPDATE_MTK)
+cdecl_const(MXCFB_SET_NIGHTMODE_MTK)
+cdecl_const(MXCFB_SET_HALFTONE_MTK)
+cdecl_const(MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE_MTK)
+cdecl_const(MXCFB_SET_UPDATE_FLAGS_MTK)
+cdecl_const(MXCFB_GET_UPDATE_FLAGS_MTK)

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -103,7 +103,7 @@ function fb:setHWRotation(canon)
 end
 
 -- To be overriden. Enable nightmode globally by switching the grayscale fb vinfo flag.
--- Requires the canHWInvertInKernel device cap.
+-- Requires the canHWInvert device cap.
 function fb:setHWNightmode(toggle)
 end
 -- To be overriden. Returns true if the grayscale flag is set to GRAYSCALE_8BIT_INVERTED on an 8bpp fb.
@@ -438,18 +438,16 @@ end
 
 function fb:toggleNightMode()
     self.night_mode = not self.night_mode
-    -- Only do SW inversion if the HW can't...
-    if not self.device:canHWInvert() then
+    if self.device:canHWInvert() then
+        -- If the device supports global inversion via the grayscale flag, do that.
+        self:setHWNightmode(self.night_mode)
+    else
+        -- Only do SW inversion if the HW can't...
         self.bb:invert()
         if self.viewport then
             -- invert and blank out the full framebuffer when we are working on a viewport
             self.full_bb:setInverse(self.bb:getInverse())
             self.full_bb:fill(Blitbuffer.COLOR_WHITE)
-        end
-    else
-        -- If the device supports global inversion via the grayscale flag, do that.
-        if self.device:canHWInvertInKernel() then
-            self:setHWNightmode(self.night_mode)
         end
     end
 end

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -102,6 +102,15 @@ end
 function fb:setHWRotation(canon)
 end
 
+-- To be overriden. Enable nightmode globally by switching the grayscale fb vinfo flag.
+-- Requires the canHWInvertInKernel device cap.
+function fb:setHWNightmode(toggle)
+end
+-- To be overriden. Returns true if the grayscale flag is set to GRAYSCALE_8BIT_INVERTED on an 8bpp fb.
+function fb:getHWNightmode()
+    return false
+end
+
 -- Rotation modes may cause desync of rotation for touch translation, so frontend may need to override this
 -- to provide a fixup.
 function fb:getTouchRotation()
@@ -430,12 +439,17 @@ end
 function fb:toggleNightMode()
     self.night_mode = not self.night_mode
     -- Only do SW inversion if the HW can't...
-    if not (self.device and self.device:canHWInvert()) then
+    if not self.device:canHWInvert() then
         self.bb:invert()
         if self.viewport then
             -- invert and blank out the full framebuffer when we are working on a viewport
             self.full_bb:setInverse(self.bb:getInverse())
             self.full_bb:fill(Blitbuffer.COLOR_WHITE)
+        end
+    else
+        -- If the device supports global inversion via the grayscale flag, do that.
+        if self.device:canHWInvertInKernel() then
+            self:setHWNightmode(self.night_mode)
         end
     end
 end

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -161,6 +161,11 @@ function framebuffer:setHWNightmode(toggle)
         return
     end
 
+    -- And on devices with the actual capability.
+    if not self.device:canHWInvert() then
+        return
+    end
+
     local vinfo = self._vinfo
     -- Just flip the grayscale flag.
     -- This shouldn't affect *anything* (layout-wise), which is why we don't touch the mmap or anything else, really.
@@ -172,6 +177,11 @@ end
 function framebuffer:getHWNightmode()
     -- Only makes sense @ 8bpp
     if self.fb_bpp ~= 8 then
+        return false
+    end
+
+    -- And on devices with the actual capability.
+    if not self.device:canHWInvert() then
         return false
     end
 

--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -150,6 +150,29 @@ function framebuffer:reinit()
     self.bb:fill(BB.COLOR_WHITE)
 end
 
+function framebuffer:setNightmode(toggle)
+    -- Only makes sense @ 8bpp
+    if self.fb_bpp ~= 8 then
+        return
+    end
+
+    -- This is common across all mxcfb-like platforms.
+    local GRAYSCALE_8BIT = 0x1
+    local GRAYSCALE_8BIT_INVERTED = 0x2
+
+    -- Do not necessarily trust our own cached vinfo, as we may have tweaked it...
+    -- Instead, query the current state again...
+    local vinfo = ffi.new("struct fb_var_screeninfo")
+    assert(C.ioctl(self.fd, C.FBIOGET_VSCREENINFO, vinfo) == 0,
+           "cannot get variable screen info")
+
+    -- ...and just flip the grayscale flag.
+    -- This shouldn't affect *anything* (layout-wise), which is why we don't touch the mmap or anything else, really.
+    vinfo.grayscale = toggle and GRAYSCALE_8BIT_INVERTED or GRAYSCALE_8BIT
+    assert(C.ioctl(self.fd, C.FBIOPUT_VSCREENINFO, vinfo) == 0,
+           "cannot set variable screen info")
+end
+
 function framebuffer:setHWRotation(mode)
     local vinfo = self._vinfo
     vinfo.rotate = self.forced_rotation[mode+1] or mode

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -504,7 +504,7 @@ local function refresh_mtk(fb, is_flashing, waveform_mode, x, y, w, h, dither)
     end
 
     -- Enable the appropriate flag when requesting a 2bit update, provided we're not dithering.
-    -- FIXME: See FBInk note about DITHER + MONOCHROME
+    -- NOTE: See FBInk note about DITHER + MONOCHROME
     if waveform_mode == C.MTK_WAVEFORM_MODE_A2 and not dither then
         fb.update_data.flags = C.EPDC_FLAG_FORCE_MONOCHROME
     else
@@ -512,7 +512,7 @@ local function refresh_mtk(fb, is_flashing, waveform_mode, x, y, w, h, dither)
     end
 
     -- Did we request HW dithering?
-    if dither then
+    if dither and fb.device:canHWDither() then
         fb.update_data.flags = bor(fb.update_data.flags, C.MTK_EPDC_FLAG_USE_DITHERING_Y4)
     end
 
@@ -730,7 +730,6 @@ function framebuffer:init()
             self.waveform_partial = self.waveform_reagl
             -- FIXME: Enable nightmode via grayscale fb flag
             self.waveform_night = C.MTK_WAVEFORM_MODE_GLKW16
-            -- FIXME: Double-check
             self.night_is_reagl = true
             self.waveform_flashnight = C.MTK_WAVEFORM_MODE_GCK16
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -521,12 +521,12 @@ local function refresh_mtk(fb, is_flashing, waveform_mode, x, y, w, h, dither)
 end
 
 -- Don't let the driver silently upgrade to REAGL
-local function set_mtk_flags(fb)
-    local flags = ffi.new("uint32_t[1]", bor(C.UPDATE_FLAGS_FAST_MODE, C.UPDATE_FLAGS_MODE_FAST_FLAG))
+function framebuffer:_MTK_ToggleFastMode(toggle)
+    local flags = ffi.new("uint32_t[1]", bor(C.UPDATE_FLAGS_FAST_MODE, toggle and C.UPDATE_FLAGS_MODE_FAST_FLAG or 0))
 
     if C.ioctl(fb.fd, C.MXCFB_SET_UPDATE_FLAGS_MTK, flags) == -1 then
         local err = ffi.errno()
-        fb.debug("MXCFB_SET_UPDATE_FLAGS_MTK ioctl failed:", ffi.string(C.strerror(err)))
+        self.debug("MXCFB_SET_UPDATE_FLAGS_MTK ioctl failed:", ffi.string(C.strerror(err)))
     end
 end
 
@@ -739,9 +739,6 @@ function framebuffer:init()
             self.waveform_night = C.MTK_WAVEFORM_MODE_GLKW16
             self.night_is_reagl = true
             self.waveform_flashnight = C.MTK_WAVEFORM_MODE_GCK16
-
-            -- Don't let the driver silently update to REAGL
-            set_mtk_flags(self)
         end
 
         -- Keep our data structures around, and setup constants

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -336,8 +336,9 @@ local function mxc_update(fb, ioc_cmd, ioc_data, is_flashing, waveform_mode, x, 
 
     -- Handle night mode shenanigans
     if fb.night_mode then
-        -- We're in nightmode! If the device can do HW inversion safely, do that!
-        if fb.device:canHWInvert() then
+        -- We're in nightmode!
+        -- If the device can do HW inversion safely, and doesn't already handle the flag automatically, do that!
+        if fb.device:canHWInvert() and not fb.device:canHWInvertInKernel() then
             ioc_data.flags = bor(ioc_data.flags, C.EPDC_FLAG_ENABLE_INVERSION)
         end
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -728,7 +728,13 @@ function framebuffer:init()
             self.waveform_flashui = self.waveform_ui
             self.waveform_reagl = C.MTK_WAVEFORM_MODE_GLR16
             self.waveform_partial = self.waveform_reagl
-            -- FIXME: Enable nightmode via grayscale fb flag
+            --- @todo: Ideally, we'd want to switch to nightmode globally, via the grayscale fb flag,
+            --         as the driver uses that to make a few nightmode-specific decisions:
+            --         * Proper pattern color for the halftone grid
+            --         * Automatic GCK16/GLKW16/DUNM waveform mode selection
+            --         * Disable the silent REAGL updates in nightmode
+            --         * Use the proper waveform mode during animated swipes
+            --         * Make better decisions for AUTO in nightmode
             self.waveform_night = C.MTK_WAVEFORM_MODE_GLKW16
             self.night_is_reagl = true
             self.waveform_flashnight = C.MTK_WAVEFORM_MODE_GCK16

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -524,7 +524,7 @@ end
 function framebuffer:_MTK_ToggleFastMode(toggle)
     local flags = ffi.new("uint32_t[1]", bor(C.UPDATE_FLAGS_FAST_MODE, toggle and C.UPDATE_FLAGS_MODE_FAST_FLAG or 0))
 
-    if C.ioctl(fb.fd, C.MXCFB_SET_UPDATE_FLAGS_MTK, flags) == -1 then
+    if C.ioctl(self.fd, C.MXCFB_SET_UPDATE_FLAGS_MTK, flags) == -1 then
         local err = ffi.errno()
         self.debug("MXCFB_SET_UPDATE_FLAGS_MTK ioctl failed:", ffi.string(C.strerror(err)))
     end

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -337,8 +337,8 @@ local function mxc_update(fb, ioc_cmd, ioc_data, is_flashing, waveform_mode, x, 
     -- Handle night mode shenanigans
     if fb.night_mode then
         -- We're in nightmode!
-        -- If the device can do HW inversion safely, and doesn't already handle the flag automatically, do that!
-        if fb.device:canHWInvert() and not fb.device:canHWInvertInKernel() then
+        -- If the device can do HW inversion safely, and doesn't already handle setting the flag automatically, do that!
+        if fb.device:canHWInvert() and not fb:getHWNightmode() then
             ioc_data.flags = bor(ioc_data.flags, C.EPDC_FLAG_ENABLE_INVERSION)
         end
 
@@ -729,8 +729,8 @@ function framebuffer:init()
             self.waveform_flashui = self.waveform_ui
             self.waveform_reagl = C.MTK_WAVEFORM_MODE_GLR16
             self.waveform_partial = self.waveform_reagl
-            --- @todo: Ideally, we'd want to switch to nightmode globally, via the grayscale fb flag,
-            --         as the driver uses that to make a few nightmode-specific decisions:
+            -- NOTE: We switch to nightmode globally, via the grayscale vinfo fb flag,
+            --       as the driver uses that to make a few nightmode-specific decisions:
             --         * Proper pattern color for the halftone grid
             --         * Automatic GCK16/GLKW16/DUNM waveform mode selection
             --         * Disable the silent REAGL updates in nightmode

--- a/ffi/mxcfb_kindle_h.lua
+++ b/ffi/mxcfb_kindle_h.lua
@@ -56,62 +56,62 @@ enum mxcfb_dithering_mode {
   EPDC_FLAG_USE_DITHERING_MAX = 5,
 };
 struct mxcfb_rect {
-  unsigned int top;
-  unsigned int left;
-  unsigned int width;
-  unsigned int height;
+  uint32_t top;
+  uint32_t left;
+  uint32_t width;
+  uint32_t height;
 };
 struct mxcfb_alt_buffer_data {
-  unsigned int phys_addr;
-  unsigned int width;
-  unsigned int height;
+  uint32_t phys_addr;
+  uint32_t width;
+  uint32_t height;
   struct mxcfb_rect alt_update_region;
 };
 struct mxcfb_update_data {
   struct mxcfb_rect update_region;
-  unsigned int waveform_mode;
-  unsigned int update_mode;
-  unsigned int update_marker;
-  unsigned int hist_bw_waveform_mode;
-  unsigned int hist_gray_waveform_mode;
+  uint32_t waveform_mode;
+  uint32_t update_mode;
+  uint32_t update_marker;
+  uint32_t hist_bw_waveform_mode;
+  uint32_t hist_gray_waveform_mode;
   int temp;
   unsigned int flags;
   struct mxcfb_alt_buffer_data alt_buffer_data;
 };
 struct mxcfb_update_data_zelda {
   struct mxcfb_rect update_region;
-  unsigned int waveform_mode;
-  unsigned int update_mode;
-  unsigned int update_marker;
+  uint32_t waveform_mode;
+  uint32_t update_mode;
+  uint32_t update_marker;
   int temp;
   unsigned int flags;
   int dither_mode;
   int quant_bit;
   struct mxcfb_alt_buffer_data alt_buffer_data;
-  unsigned int hist_bw_waveform_mode;
-  unsigned int hist_gray_waveform_mode;
-  unsigned int ts_pxp;
-  unsigned int ts_epdc;
+  uint32_t hist_bw_waveform_mode;
+  uint32_t hist_gray_waveform_mode;
+  uint32_t ts_pxp;
+  uint32_t ts_epdc;
 };
 struct mxcfb_update_data_rex {
   struct mxcfb_rect update_region;
-  unsigned int waveform_mode;
-  unsigned int update_mode;
-  unsigned int update_marker;
+  uint32_t waveform_mode;
+  uint32_t update_mode;
+  uint32_t update_marker;
   int temp;
   unsigned int flags;
   int dither_mode;
   int quant_bit;
   struct mxcfb_alt_buffer_data alt_buffer_data;
-  unsigned int hist_bw_waveform_mode;
-  unsigned int hist_gray_waveform_mode;
+  uint32_t hist_bw_waveform_mode;
+  uint32_t hist_gray_waveform_mode;
 };
 static const int MXCFB_SEND_UPDATE = 1078478382;
 static const int MXCFB_SEND_UPDATE_ZELDA = 1079526958;
 static const int MXCFB_SEND_UPDATE_REX = 1079002670;
 struct mxcfb_update_marker_data {
-  unsigned int update_marker;
-  unsigned int collision_test;
+  uint32_t update_marker;
+  uint32_t collision_test;
 };
 static const int MXCFB_WAIT_FOR_UPDATE_COMPLETE = 3221767727;
 static const int MXCFB_WAIT_FOR_UPDATE_COMPLETE_PEARL = 1074021935;
@@ -125,4 +125,71 @@ struct mxcfb_nightmode_ctrl {
   int current_level;
 };
 static const int MXCFB_SET_NIGHTMODE = 2147763786;
+static const int MTK_EPDC_FLAG_USE_DITHERING_Y4 = 16384;
+static const int MTK_EPDC_FLAG_USE_REGAL = 32768;
+static const int MTK_EPDC_FLAG_ENABLE_SWIPE = 65536;
+static const int MTK_WAVEFORM_MODE_INIT = 0;
+static const int MTK_WAVEFORM_MODE_DU = 1;
+static const int MTK_WAVEFORM_MODE_GC16 = 2;
+static const int MTK_WAVEFORM_MODE_GC16_FAST = 2;
+static const int MTK_WAVEFORM_MODE_GL16 = 3;
+static const int MTK_WAVEFORM_MODE_GL16_FAST = 3;
+static const int MTK_WAVEFORM_MODE_GL4 = 3;
+static const int MTK_WAVEFORM_MODE_GL16_INV = 3;
+static const int MTK_WAVEFORM_MODE_GLR16 = 4;
+static const int MTK_WAVEFORM_MODE_REAGL = 4;
+static const int MTK_WAVEFORM_MODE_GLD16 = 5;
+static const int MTK_WAVEFORM_MODE_REAGLD = 5;
+static const int MTK_WAVEFORM_MODE_A2 = 6;
+static const int MTK_WAVEFORM_MODE_DU4 = 7;
+static const int MTK_WAVEFORM_MODE_LAST = 7;
+static const int MTK_WAVEFORM_MODE_GCK16 = 8;
+static const int MTK_WAVEFORM_MODE_GLKW16 = 9;
+static const int MTK_WAVEFORM_MODE_GC16_PARTIAL = 10;
+static const int MTK_WAVEFORM_MODE_GCK16_PARTIAL = 11;
+static const int MTK_WAVEFORM_MODE_DUNM = 12;
+static const int MTK_WAVEFORM_MODE_P2SW = 13;
+enum MTK_SWIPE_DIRECTION_ENUM {
+  MTK_SWIPE_DOWN = 0,
+  MTK_SWIPE_UP = 1,
+  MTK_SWIPE_LEFT = 2,
+  MTK_SWIPE_RIGHT = 3,
+  MTK_SWIPE_MAX = 4,
+};
+struct mxcfb_swipe_data {
+  uint32_t direction;
+  uint32_t steps;
+};
+struct mxcfb_update_data_mtk {
+  struct mxcfb_rect update_region;
+  uint32_t waveform_mode;
+  uint32_t update_mode;
+  uint32_t update_marker;
+  int temp;
+  unsigned int flags;
+  int dither_mode;
+  int quant_bit;
+  struct mxcfb_alt_buffer_data alt_buffer_data;
+  struct mxcfb_swipe_data swipe_data;
+  uint32_t hist_bw_waveform_mode;
+  uint32_t hist_gray_waveform_mode;
+  uint32_t ts_pxp;
+  uint32_t ts_epdc;
+};
+struct mxcfb_halftone_data {
+  struct mxcfb_rect region[2];
+  int halftone_mode;
+};
+typedef union {
+  uint32_t flag;
+  uint32_t markers[64];
+} mxcfb_markers_data;
+static const int UPDATE_FLAGS_FAST_MODE = -2147483648;
+static const int UPDATE_FLAGS_MODE_FAST_FLAG = 1;
+static const int MXCFB_SEND_UPDATE_MTK = 1080051246;
+static const int MXCFB_SET_NIGHTMODE_MTK = 2148550218;
+static const int MXCFB_SET_HALFTONE_MTK = 1076119115;
+static const int MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE_MTK = 3221505591;
+static const int MXCFB_SET_UPDATE_FLAGS_MTK = 1074021947;
+static const int MXCFB_GET_UPDATE_FLAGS_MTK = 3221505596;
 ]]

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -67,7 +67,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    cfea2676d970e375c6d0228ad691a9431becbef2
+    b7a81463502c8a445e85edd8e1903dca0ede7f5f
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/lua-ljsqlite3/init.lua
+++ b/thirdparty/lua-ljsqlite3/init.lua
@@ -231,8 +231,8 @@ end
 
 -- Throw error for a given connection.
 local function E_conn(pconn, code)
-  local code, msg = codemsg(pconn, code)
-  err(code, msg)
+  local scode, msg = codemsg(pconn, code)
+  err(scode, msg)
 end
 
 -- Test code is OK or throw error for a given connection.
@@ -344,9 +344,9 @@ local function open(str, mode)
   connstmt[conn] = setmetatable({}, { __mode = "k" })
   conncb[conn] = { scalar = {}, step = {}, final = {} }
   if code ~= sql.SQLITE_OK then
-    local code, msg = codemsg(conn._ptr, code) -- Before closing!
+    local scode, msg = codemsg(conn._ptr, code) -- Before closing!
     conn:close() -- Free resources, should not fail here in this case!
-    err(code, msg)
+    err(scode, msg)
   end
   return conn
 end


### PR DESCRIPTION
As found on the PW5 ;).

Thankfully, the driver's API is designed to match the mxcfb API, so this was hilariously trivial compared to the sunxi insanity ;).

----

* On mxcfb-like devices with hardware inversion support, toggle nightmode by switching the grayscale fb vinfo flag when we're running at 8bpp. All the mxcfb-like drivers check this to toggle PxP/MDP inversion, but the MTK driver also does it in other places to make better decisions in nightmode.
* Implement the refresh machinery for the MTK driver found on Kindles. Its API is thankfully based on the mxcfb API, so there's nothing drastic happening ;).
* Resync eink headers w/ FBInk.
* Update FBInk.
* Random lj-sqlite3 luacheck cleanup ;).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1457)
<!-- Reviewable:end -->
