### PR TITLE
Makefile.defs: fix regex to handle luarocks paths with numbers

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -19,7 +19,7 @@ NDK?=$(TOOLCHAIN_DIR)/android-ndk-r15c
 NDKABI?=14
 
 # Detect LuaRocks 3
-LR_VER_NUM := $(shell luarocks --version | grep -o [0-9].[0-9])
+LR_VER_NUM := $(shell luarocks --version | grep -o [0-9].[0-9]\$)
 LR_GT_3_0 := $(shell awk -v LR_VER_NUM=$(LR_VER_NUM) 'BEGIN { print (LR_VER_NUM >= 3.0); }')
 
 # Some CMake flags


### PR DESCRIPTION
When using nixpkgs, the path to luarocks will frequently contain
[0-9].[0-9] subpatterns in the path; for example:

  $ luarocks --version
  /nix/store/f7qgsj4zckar8jjfl3pmzklcz5wa7mz7-luarocks-3.8.0/bin/.luarocks-wrapped 3.8.0

Let's update the `LR_VER_NUM` regex to only match the number at the
*end* of the line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1485)
<!-- Reviewable:end -->
