### PR TITLE
Fix build on Mac OS X 13.3+ (missing ifr_netmask)

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -510,12 +510,6 @@ endif
 ifdef DARWIN_AARCH64_HOST
 # At the moment of writing, apple-m1 is the lowest common denominator for Apple silicon chips. Should work for M2 as well
 	HOST_ARCH:=-mcpu=apple-m1
-
-	# Darwin 22.4 (Ventura 13.3), and presumably later kernels don't support ifr_netmask
-	ifneq ("$(shell echo -e `uname -r`"\n22.3" | sort -Vr | head -1)", "22.3")
-		export DARWIN_AARCH64_HOST_NO_IFR_NETMASK:=1
-	endif
-
 	BREW_PREFIX:=$(shell command brew --prefix 2>/dev/null)
 	ifneq (,$(BREW_PREFIX))
 		export DARWIN_AARCH64_HOST_CFLAG:=-I$(BREW_PREFIX)/include

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -510,6 +510,12 @@ endif
 ifdef DARWIN_AARCH64_HOST
 # At the moment of writing, apple-m1 is the lowest common denominator for Apple silicon chips. Should work for M2 as well
 	HOST_ARCH:=-mcpu=apple-m1
+
+	# Darwin 22.4 (Ventura 13.3), and presumably later kernels don't support ifr_netmask
+	ifneq ("$(shell echo -e `uname -r`"\n22.3" | sort -Vr | head -1)", "22.3")
+		export DARWIN_AARCH64_HOST_NO_IFR_NETMASK:=1
+	endif
+
 	BREW_PREFIX:=$(shell command brew --prefix 2>/dev/null)
 	ifneq (,$(BREW_PREFIX))
 		export DARWIN_AARCH64_HOST_CFLAG:=-I$(BREW_PREFIX)/include

--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -33,15 +33,11 @@ endif()
 set(SED_CMD1 sh -c "${ISED} 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=\"\"|g' libtool")
 set(SED_CMD2 sh -c "${ISED} 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool")
 
-# patch: ignore limited broadcast address
-set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/zbeacon.patch")
-# patch: add _DEFAULT_SOURCE define for glibc starting at version 2.20
-set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/czmq_default_source_define.patch")
-
-if ($ENV{DARWIN_AARCH64_HOST_NO_IFR_NETMASK})
-    set(PATCH_CMD ./autogen.sh COMMAND ${PATCH_CMD2})
-else()
-    set(PATCH_CMD ./autogen.sh COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2})
+if(NOT DEFINED ENV{DARWIN})
+    # patch: ignore limited broadcast address
+    set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/zbeacon.patch")
+    # patch: add _DEFAULT_SOURCE define for glibc starting at version 2.20
+    set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/czmq_default_source_define.patch")
 endif()
 
 ko_write_gitclone_script(
@@ -55,7 +51,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND ${PATCH_CMD}
+    PATCH_COMMAND ./autogen.sh COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2}
     CONFIGURE_COMMAND COMMAND ${CFG_CMD} COMMAND ${SED_CMD1} COMMAND ${SED_CMD2}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}
     INSTALL_COMMAND ${KO_MAKE_RECURSIVE} installdirs uninstall install

--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -38,6 +38,12 @@ set(PATCH_CMD1 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/zbeacon.patch")
 # patch: add _DEFAULT_SOURCE define for glibc starting at version 2.20
 set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/czmq_default_source_define.patch")
 
+if ($ENV{DARWIN_AARCH64_HOST_NO_IFR_NETMASK})
+    set(PATCH_CMD ./autogen.sh COMMAND ${PATCH_CMD2})
+else()
+    set(PATCH_CMD ./autogen.sh COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2})
+endif()
+
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/zeromq/czmq.git
@@ -49,7 +55,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
-    PATCH_COMMAND ./autogen.sh COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2}
+    PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND COMMAND ${CFG_CMD} COMMAND ${SED_CMD1} COMMAND ${SED_CMD2}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}
     INSTALL_COMMAND ${KO_MAKE_RECURSIVE} installdirs uninstall install


### PR DESCRIPTION
https://github.com/koreader/koreader/issues/8797#issuecomment-1499554576

Mac OS X 13.3 (and 13.3.1) seems to have dropped ifr_netmask exposition in the kernel. These changes attempt to automatically omit ifr_netmask patch for czmq for Darwin 22.4+ kernels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1596)
<!-- Reviewable:end -->
