### PR TITLE
SDL: toggle fullscreen mode

### DIFF
--- a/ffi-cdecl/SDL2_0_decl.c
+++ b/ffi-cdecl/SDL2_0_decl.c
@@ -135,6 +135,7 @@ cdecl_func(SDL_SetSurfacePalette)
 cdecl_func(SDL_LockSurface)
 cdecl_func(SDL_UnlockSurface)
 cdecl_func(SDL_SetWindowIcon)
+cdecl_func(SDL_SetWindowFullscreen)
 
 cdecl_func(SDL_GetBasePath)
 cdecl_func(SDL_GetPrefPath)

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -153,6 +153,15 @@ function S.createTexture(w, h)
         w, h)
 end
 
+
+function S.setWindowFullscreen(full_screen)
+    local flags = full_screen and SDL.SDL_WINDOW_FULLSCREEN_DESKTOP or 0
+    if SDL.SDL_SetWindowFullscreen(S.screen, flags) ~= 0 then
+        return nil, ffi.string(SDL.SDL_GetError())
+    end
+    return true
+end
+
 function S.destroyTexture(texture)
     SDL.SDL_DestroyTexture(texture)
 end

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -153,7 +153,6 @@ function S.createTexture(w, h)
         w, h)
 end
 
-
 function S.setWindowFullscreen(full_screen)
     local flags = full_screen and SDL.SDL_WINDOW_FULLSCREEN_DESKTOP or 0
     if SDL.SDL_SetWindowFullscreen(S.screen, flags) ~= 0 then

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -728,6 +728,7 @@ int SDL_SetSurfacePalette(SDL_Surface *, SDL_Palette *) __attribute__((visibilit
 int SDL_LockSurface(SDL_Surface *) __attribute__((visibility("default")));
 void SDL_UnlockSurface(SDL_Surface *) __attribute__((visibility("default")));
 void SDL_SetWindowIcon(SDL_Window *, SDL_Surface *) __attribute__((visibility("default")));
+int SDL_SetWindowFullscreen(SDL_Window *, Uint32) __attribute__((visibility("default")));
 char *SDL_GetBasePath(void) __attribute__((visibility("default")));
 char *SDL_GetPrefPath(const char *, const char *) __attribute__((visibility("default")));
 typedef enum {


### PR DESCRIPTION
Toggles between fullscreen and window mode.
When returning back to window mode previous size and position are restored.

Quite useful for Linux/ChromeOS 2in1 / convertible devices.
Might be useful on desktop too (maybe we can map it to F11 on linux?, it is not needed for mac)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1492)
<!-- Reviewable:end -->
