### PR TITLE
generic linux package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include Makefile.defs
 .NOTPARALLEL:
 
 DO_STRIP := $(if $(or $(EMULATE_READER),$(KODEBUG)),,1)
-DO_STRIP := $(if $(or $(DO_STRIP),$(APPIMAGE),$(DEBIAN)),1,)
+DO_STRIP := $(if $(or $(DO_STRIP),$(APPIMAGE),$(LINUX)),1,)
 
 $(info ************ Building for MACHINE: "$(MACHINE)" **********)
 $(info ************ PATH: "$(PATH)" **********)

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -58,6 +58,8 @@ else
 	export NDKABI?=18
 endif
 
+LINUX_ARCH?=native
+
 # Detect LuaRocks 3
 LR_VER_NUM := $(shell luarocks --version | grep -Eo '[0-9]+.[0-9]+')
 LR_GT_3_0 := $(shell awk -v LR_VER_NUM=$(LR_VER_NUM) 'BEGIN { print (LR_VER_NUM >= 3.0); }')
@@ -165,22 +167,16 @@ else ifeq ($(TARGET), appimage)
 	export EMULATE_READER=1
 	export SDL=1
 	export APPIMAGE=1
-else ifeq ($(TARGET), debian)
+else ifeq ($(TARGET), linux)
 	export SDL=1
-	export DEBIAN=1
-	export EMULATE_READER=1
-else ifeq ($(TARGET), debian-armel)
-	CHOST?=arm-linux-gnueabi
-	export SDL=1
-	export DEBIAN_CROSS=1
-else ifeq ($(TARGET), debian-armhf)
-	CHOST?=arm-linux-gnueabihf
-	export SDL=1
-	export DEBIAN_CROSS=1
-else ifeq ($(TARGET), debian-arm64)
-	CHOST?=aarch64-linux-gnu
-	export SDL=1
-	export DEBIAN_CROSS=1
+	ifeq ($(LINUX_ARCH), arm)
+		CHOST?=arm-linux-gnueabihf
+	else ifeq ($(LINUX_ARCH), arm64)
+		CHOST?=aarch64-linux-gnu
+	else
+		LINUX=1
+		export EMULATE_READER=1
+	endif
 else ifeq ($(TARGET), macos)
 	export SDL=1
 	export MACOS=1
@@ -524,14 +520,13 @@ else ifeq ($(TARGET), arm-generic)
 	# Defaults to generic crap
 	ARM_ARCH:=$(ARMV6_GENERIC_ARCH)
 	ARM_ARCH+=-mfloat-abi=softfp
-else ifeq ($(TARGET), debian-armel)
-	ARM_ARCH:=$(ARMV7_GENERIC_ARCH)
-	ARM_ARCH+=-mfloat-abi=softfp
-else ifeq ($(TARGET), debian-armhf)
-	ARM_ARCH:=$(ARMV7_GENERIC_ARCH)
-	ARM_ARCH+=-mfloat-abi=hard
-else ifeq ($(TARGET), debian-arm64)
-	ARM_ARCH:=$(ARM64_GENERIC_ARCH)
+else ifeq ($(TARGET), linux)
+	ifeq ($(LINUX_ARCH), arm)
+		ARM_ARCH:=$(ARMV7_GENERIC_ARCH)
+		ARM_ARCH+=-mfloat-abi=hard
+	else ifeq ($(LINUX_ARCH), arm64)
+		ARM_ARCH:=$(ARM64_GENERIC_ARCH)
+	endif
 else
 	# else, we are compiling emulator on x86
 	ARM_ARCH:=
@@ -543,7 +538,7 @@ ifdef APPIMAGE
 	HOST_ARCH:=-mtune=generic -march=x86-64
 endif
 
-ifdef DEBIAN
+ifdef LINUX
 	HOST_ARCH:=-mtune=generic
 endif
 

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -10,6 +10,9 @@ assert_var_defined(LDFLAGS)
 
 ep_get_source_dir(SOURCE_DIR)
 
+# Some of the LUA files are executables for no good reason.
+list(APPEND PATCH_CMD COMMAND chmod a-x turbo/platform.lua turbo/socket_ffi.lua turbo/syscall.lua)
+
 set(BUILD_CMD ${KO_MAKE_RECURSIVE} "CC=${CC}" "CFLAGS=${CFLAGS}" "LDFLAGS=${LDFLAGS}" all)
 
 # Drop duplicate cdefs, make sure turbo find its libtffi_wrap library, and pull in upstream fixes


### PR DESCRIPTION
* remove soft-float arm32 variant
* use `LINUX_ARCH` for cross compilation (supported are `arm` and `arm64`)

* if `LINUX_ARCH` is not `arm` or `arm64` we assume native compilation. It should work fine on all of the supported targets but only was tested against a 64 bit host.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1504)
<!-- Reviewable:end -->
