### PR TITLE
MuPDF: fix build

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -136,6 +136,9 @@ set(PATCH_CMD9 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/webp-upstream-697749.pat
 # add support for cbz chapters
 set(PATCH_CMD10 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/mupdf_cbz_chapter_support.patch")
 
+# don't try link with libraries when building generator helpers…
+set(PATCH_CMD11 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/fix_link_cmd.patch")
+
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
 ep_get_source_dir(SOURCE_DIR)
@@ -152,7 +155,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6} COMMAND ${PATCH_CMD7} COMMAND ${PATCH_CMD8} COMMAND ${PATCH_CMD9} COMMAND ${PATCH_CMD10}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6} COMMAND ${PATCH_CMD7} COMMAND ${PATCH_CMD8} COMMAND ${PATCH_CMD9} COMMAND ${PATCH_CMD10} COMMAND ${PATCH_CMD11}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/fix_link_cmd.patch
+++ b/thirdparty/mupdf/fix_link_cmd.patch
@@ -1,0 +1,11 @@
+--- a/Makefile	2023-02-19 19:58:09.894692877 +0100
++++ b/Makefile	2023-02-19 19:58:17.818158811 +0100
+@@ -75,7 +75,7 @@
+ CC_CMD = $(QUIET_CC) $(CC) $(CFLAGS) -o $@ -c $<
+ CXX_CMD = $(QUIET_CXX) $(CXX) $(filter-out -Wdeclaration-after-statement,$(CFLAGS)) -o $@ -c $<
+ AR_CMD = $(QUIET_AR) $(AR) cr $@ $^
+-LINK_CMD = $(QUIET_LINK) $(CC) $(LDFLAGS) -o $@ $^ $(LIBS)
++LINK_CMD = $(QUIET_LINK) $(CC) $(LDFLAGS) -o $@ $^
+ MKDIR_CMD = $(QUIET_MKDIR) mkdir -p $@
+ RM_CMD = $(QUIET_RM) rm -f $@
+ TAGS_CMD = $(QUIET_TAGS) ctags $^


### PR DESCRIPTION
Patch the makefile link command so the build process does not try to link with system libraries (e.g. `-lpeg`), even when building the generator helpers (like `cnamedump.exe`). Since mupdf's build system is only in charge of building a static library, we can just drop the `$(LIBS)` part of the link command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1586)
<!-- Reviewable:end -->
