### PR TITLE
SDL: add multitouch support

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -331,8 +331,6 @@ end
 local SDL_BUTTON_LEFT = 1
 local SDL_BUTTON_RIGHT = 3
 
-local is_in_touch = false
-
 function S.waitForEvent(sec, usec)
     local event = ffi.new("union SDL_Event")
     -- TimeVal to ms if we were passed one to begin with, otherwise, -1 => block.

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -348,12 +348,7 @@ function S.waitForEvent(sec, usec)
     end
 
     -- if we got an event, examine it here and generate events for koreader
-    if ffi.os == "OSX" and (event.type == SDL.SDL_FINGERMOTION or
-        event.type == SDL.SDL_FINGERDOWN or
-        event.type == SDL.SDL_FINGERUP) then
-        -- noop for trackpad finger inputs which interfere with emulated mouse inputs
-        do end -- luacheck: ignore 541
-    elseif event.type == SDL.SDL_KEYDOWN then
+    if event.type == SDL.SDL_KEYDOWN then
         genEmuEvent(C.EV_KEY, event.key.keysym.sym, 1)
     elseif event.type == SDL.SDL_KEYUP then
         genEmuEvent(C.EV_KEY, event.key.keysym.sym, 0)


### PR DESCRIPTION
Partially inspired by the Android implementation.

After I added it, I suddenly realized we could've had fake multitouch on desktop for years. There's a right button on the mouse, after all. A possible alternative would be to simply fake right mouse button as being two fingers at once, as opposed to having to truly press left and right at the same time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1599)
<!-- Reviewable:end -->
