### PR TITLE
Enable SSH server for pocketbook devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ all: $(OUTPUT_DIR)/libs $(if $(ANDROID),,$(LUAJIT)) \
 		$(if $(WIN32),,$(OUTPUT_DIR)/sdcv) \
 		$(if $(MACOS),$(OUTPUT_DIR)/koreader,) \
 		$(if $(MACOS),$(SDL2_LIB),) \
-		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/dropbear,) \
-		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
+		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK)),$(OUTPUT_DIR)/dropbear,) \
+		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK)),$(OUTPUT_DIR)/sftp-server,) \
 		$(if $(or $(ANDROID),$(DARWIN),$(WIN32)),,$(OUTPUT_DIR)/tar) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK),$(REMARKABLE)),$(OUTPUT_DIR)/fbink,) \
 		$(if $(KOBO),$(OUTPUT_DIR)/data/KoboUSBMS.tar.gz,) \
@@ -44,8 +44,8 @@ ifeq ($(DO_STRIP),1)
 	STRIP_FILES="\
 		$(if $(WIN32),,$(OUTPUT_DIR)/sdcv) \
 		$(if $(or $(ANDROID),$(DARWIN),$(WIN32)),,$(OUTPUT_DIR)/tar) \
-		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/dropbear,) \
-		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO)),$(OUTPUT_DIR)/sftp-server,) \
+		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK)),$(OUTPUT_DIR)/dropbear,) \
+		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK)),$(OUTPUT_DIR)/sftp-server,) \
 		$(if $(or $(KINDLE),$(KOBO)),$(OUTPUT_DIR)/scp,) \
 		$(if $(or $(CERVANTES),$(KINDLE),$(KOBO),$(POCKETBOOK),$(REMARKABLE)),$(OUTPUT_DIR)/fbink,) \
 		$(if $(REMARKABLE),$(OUTPUT_DIR)/button-listen,) \

--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -28,6 +28,8 @@ elseif($ENV{KINDLE})
     set(PATCH_CMD7 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/dropbear-2018.76-scp-command-hack-kindle.patch")
 elseif($ENV{CERVANTES})
     set(PATCH_CMD7 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/dropbear-2018.76-scp-command-hack-cervantes.patch")
+elseif($ENV{POCKETBOOK})
+    set(PATCH_CMD7 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/dropbear-2018.76-scp-command-hack-pocketbook.patch")
 endif()
 set(PATCH_CMD8 sh -c "autoreconf -fi")
 

--- a/thirdparty/dropbear/dropbear-2018.76-scp-command-hack-pocketbook.patch
+++ b/thirdparty/dropbear/dropbear-2018.76-scp-command-hack-pocketbook.patch
@@ -1,0 +1,62 @@
+diff --git a/default_options.h b/default_options.h
+index 7d28085..c1a14ef 100644
+--- a/default_options.h
++++ b/default_options.h
+@@ -13,7 +13,7 @@ Options can also be defined with -DDROPBEAR_XXX=[0,1] in Makefile CFLAGS
+ 
+ IMPORTANT: Some options will require "make clean" after changes */
+ 
+-#define DROPBEAR_DEFPORT "22"
++#define DROPBEAR_DEFPORT "2222"
+ 
+ /* Listen on all interfaces */
+ #define DROPBEAR_DEFADDRESS ""
+@@ -34,7 +34,7 @@ IMPORTANT: Some options will require "make clean" after changes */
+  * Both of these flags can be defined at once, don't compile without at least
+  * one of them. */
+ #define NON_INETD_MODE 1
+-#define INETD_MODE 1
++#define INETD_MODE 0
+ 
+ /* Include verbose debug output, enabled with -v at runtime. 
+  * This will add a reasonable amount to your executable size. */
+@@ -250,7 +250,10 @@ Homedir is prepended unless path begins with / */
+  * OpenSSH), set the path below and set DROPBEAR_SFTPSERVER. 
+  * The sftp-server program is not provided by Dropbear itself */
+ #define DROPBEAR_SFTPSERVER 1
+-#define SFTPSERVER_PATH "/usr/libexec/sftp-server"
++#define SFTPSERVER_PATH "/mnt/ext1/applications/koreader/sftp-server"
++
++// Hack! Absolute path, no trailing slash...
++#define DBSCP_PATH "/mnt/ext1/applications/koreader"
+ 
+ /* This is used by the scp binary when used as a client binary. If you're
+  * not using the Dropbear client, you'll need to change it */
+@@ -259,6 +262,7 @@ Homedir is prepended unless path begins with / */
+ /* Whether to log commands executed by a client. This only logs the 
+  * (single) command sent to the server, not what a user did in a 
+  * shell/sftp session etc. */
++// NOTE: Consider setting this to 1 to debug our crazy scp/sftp hack...
+ #define LOG_COMMANDS 0
+ 
+ /* Window size limits. These tend to be a trade-off between memory
+diff --git a/svr-chansession.c b/svr-chansession.c
+index faf62e5..08f3ca3 100644
+--- a/svr-chansession.c
++++ b/svr-chansession.c
+@@ -661,6 +661,15 @@ static int sessioncommand(struct Channel *channel, struct ChanSess *chansess,
+ 				/* TODO - send error - too long ? */
+ 				return DROPBEAR_FAILURE;
+ 			}
++
++			// HACK. This is terrible. Truly, truly awful.
++			if (strncmp(chansess->cmd, "scp", 3) == 0) {
++				char* mangled_cmd = m_malloc(cmdlen + sizeof(DBSCP_PATH));
++				snprintf(mangled_cmd, cmdlen + sizeof(DBSCP_PATH) + 1, "%s/%s", DBSCP_PATH, chansess->cmd);
++				m_free(chansess->cmd);
++				chansess->cmd = m_strdup(mangled_cmd);
++				m_free(mangled_cmd);
++			}
+ 		}
+ 		if (issubsys) {
+ #if DROPBEAR_SFTPSERVER


### PR DESCRIPTION
Pocketbooks have a internal dropbear SSH server that is not used (I'm not sure why but most likely they use it for development). I was able to boot this SSH server so I was wondering if I it would be possible to use KoReaders dropbear server implementation with the no password improvements.

After making my own build of them it seems that this is actually working fine with some restrictions. You can only login with the `reader` user and don't have root access. But it will make debugging Pocketbooks a lot easier!

The command to login into pocketbooks is:

```
ssh -T reader@10.0.0.251 -p 2222
```

For some reason there is no tty access even when `lsof /dev/pts/*` gives results do the `-T` flag is needed else the following error will be thrown:

```
debug2: channel_input_status_confirm: type 100 id 0
PTY allocation request failed on channel 0
debug3: receive packet: type 100
debug2: channel_input_status_confirm: type 100 id 0
shell request failed on channel 0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1559)
<!-- Reviewable:end -->
