### PR TITLE
xtext: fix inconsistent rendering of arabic text

### DIFF
--- a/xtext.cpp
+++ b/xtext.cpp
@@ -1747,7 +1747,7 @@ public:
         // for (int i = start; i < end; i++) {
         //     hb_buffer_add(_hb_buffer, (hb_codepoint_t)(m_text[i]), i);
         // }
-        int extra = (end == m_length) ? 1 : 0; // in case we added ZWJ+Ellipsis at end
+        int extra = (end > m_length) ? 1 : 0; // in case we added ZWJ+Ellipsis at end
         hb_buffer_add_codepoints(_hb_buffer, (hb_codepoint_t*)m_text, m_length+extra, start, end-start);
         hb_buffer_set_content_type(_hb_buffer, HB_BUFFER_CONTENT_TYPE_UNICODE);
 


### PR DESCRIPTION
Fix issue introduced by 08efc6da (#1543): when not truncating with ellipsis, an added and uninitialized trailing char was given to Harfbuzz, which could cause the last real char in Arabic text to not get its correct final form.
See https://github.com/koreader/koreader/issues/10030#issuecomment-1383172778.
Should allow closing https://github.com/koreader/koreader/issues/10030.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1574)
<!-- Reviewable:end -->
