### PR TITLE
xtext: Replace soft hyphens with hyphen at eol

### DIFF
--- a/xtext.cpp
+++ b/xtext.cpp
@@ -1186,6 +1186,10 @@ public:
             lua_pushboolean(m_L, true);
             lua_rawset(m_L, -3);
         }
+
+        if (m_text[candidate_end] == 0xAD) {
+            m_text[candidate_end] = '-';
+        }
     }
 
     // Based on crengine/src/lvfntman.cpp drawTextString() with _kerningMode == KERNING_MODE_HARFBUZZ


### PR DESCRIPTION
Replaces a soft-hyphen with a hyphen, if it is at the end of a line.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1536)
<!-- Reviewable:end -->
