### PR TITLE
Update to KoboUSBMS 1.3.7

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v1.3.6
+    tags/v1.3.7
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
Fixes battery discovery on the Clara 2E (and make the whole sysfs node discovery less of a clusterfuck in the process ;)).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1571)
<!-- Reviewable:end -->
