### PR TITLE
Makefile.defs: Use path agnostic bash location for $SHELL

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,4 +1,4 @@
-SHELL:=/bin/bash
+SHELL:=/usr/bin/env bash
 
 # Use ccache in build system by default. Define USE_NO_CCACHE=1 to force disable it.
 ifeq ($(USE_NO_CCACHE), 1)


### PR DESCRIPTION
This fixes koreader not being built on platforms where bash isnt at /bin/bash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1529)
<!-- Reviewable:end -->
