### PR TITLE
Update to HarfBuzz 4.4.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -44,7 +44,7 @@ if($ENV{ANDROID})
     set(CFG_CMD "${CFG_CMD} && ${ISED} 's|soname_spec=.*|soname_spec=\"\\\\\$libname\\\\\$release\\\\\$shared_ext\\\\\$major\"|' libtool")
 endif()
 
-set(HB_VER 3.0.0)
+set(HB_VER 4.4.0)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
ref https://github.com/koreader/koreader-base/pull/1434#issuecomment-1133254021
Shouldn't require gcc >= 5 and still work with 4.9.
Compiles and works on my emulator and my Kobo.
https://github.com/harfbuzz/harfbuzz/releases

I don't remember what failed previously, if it was compilation and noticed early, or if it compiled and just caused odd crashes on Android.
But let's see how/if it builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1496)
<!-- Reviewable:end -->
