### PR TITLE
Remove old pocketbook input selection

### DIFF
--- a/ffi/input.lua
+++ b/ffi/input.lua
@@ -6,10 +6,6 @@ if util.isSDL() then
     end
 elseif util.isAndroid() then
     return require("ffi/input_android")
-    -- FIXME: Currently we support both ffi poll mode, and InkViewMain thread wrapper.
-    -- Nuke this global check once we switch the client to poll mode exclusively.
-elseif util.isPocketbook() and _G.POCKETBOOK_FFI then
+elseif util.isPocketbook() then
     return require("ffi/input_pocketbook")
-else
-    return require("libs/libkoreader-input")
 end

--- a/ffi/input.lua
+++ b/ffi/input.lua
@@ -8,4 +8,6 @@ elseif util.isAndroid() then
     return require("ffi/input_android")
 elseif util.isPocketbook() then
     return require("ffi/input_pocketbook")
+else
+    return require("libs/libkoreader-input")
 end


### PR DESCRIPTION
As discussed in https://github.com/koreader/koreader/issues/9427 removing the old global switch for pocketbook input selection.

Depends on: https://github.com/koreader/koreader/pull/9871

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1560)
<!-- Reviewable:end -->
