### PR TITLE
cre & xtext: more soft hypheness

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -558,6 +558,18 @@ static int getHyphenationForWord(lua_State *L) {
     return 1;
 }
 
+static int softHyphenateText(lua_State *L) {
+    const char *lang = luaL_checkstring(L, 1);
+    const char *text = luaL_checkstring(L, 2);
+    TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( lString32(lang) );
+    lString32 utext = Utf8ToUnicode(text);
+    // We provide use_default_hyph_method=true, to use the hyph dict for
+    // that language, even if hyphenation is disabled in crengine
+    lString32 hyphenated_text = lang_cfg->softHyphenateText(utext, true);
+    lua_pushstring(L, UnicodeToLocal(hyphenated_text).c_str());
+    return 1;
+}
+
 static int getIntProperty(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     const char *propName = luaL_checkstring(L, 2);
@@ -3835,6 +3847,7 @@ static const struct luaL_Reg cre_func[] = {
     {"getDomVersionWithNormalizedXPointers", getDomVersionWithNormalizedXPointers},
     {"setUserHyphenationDict", setUserHyphenationDict},
     {"getHyphenationForWord", getHyphenationForWord},
+    {"softHyphenateText", softHyphenateText},
     {"renderImageData", renderImageData},
     {"smoothScaleBlitBuffer", smoothScaleBlitBuffer},
     {NULL, NULL}


### PR DESCRIPTION
#### cre.cpp: add `cre.softHyphenateText(lang, text)`

Allow getting any text soft-hyphenated according to crengine hyphenation dicts. May be used by frontend's textboxwidget to hyphenate text before wrapping and rendering it with xtext. See https://github.com/koreader/koreader/pull/9630#issuecomment-1278158193.
Bump crengine for https://github.com/koreader/crengine/pull/492 :
- TextLang: add `TextLangCfg->softHyphenateText(lang, text)`

#### xtext: properly support soft-hyphens

If soft-hyphens were present in the input text, it was considered (by libunibreak) as a candidate for breaking a line, but no real hyphen would be shown when the line is rendered.
So, be sure we properly draw a real hyphen when shaping a line ending with a soft-hyphen.
(Refactor the ellipsis substitution code so we can reuse it with hyphen substitution.)
See https://github.com/koreader/koreader/pull/9630#issuecomment-1279339219 and followups.

#### xtext: option to allow limiting usage of soft-hyphens

Add `makeLine(..., expansion_pct_rather_than_hyphen)`, which can be provided non-zero if text is going to be justified, to avoid small hyphenated words. Ie, with 100:
when about to wrap on a soft hyphen, if a wrap on a previous non-hyphen candidate would get justification to expand the spaces by less than 100% (so, at most double width spaces), consider this expansion admissible and better than this hyphen (which would probably make a small part of a word hyphenated at end of this line).

#### xtext: better ellipsis support with Arabic text

Subtituting a char with an ellipsis on Arabic text could change the "form" (initial, medial, final) of that char, possibly making the meaning of the truncated word ambiguous, but also longer and overflowing the targeted width.
Fix this by substituting with Zero-width-joinder and an ellipsis when needed, which should hopefully keep the previous char's original form.
See https://github.com/koreader/koreader/issues/5359#issuecomment-1287904250 and previous posts/attemps/discussions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1543)
<!-- Reviewable:end -->
