### PR TITLE
SDL: Fix a bunch of input timeout edge-cases

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -270,15 +270,10 @@ local SDL_BUTTON_LEFT = 1
 local is_in_touch = false
 
 function S.waitForEvent(sec, usec)
-    -- If we're asking to sleep for a non-zero amount of time, but for less than 1ms (i.e., below our precision),
-    -- round *up*, to avoid a bunch of roundtrips during that fractional ms.
-    if sec == 0 and usec ~= 0 and usec < 1000 then
-        usec = 1000
-    end
-
     local event = ffi.new("union SDL_Event")
-    -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
-    local timeout = sec and math.floor((sec * 1000000 + usec) / 1000 + 0.5) or -1
+    -- TimeVal to ms if we were passed one to begin with, otherwise, -1 => block.
+    -- NOTE: Since we have *less* precision than a timeval, we round *up*, to avoid passing zero for < 1ms timevals.
+    local timeout = sec and math.ceil((sec * 1000000 + usec) * (1/1000)) or -1
 
     -- Reset the queue
     inputQueue = {}

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -270,15 +270,17 @@ local SDL_BUTTON_LEFT = 1
 local is_in_touch = false
 
 function S.waitForEvent(sec, usec)
+    print("S.waitForEvent", sec, usec)
     local event = ffi.new("union SDL_Event")
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
-    local timeout = sec and math.floor(sec * 1000000 + usec + 0.5) / 1000 or -1
+    local timeout = sec and math.floor((sec * 1000000 + usec) / 1000 + 0.5) or -1
 
     -- Reset the queue
     inputQueue = {}
 
     -- Wait for event
     local got_event = SDL.SDL_WaitEventTimeout(event, timeout)
+    print("SDL.SDL_WaitEventTimeout", timeout, "returned", got_event)
     if got_event == 0 then
         -- ETIME
         return false, C.ETIME
@@ -413,6 +415,8 @@ function S.waitForEvent(sec, usec)
         -- send Alt + F4
         genEmuEvent(C.EV_KEY, 1073742050, 1)
         genEmuEvent(C.EV_KEY, 1073741885, 1)
+    else
+        print("Unhandled event.type:", event.type)
     end
 
     if #inputQueue > 0 then
@@ -421,6 +425,7 @@ function S.waitForEvent(sec, usec)
     else
         -- SDL returned early, but without an event we actually use.
         -- Back to Input:waitEvent to recompute the timeout
+        print("returned EINTR")
         return false, C.EINTR
     end
 end

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -270,6 +270,12 @@ local SDL_BUTTON_LEFT = 1
 local is_in_touch = false
 
 function S.waitForEvent(sec, usec)
+    -- If we're asking to sleep for a non-zero amount of time, but for less than 1ms (i.e., below our precision),
+    -- round *up*, to avoid a bunch of roundtrips during that fractional ms.
+    if sec == 0 and usec ~= 0 and usec < 1000 then
+        usec = 1000
+    end
+
     local event = ffi.new("union SDL_Event")
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor((sec * 1000000 + usec) / 1000 + 0.5) or -1

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -270,7 +270,6 @@ local SDL_BUTTON_LEFT = 1
 local is_in_touch = false
 
 function S.waitForEvent(sec, usec)
-    print("S.waitForEvent", sec, usec)
     local event = ffi.new("union SDL_Event")
     -- TimeVal's :tomsecs if we were passed one to begin with, otherwise, -1 => block
     local timeout = sec and math.floor((sec * 1000000 + usec) / 1000 + 0.5) or -1
@@ -280,7 +279,6 @@ function S.waitForEvent(sec, usec)
 
     -- Wait for event
     local got_event = SDL.SDL_WaitEventTimeout(event, timeout)
-    print("SDL.SDL_WaitEventTimeout", timeout, "returned", got_event)
     if got_event == 0 then
         -- ETIME
         return false, C.ETIME
@@ -415,8 +413,6 @@ function S.waitForEvent(sec, usec)
         -- send Alt + F4
         genEmuEvent(C.EV_KEY, 1073742050, 1)
         genEmuEvent(C.EV_KEY, 1073741885, 1)
-    else
-        print("Unhandled event.type:", event.type)
     end
 
     if #inputQueue > 0 then
@@ -425,7 +421,6 @@ function S.waitForEvent(sec, usec)
     else
         -- SDL returned early, but without an event we actually use.
         -- Back to Input:waitEvent to recompute the timeout
-        print("returned EINTR")
         return false, C.EINTR
     end
 end


### PR DESCRIPTION
One being a failure to actually round properly, which lead to potentially passing a float to a C function that takes an int; and the other being that SDL's input timeout only has ms precision, which is much coarser than us, which meant that anything > 0 and < 1 ms was asking for an immediate return for as long as that fractional ms ticked. Instead, we now round up to 1ms in these cases.

Goes hand in hand w/ https://github.com/koreader/koreader/commit/d034e1a71955b45ce02587fdcd0a58b9f491de50

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1541)
<!-- Reviewable:end -->
