### PR TITLE
Update to KoboUSBMS 1.3.1

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v1.3.0
+    tags/v1.3.1
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Allows connecting to ports negotiated as CDP (which *should* be most PD-aware and not misbehaving and/or nerfed USB 3.1 (or is that 3.2 now?)/4.0 (i.e., Thunderbolt 3/4) ports).

USB is fun.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1473)
<!-- Reviewable:end -->
