### PR TITLE
ffiUtil: Make orderedPairs behave with mixed key types

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -677,7 +677,7 @@ local function orderedNext(t, state)
     -- We use a temporary ordered key table that is stored in the table being iterated.
 
     local key = nil
-    --print("orderedNext: state = "..tostring(state))
+    -- print("orderedNext: state = "..tostring(state))
     if state == nil then
         -- the first time, generate the index
         t.__orderedIndex = __genOrderedIndex(t)

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -655,12 +655,20 @@ end
 -- pairs(), but with *keys* sorted alphabetically.
 -- c.f., http://lua-users.org/wiki/SortedIteration
 -- See also http://lua-users.org/wiki/SortedIterationSimple
-local function __genOrderedIndex( t )
+local function __genOrderedIndex(t)
     local orderedIndex = {}
     for key in pairs(t) do
-        table.insert( orderedIndex, key )
+        table.insert(orderedIndex, key)
     end
-    table.sort( orderedIndex )
+    table.sort(orderedIndex, function(v1, v2)
+        if type(v1) ~= type(v2) then
+            -- Handle type mismatches by squashing to string
+            return tostring(v1) < tostring(v2)
+        else
+            -- Assumes said type supports the < comparison operator
+            return v1 < v2
+        end
+    end)
     return orderedIndex
 end
 
@@ -669,10 +677,10 @@ local function orderedNext(t, state)
     -- We use a temporary ordered key table that is stored in the table being iterated.
 
     local key = nil
-    --print("orderedNext: state = "..tostring(state) )
+    --print("orderedNext: state = "..tostring(state))
     if state == nil then
         -- the first time, generate the index
-        t.__orderedIndex = __genOrderedIndex( t )
+        t.__orderedIndex = __genOrderedIndex(t)
         key = t.__orderedIndex[1]
     else
         -- fetch the next value

--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -661,12 +661,12 @@ local function __genOrderedIndex(t)
         table.insert(orderedIndex, key)
     end
     table.sort(orderedIndex, function(v1, v2)
-        if type(v1) ~= type(v2) then
-            -- Handle type mismatches by squashing to string
-            return tostring(v1) < tostring(v2)
-        else
+        if type(v1) == type(v2) then
             -- Assumes said type supports the < comparison operator
             return v1 < v2
+        else
+            -- Handle type mismatches by squashing to string
+            return tostring(v1) < tostring(v2)
         end
     end)
     return orderedIndex


### PR DESCRIPTION
Usually involves sorting numbers with strings, but could theoretically be more esoteric ;).

Still assumes that matching types supports comparisons, which may not always be true for custom types without an overloaded operator...

Should be fine for our current needs, though.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1517)
<!-- Reviewable:end -->
