### PR TITLE
reduce disk usage of thirdparty build directories

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -144,6 +144,7 @@ ko_write_gitclone_script(
     https://github.com/ArtifexSoftware/mupdf.git
     tags/1.13.0
     ${SOURCE_DIR}
+    "thirdparty/jbig2dec thirdparty/mujs thirdparty/openjpeg"
 )
 
 include(ExternalProject)

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -98,6 +98,7 @@ ko_write_gitclone_script(
     https://github.com/openssl/openssl.git
     OpenSSL_1_1_1q
     ${SOURCE_DIR}
+    none
 )
 
 include(ExternalProject)


### PR DESCRIPTION
- shallower clones
- sparse checkouts for the initial repos
- support not fetching/setting up any submodules
- disable all OpenSSL submodules (not used)
- only fetch/checkout the MuPDF submodules that are needed

Stats after building 3 versions (emulator debug & release versions, kindlepw2 release version):

|                                                  | master |     PR |
| -------------------------                        | ------:|-------:|
| `thirdparty/*/build/git_checkout`                |   2.6G |   296M |
| `thirdparty/*/build/x86_64-pc-linux-gnu`         |   3.2G |   1.5G |
| `thirdparty/*/build/x86_64-pc-linux-gnu-debug`   |   3.6G |   2.0G |
| `thirdparty/*/build/arm-kindlepw2-linux-gnueabi` |   3.5G |   1.8G |
| `thirdparty/*/build`                             |  13.0G |   5.5G |

Still high, but much better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1578)
<!-- Reviewable:end -->
