### PR TITLE
{Fake Events} for charging

### DIFF
--- a/input/libue.h
+++ b/input/libue.h
@@ -172,6 +172,7 @@ static inline void
     ue_dump_event(struct uevent* uevp)
 {
 	UE_LOG(LOG_INFO, "%s %s", uev_action_str[uevp->action], uevp->devpath);
+	printf("%s %s\n", uev_action_str[uevp->action], uevp->devpath);
 }
 
 static inline void


### PR DESCRIPTION

Kobo Sage is not always recognizing the  plug in of an usb cable  This PR should fix this.

The mass of the changes are due to tab - spaces.

The notable changes start at  line # 98.

Not quite read yet.

This is connected to the quirks from https://github.com/koreader/koreader/pull/8934

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1508)
<!-- Reviewable:end -->
