### PR TITLE
Allow forgoing the whole "nightmode via grayscale fb flag" thing on some

### DIFF
--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -156,6 +156,12 @@ end
 
 
 function framebuffer:setHWNightmode(toggle)
+    -- On some devices, the fb driver does some funky post-processing with the values passed by userland...
+    -- This is catastrophically bad when this affects the rotate flag, so, don't do anything on those ;).
+    if not self.device:canModifyFBInfo() then
+        return
+    end
+
     -- Only makes sense @ 8bpp
     if self.fb_bpp ~= 8 then
         return
@@ -175,6 +181,10 @@ function framebuffer:setHWNightmode(toggle)
 end
 
 function framebuffer:getHWNightmode()
+    if not self.device:canModifyFBInfo() then
+        return false
+    end
+
     -- Only makes sense @ 8bpp
     if self.fb_bpp ~= 8 then
         return false


### PR DESCRIPTION
devices

I had momentarily blocked out the painful memory that most NTX boards do
wonderfully weird things in their ioctl handler...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1468)
<!-- Reviewable:end -->
