### PR TITLE
Bump KoboUSBMS to 1.3.8

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    tags/v1.3.7
+    tags/v1.3.8
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
We now use a very slightly larger font size for the bottom status line (Re: https://github.com/koreader/koreader/issues/10097).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1587)
<!-- Reviewable:end -->
