### PR TITLE
Bump sdcv to 0.5.4 + a couple of PRs to fix it

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -77,10 +77,14 @@ set(CMAKE_SKIP_BUILD_RPATH True)
 set(ENABLE_NLS False CACHE BOOL "")
 set(WITH_READLINE False CACHE BOOL "")
 
-# Force utf8 command line parsing, and accept not-found -u dictnames
-set(PATCH_CMD1 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-locale-hack.patch")
+# Don't crash when passing unknown dicts to -u
+set(PATCH_CMD1 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-pr91.patch")
+# Use proper types for off_t stuff so as not to upset large file support
+set(PATCH_CMD2 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-pr90.patch")
+# Force utf8 command line parsing
+set(PATCH_CMD3 "${KO_PATCH_SH} ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-locale-hack.patch")
 
-set(SDCV_GIT_COMMIT d054adb37c635ececabc31b147c968a480d1891a)
+set(SDCV_GIT_COMMIT tags/v0.5.4)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
@@ -96,7 +100,7 @@ download_project(
     GIT_TAG
     ${SDCV_GIT_COMMIT}
     #DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND COMMAND ${PATCH_CMD1}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3}
 )
 
 add_subdirectory("${CMAKE_BINARY_DIR}/sdcv-src"

--- a/thirdparty/sdcv/sdcv-locale-hack.patch
+++ b/thirdparty/sdcv/sdcv-locale-hack.patch
@@ -1,5 +1,5 @@
 diff --git a/src/sdcv.cpp b/src/sdcv.cpp
-index 60a21ad..8b585b4 100644
+index 46db492..d4fbcde 100644
 --- a/src/sdcv.cpp
 +++ b/src/sdcv.cpp
 @@ -63,7 +63,10 @@ static void list_dicts(const std::list<std::string> &dicts_dir_list, bool use_js
@@ -35,7 +35,7 @@ index 60a21ad..8b585b4 100644
            _("for search use only dictionary with this bookname"),
            _("bookname") },
          { "non-interactive", 'n', 0, G_OPTION_ARG_NONE, &non_interactive,
-@@ -103,7 +113,7 @@ try {
+@@ -105,7 +115,7 @@ try {
            _("output must be in utf8"), nullptr },
          { "utf8-input", '1', 0, G_OPTION_ARG_NONE, &utf8_input,
            _("input of sdcv in utf8"), nullptr },
@@ -44,14 +44,3 @@ index 60a21ad..8b585b4 100644
            _("use this directory as path to stardict data directory"),
            _("path/to/dir") },
          { "only-data-dir", 'x', 0, G_OPTION_ARG_NONE, &only_data_dir,
-@@ -186,7 +196,9 @@ try {
-         // add bookname to list
-         gchar **p = get_impl(use_dict_list);
-         while (*p) {
--            order_list.push_back(bookname_to_ifo.at(*p));
-+            if (bookname_to_ifo.count(*p) > 0) { // don't fail if -u <bookname> is not found
-+                order_list.push_back(bookname_to_ifo.at(*p));
-+            }
-             ++p;
-         }
-     } else {

--- a/thirdparty/sdcv/sdcv-pr90.patch
+++ b/thirdparty/sdcv/sdcv-pr90.patch
@@ -1,0 +1,172 @@
+diff --git a/src/dictziplib.hpp b/src/dictziplib.hpp
+index 859c295..2e81873 100644
+--- a/src/dictziplib.hpp
++++ b/src/dictziplib.hpp
+@@ -27,7 +27,7 @@ public:
+ private:
+     const char *start; /* start of mmap'd area */
+     const char *end; /* end of mmap'd area */
+-    unsigned long size; /* size of mmap */
++    off_t size; /* size of mmap */
+ 
+     int type;
+     z_stream zStream;
+@@ -47,7 +47,7 @@ private:
+     std::string origFilename;
+     std::string comment;
+     unsigned long crc;
+-    unsigned long length;
++    off_t length;
+     unsigned long compressedLength;
+     DictCache cache[DICT_CACHE_SIZE];
+     MapFile mapfile;
+diff --git a/src/mapfile.hpp b/src/mapfile.hpp
+index c69dd57..91b2543 100644
+--- a/src/mapfile.hpp
++++ b/src/mapfile.hpp
+@@ -22,13 +22,13 @@ public:
+     ~MapFile();
+     MapFile(const MapFile &) = delete;
+     MapFile &operator=(const MapFile &) = delete;
+-    bool open(const char *file_name, unsigned long file_size);
++    bool open(const char *file_name, off_t file_size);
+     gchar *begin() { return data; }
+ 
+ private:
+     char *data = nullptr;
+-    unsigned long size = 0ul;
+ #ifdef HAVE_MMAP
++    size_t size = 0u;
+     int mmap_fd = -1;
+ #elif defined(_WIN32)
+     HANDLE hFile = 0;
+@@ -36,9 +36,8 @@ private:
+ #endif
+ };
+ 
+-inline bool MapFile::open(const char *file_name, unsigned long file_size)
++inline bool MapFile::open(const char *file_name, off_t file_size)
+ {
+-    size = file_size;
+ #ifdef HAVE_MMAP
+     if ((mmap_fd = ::open(file_name, O_RDONLY)) < 0) {
+         // g_print("Open file %s failed!\n",fullfilename);
+@@ -46,14 +45,16 @@ inline bool MapFile::open(const char *file_name, unsigned long file_size)
+     }
+     struct stat st;
+     if (fstat(mmap_fd, &st) == -1 || st.st_size < 0 || (st.st_size == 0 && S_ISREG(st.st_mode))
+-        || sizeof(st.st_size) > sizeof(file_size) || static_cast<unsigned long>(st.st_size) != file_size) {
++        || st.st_size != file_size) {
+         close(mmap_fd);
+         return false;
+     }
+ 
+-    data = (gchar *)mmap(nullptr, file_size, PROT_READ, MAP_SHARED, mmap_fd, 0);
++    size = static_cast<size_t>(st.st_size);
++    data = (gchar *)mmap(nullptr, size, PROT_READ, MAP_SHARED, mmap_fd, 0);
+     if ((void *)data == (void *)(-1)) {
+         // g_print("mmap file %s failed!\n",idxfilename);
++        size = 0u;
+         data = nullptr;
+         return false;
+     }
+diff --git a/src/stardict_lib.cpp b/src/stardict_lib.cpp
+index 136fbb1..83fbc59 100644
+--- a/src/stardict_lib.cpp
++++ b/src/stardict_lib.cpp
+@@ -429,7 +429,7 @@ public:
+         if (idxfile)
+             fclose(idxfile);
+     }
+-    bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) override;
++    bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) override;
+     const gchar *get_key(glong idx) override;
+     void get_data(glong idx) override { get_key(idx); }
+     const gchar *get_key_and_data(glong idx) override
+@@ -489,7 +489,7 @@ public:
+     {
+     }
+     ~WordListIndex() { g_free(idxdatabuf); }
+-    bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) override;
++    bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) override;
+     const gchar *get_key(glong idx) override { return wordlist[idx]; }
+     void get_data(glong idx) override;
+     const gchar *get_key_and_data(glong idx) override
+@@ -615,7 +615,7 @@ bool OffsetIndex::save_cache(const std::string &url, bool verbose)
+     return false;
+ }
+ 
+-bool OffsetIndex::load(const std::string &url, gulong wc, gulong fsize, bool verbose)
++bool OffsetIndex::load(const std::string &url, gulong wc, off_t fsize, bool verbose)
+ {
+     wordcount = wc;
+     gulong npages = (wc - 1) / ENTR_PER_PAGE + 2;
+@@ -758,7 +758,7 @@ bool OffsetIndex::lookup(const char *str, std::set<glong> &idxs, glong &next_idx
+     return bFound;
+ }
+ 
+-bool WordListIndex::load(const std::string &url, gulong wc, gulong fsize, bool)
++bool WordListIndex::load(const std::string &url, gulong wc, off_t fsize, bool)
+ {
+     gzFile in = gzopen(url.c_str(), "rb");
+     if (in == nullptr)
+@@ -771,7 +771,7 @@ bool WordListIndex::load(const std::string &url, gulong wc, gulong fsize, bool)
+     if (len < 0)
+         return false;
+ 
+-    if (gulong(len) != fsize)
++    if (static_cast<off_t>(len) != fsize)
+         return false;
+ 
+     wordlist.resize(wc + 1);
+@@ -920,7 +920,7 @@ bool Dict::Lookup(const char *str, std::set<glong> &idxs, glong &next_idx)
+ 
+ bool Dict::load(const std::string &ifofilename, bool verbose)
+ {
+-    gulong idxfilesize;
++    off_t idxfilesize;
+     if (!load_ifofile(ifofilename, idxfilesize))
+         return false;
+ 
+@@ -964,7 +964,7 @@ bool Dict::load(const std::string &ifofilename, bool verbose)
+     return true;
+ }
+ 
+-bool Dict::load_ifofile(const std::string &ifofilename, gulong &idxfilesize)
++bool Dict::load_ifofile(const std::string &ifofilename, off_t &idxfilesize)
+ {
+     DictInfo dict_info;
+     if (!dict_info.load_from_ifo_file(ifofilename, false))
+diff --git a/src/stardict_lib.hpp b/src/stardict_lib.hpp
+index 49dde07..bb5c4de 100644
+--- a/src/stardict_lib.hpp
++++ b/src/stardict_lib.hpp
+@@ -77,8 +77,8 @@ struct DictInfo {
+     std::string website;
+     std::string date;
+     std::string description;
+-    guint32 index_file_size;
+-    guint32 syn_file_size;
++    off_t index_file_size;
++    off_t syn_file_size;
+     std::string sametypesequence;
+ 
+     bool load_from_ifo_file(const std::string &ifofilename, bool istreedict);
+@@ -91,7 +91,7 @@ public:
+     guint32 wordentry_size;
+ 
+     virtual ~IIndexFile() {}
+-    virtual bool load(const std::string &url, gulong wc, gulong fsize, bool verbose) = 0;
++    virtual bool load(const std::string &url, gulong wc, off_t fsize, bool verbose) = 0;
+     virtual const gchar *get_key(glong idx) = 0;
+     virtual void get_data(glong idx) = 0;
+     virtual const gchar *get_key_and_data(glong idx) = 0;
+@@ -160,7 +160,7 @@ private:
+     std::unique_ptr<IIndexFile> idx_file;
+     std::unique_ptr<SynFile> syn_file;
+ 
+-    bool load_ifofile(const std::string &ifofilename, gulong &idxfilesize);
++    bool load_ifofile(const std::string &ifofilename, off_t &idxfilesize);
+ };
+ 
+ class Libs

--- a/thirdparty/sdcv/sdcv-pr91.patch
+++ b/thirdparty/sdcv/sdcv-pr91.patch
@@ -1,0 +1,32 @@
+diff --git a/src/sdcv.cpp b/src/sdcv.cpp
+index 170ac2f..46db492 100644
+--- a/src/sdcv.cpp
++++ b/src/sdcv.cpp
+@@ -186,10 +186,11 @@ try {
+         }
+ 
+         // add bookname to list
+-        gchar **p = get_impl(use_dict_list);
+-        while (*p) {
+-            order_list.push_back(bookname_to_ifo.at(*p));
+-            ++p;
++        for (gchar **p = get_impl(use_dict_list); *p != nullptr; ++p) {
++            auto it = bookname_to_ifo.find(*p);
++            if (it != bookname_to_ifo.end()) {
++                order_list.push_back(it->second);
++            }
+         }
+     } else {
+         std::string ordering_cfg_file = std::string(g_get_user_config_dir()) + G_DIR_SEPARATOR_S "sdcv_ordering";
+@@ -201,7 +202,10 @@ try {
+         if (ordering_file != nullptr) {
+             std::string line;
+             while (stdio_getline(ordering_file, line)) {
+-                order_list.push_back(bookname_to_ifo.at(line));
++                auto it = bookname_to_ifo.find(line);
++                if (it != bookname_to_ifo.end()) {
++                    order_list.push_back(it->second);
++                }
+             }
+             fclose(ordering_file);
+         }


### PR DESCRIPTION
I'm not sure if it was actually broken for me before, but at least this one works on both Kobo & Android ;).

@pazos's hunch was nearly perfectly spot-on (my working theory is that it's the `sizeof` comparisons that were broken, quite likely because off64_t vs. ulong, and not the fstat call itself).

Split our existing patch in two, and submitted the sanest part of it upstream, because apparently I'd forgotten about it, and it happened to have been reported upstream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1516)
<!-- Reviewable:end -->
