### PR TITLE
Third-party bumps

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v1.3.5
+    tags/v1.3.6
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -76,7 +76,7 @@ set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/koreader-luajit-enable-t
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/LuaJIT/LuaJIT
-    564147f518af5a5d8985d9e09fc3a768231f4e75
+    8625eee71f16a3a780ec92bc303c17456efc7fb3
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* LuaJIT 20221209
* KoboUSBMS 1.3.6 (for the new sage PCB)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1564)
<!-- Reviewable:end -->
