### PR TITLE
Revert "[CI] Switch Android Docker image from 18.04 to 22.04"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,11 +177,11 @@ jobs:
     <<: *XCOMPILE_TPL
     environment:
       TARGET: "android"
-      DOCKER_IMG: koreader/koandroid:0.6.0
+      DOCKER_IMG: koreader/koandroid:0.5.2
 
   android-x86:
     <<: *ANDROID_TPL
     environment:
       TARGET: "android"
       ANDROID_ARCH: "x86"
-      DOCKER_IMG: koreader/koandroid:0.6.0
+      DOCKER_IMG: koreader/koandroid:0.5.2


### PR DESCRIPTION
Reverts koreader/koreader-base#1597

The CI only checks for Android ARM anymore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1598)
<!-- Reviewable:end -->
