### PR TITLE
thirdparty/sdcv v0.5.4

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -78,7 +78,7 @@ set(WITH_READLINE False CACHE BOOL "")
 # Force utf8 command line parsing, and accept not-found -u dictnames
 set(PATCH_CMD1 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-locale-hack.patch")
 
-set(SDCV_GIT_COMMIT d054adb37c635ececabc31b147c968a480d1891a)
+set(SDCV_GIT_COMMIT tags/v0.5.4)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
https://github.com/Dushistov/sdcv/compare/v0.5.3...v0.5.4

Except of course we were on a slightly more recent commit, cf. <https://github.com/koreader/koreader-base/pull/1431>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1495)
<!-- Reviewable:end -->
