### PR TITLE
bump crengine: fix styles under boxing elements

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -2180,6 +2180,14 @@ bool docToWindowRect(LVDocView *tv, lvRect &rc) {
         // get top truncated/clipped to current page top
         topLeft = rc.topLeft();
         if (tv->docToWindowPoint(topLeft, false, true)) {
+            // Bottom might be just outside the page, and if top is capped
+            // to bottom, it means the full rect was outside the page
+            if ( bottomRight.y - topLeft.y <= 0 ) { // zero-height rect
+                if (!tv->docToWindowPoint(bottomRight)) {
+                    // bottom was indeed outside the page: so is this rect
+                    return false;
+                }
+            }
             rc.setTopLeft(topLeft);
             return true;
         }

--- a/cre.cpp
+++ b/cre.cpp
@@ -561,7 +561,7 @@ static int getHyphenationForWord(lua_State *L) {
 static int softHyphenateText(lua_State *L) {
     const char *lang = luaL_checkstring(L, 1);
     const char *text = luaL_checkstring(L, 2);
-    TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( lString32(lang) );
+    TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg( lString32(lang), true );
     lString32 utext = Utf8ToUnicode(text);
     // We provide use_default_hyph_method=true, to use the hyph dict for
     // that language, even if hyphenation is disabled in crengine


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/496:
- getTextLangCfg(lang_tag): add 'force' parameter (and use it in cre.cpp's softHyphenateText()).
  Fixes small issue noticed at https://github.com/koreader/koreader/pull/9630#issuecomment-1314320371
- Styles: check when inheritable CSS set on boxing elements

cre.cpp: docToWindowRect(): ignore rect over page top
See https://github.com/koreader/koreader/pull/9850#issuecomment-1336137373

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1557)
<!-- Reviewable:end -->
