### PR TITLE
bump crengine: support for font-family to font name mapping

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1416,12 +1416,16 @@ static int getFontFaceFilenameAndFaceIndex(lua_State *L) {
 	lString8 filename;
 	int faceindex = -1;
 	int family = -1;
-	bool found = fontMan->getFontFileNameAndFaceIndex(lString32(facename), bold, italic, filename, faceindex, family);
+	bool has_ot_math = false;
+	bool has_emojis = false;
+	bool found = fontMan->getFontFileNameAndFaceIndex(lString32(facename), bold, italic, filename, faceindex, family, has_ot_math, has_emojis);
 	if (found) {
 		lua_pushstring(L, filename.c_str());
 		lua_pushinteger(L, faceindex);
 		lua_pushboolean(L, family == css_ff_monospace);
-		return 3;
+		lua_pushboolean(L, has_ot_math);
+		lua_pushboolean(L, has_emojis);
+		return 5;
 	}
 
 	return 0;


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/490 : 
- CSS parsing: accept (and ignore) namesspaces
- `isImage()`: more checks for `<object>` as it can have inner content
- `getFontFileNameAndFaceIndex()`: returns if font has math support
- `getFontFileNameAndFaceIndex()`: returns if font has emojis
- CSS/Fonts: add support for `font-family` to font name mapping

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1526)
<!-- Reviewable:end -->
