### PR TITLE
bump crengine: minor fixes, add getPageXPointer()

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -1003,6 +1003,19 @@ static int getXPointer(lua_State *L) {
 	return 1;
 }
 
+static int getPageXPointer(lua_State *L) {
+	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+	int pageno = luaL_checkint(L, 2);
+	bool internal = false;
+	if (lua_isboolean(L, 3)) {
+		internal = lua_toboolean(L, 3);
+	}
+	ldomXPointer xp = doc->text_view->getPageBookmark(pageno - 1, true, internal);
+	lua_pushstring(L, UnicodeToLocal(xp.toString()).c_str());
+
+	return 1;
+}
+
 static int getFullHeight(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 
@@ -3963,6 +3976,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"getCurrentPos", getCurrentPos},
     {"getCurrentPercent", getCurrentPercent},
     {"getXPointer", getXPointer},
+    {"getPageXPointer", getPageXPointer},
     {"getPageOffsetX", getPageOffsetX},
     {"getPageStartY", getPageStartY},
     {"getPageHeight", getPageHeight},


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/513:
- Update German hyphenation patterns
- CSS stylesheets cache: also clear it after initial load
- getSurroundingAddedHeight(): use interline_scale_factor
- LVDocView::getNodeByPoint(): tweak again for text selection
- LVDocView::getPageBookmark(): behave as getBookmark()

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1590)
<!-- Reviewable:end -->
