### PR TITLE
mupdf: Fix corrupt pdf metadata info if longer than 255 bytes

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -276,8 +276,14 @@ function document_mt.__index:openPage(number)
 end
 
 local function getMetadataInfo(doc, info)
-    local buf = ffi.new("char[?]", 255)
-    local res = M.fz_lookup_metadata(context(), doc, info, buf, 255)
+    local bufsize = 255
+    local buf = ffi.new("char[?]", bufsize)
+    local res = M.fz_lookup_metadata(context(), doc, info, buf, bufsize)
+    if res > bufsize then
+        bufsize = res + 1
+        buf = ffi.new("char[?]", bufsize)
+        res = M.fz_lookup_metadata(context(), doc, info, buf, bufsize)
+    end
     if res > -1 then
         return ffi.string(buf, res)
     end


### PR DESCRIPTION
The function fz_lookup_metadata returns the length the metadata item actually has, not how much was written into the supplied buffer which is what the caller expects. This matters if the item is longer than the supplied fixed size buffer because ffi.string will read out of bounds and include the garbage it reads in the resulting lua string.

This is fixed by checking the return value and calling fz_lookup_metadata again with an appropriately sized buffer if the metadata item is longer than the initial buffer.

Another option would be to call the function first with a zero sized buffer, but than every call would pay the cost of two calls instead of only those calls that actually need a larger buffer.


koreader/koreader#9855

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1558)
<!-- Reviewable:end -->
