### PR TITLE
PB Input: Handle EV_KEY & EV_MSC translations here, instead of in front

### DIFF
--- a/ffi/input_pocketbook.lua
+++ b/ffi/input_pocketbook.lua
@@ -98,7 +98,7 @@ local function translateEvent(t, par1, par2)
         or t == C.EVT_EXIT then
         -- Handle those as MiscEvent as this makes it easy to return a string directly,
         -- which can be used in uimanager.lua as an event_handler index.
-        genEmuEvent(C.EV_MSC, t, nil)
+        genEmuEvent(C.EV_MSC, t, 0)
     else
         genEmuEvent(t, par1, par2)
     end


### PR DESCRIPTION
This makes PB logs one billion percent less mysterious, and actually allows cleaning up some nastiness in front.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1545)
<!-- Reviewable:end -->
