### PR TITLE
bump crengine: rendering, CSS and hyphenation tweaks

### DIFF
--- a/.ci/emulator_install.sh
+++ b/.ci/emulator_install.sh
@@ -8,8 +8,7 @@ test -d "${HOME}/.luarocks" || {
     mkdir "${HOME}/.luarocks"
     cp /etc/luarocks/config-5.1.lua "${HOME}/.luarocks/config.lua"
     echo "wrap_bin_scripts = false" >>"${HOME}/.luarocks/config.lua"
-    # XXX commented out for testing
-    # travis_retry luarocks --local install busted 2.0.0-1
+    travis_retry luarocks --local install busted 2.0.0-1
     # for verbose_print module
     travis_retry luarocks --local install ansicolors
 }

--- a/.ci/emulator_install.sh
+++ b/.ci/emulator_install.sh
@@ -8,7 +8,8 @@ test -d "${HOME}/.luarocks" || {
     mkdir "${HOME}/.luarocks"
     cp /etc/luarocks/config-5.1.lua "${HOME}/.luarocks/config.lua"
     echo "wrap_bin_scripts = false" >>"${HOME}/.luarocks/config.lua"
-    travis_retry luarocks --local install busted 2.0.0-1
+    # XXX commented out for testing
+    # travis_retry luarocks --local install busted 2.0.0-1
     # for verbose_print module
     travis_retry luarocks --local install ansicolors
 }


### PR DESCRIPTION
Includes:
- Fix sizing of float/inline-block image containers https://github.com/koreader/crengine/pull/467
- Fix body background drawing and other clipping issues
- Drawing: don't use `setHidePartialGlyphs()`
- CSS: ignore the `<body>` parent of `<DocFragment>`
- CSS colors: parse `rgb()/rgba()` and 4/8 digits hex values
- LVString: update/fix char props and `lStr_findWordBounds()` https://github.com/koreader/crengine/pull/468
- `UserHyphDict::getHyphenation()`: trim word with `lStr_findWordBounds()` https://github.com/koreader/crengine/pull/469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1462)
<!-- Reviewable:end -->
