### PR TITLE
[WIP]: Repurpose osx loader for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(ANDROID),$(LPEG_DYNLIB) $(LPEG_RE),) \
 		$(if $(WIN32),,$(ZMQ_LIB) $(CZMQ_LIB)) \
 		$(if $(WIN32),,$(OUTPUT_DIR)/sdcv) \
-		$(if $(MACOS),$(OUTPUT_DIR)/koreader,) \
+		$(if $(or $(MACOS),$(DEBIAN)),$(OUTPUT_DIR)/koreader,) \
 		$(if $(MACOS),$(SDL2_LIB),) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/dropbear,) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
@@ -213,12 +213,17 @@ $(OUTPUT_DIR)/libs/libXss.so.1: libxss-dummy.c
 include Makefile.third
 
 # ===========================================================================
-# entry point for the application in OSX
+# entry point for the desktop/SDL application
 
-$(OUTPUT_DIR)/koreader: osx_loader.c
+ifdef DARWIN
+$(OUTPUT_DIR)/koreader: desktop_loader.c
 	$(CC) -pagezero_size 10000 -image_base 100000000 \
 	-I$(LUAJIT_DIR)/src $(LUAJIT_STATIC) -o $@ $^
-
+else
+$(OUTPUT_DIR)/koreader: desktop_loader.c $(LUAJIT_STATIC)
+	$(CC) -I$(LUAJIT_DIR)/src \
+	$(CFLAGS) -Wl,-E -o $@ $^ -lm -ldl
+endif
 # ===========================================================================
 # very simple "launcher" for koreader on the remarkable
 

--- a/desktop_loader.c
+++ b/desktop_loader.c
@@ -75,18 +75,12 @@ char *executablePath() {
 int main(int argc, const char * argv[]) {
     int retval;
     char buffer[PATH_MAX];
-    char assetsPath[PATH_MAX];
     char *binPath;
     lua_State *L;
 
     binPath = executablePath();
     if (!(chdir(dirname(binPath)) == 0 && chdir(ASSETS_PATH) == 0)) {
         fprintf(stderr, "[%s]: chdir to koreader assets failed!\n", LOGNAME);
-        exit(EXIT_FAILURE);
-    }
-
-    if (getcwd(assetsPath, sizeof(assetsPath)) == NULL) {
-        fprintf(stderr, "[%s]: unable to obtain koreader assets path!\n", LOGNAME);
         exit(EXIT_FAILURE);
     }
 


### PR DESCRIPTION
Useful to enforce app name & app icon across different desktop environments, including ChromeOS.

On most DE's the icon is fine starting with the shell script but the app name is not. On some DE's and ChromeOS the app icon is missing if we start with a shell script.

Here's Gnome, for instance:

current behaviour:
![2022-07-01_22-10](https://user-images.githubusercontent.com/975883/176962776-70e62bab-f957-4170-810b-5255bb197aaa.png)

new:
![2022-07-01_22-09](https://user-images.githubusercontent.com/975883/176962794-7246f0fa-6c1b-41e0-913e-d1542c112898.png)

Requires a few changes in the frontend. 
We lost the ability of restarting the app, which is not possible without too much code changes as we're closing the lua state at the end of reader.lua.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1497)
<!-- Reviewable:end -->
