### PR TITLE
osx_loader: remove compiler flags no longer relevant since LuaJIT 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,8 +220,7 @@ include Makefile.third
 # entry point for the application in OSX
 
 $(OUTPUT_DIR)/koreader: osx_loader.c
-	$(CC) -pagezero_size 10000 -image_base 100000000 \
-	-I$(LUAJIT_DIR)/src $(LUAJIT_STATIC) -o $@ $^
+	$(CC) -I$(LUAJIT_DIR)/src $(LUAJIT_STATIC) -o $@ $^
 
 # ===========================================================================
 # very simple "launcher" for koreader on the remarkable


### PR DESCRIPTION
Probably never needed but it was part of LuaJIT instructions in mid 2020. c.f: https://github.com/koreader/koreader-base/pull/1151#discussion_r461683073

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1533)
<!-- Reviewable:end -->
