### PR TITLE
Enable gsensor EVT_ORIENTATION events on modern Pocketbook devices with InkView version 6.7

### DIFF
--- a/ffi/input_pocketbook.lua
+++ b/ffi/input_pocketbook.lua
@@ -163,7 +163,7 @@ function input:open()
         return
     end
 
-    -- This enables the inkview orientation events to be send to translateEvent
+    -- This enables the inkview orientation events to be sent to translateEvent
     C.setenv("SUPPORT_EVT_ORIENTATION", "YES", 1)
 
     -- Initialize inkview ordinarily.

--- a/ffi/input_pocketbook.lua
+++ b/ffi/input_pocketbook.lua
@@ -162,6 +162,10 @@ function input:open()
         inkview.iv_setup_gsensor()
         return
     end
+
+    -- This enables the inkview orientation events to be send to translateEvent
+    C.setenv("SUPPORT_EVT_ORIENTATION", "YES", 1)
+
     -- Initialize inkview ordinarily.
     compat.PrepareForLoop(translateEvent)
 end


### PR DESCRIPTION
This enabled the GSensor for modern PocketBook devices using the still unreleased firmware 6.7 and later.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1566)
<!-- Reviewable:end -->
