### PR TITLE
SDL: avoid silly ABS_MT_TRACKING_ID for mouse button presses

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -235,8 +235,9 @@ local function getFingerSlot(event)
 end
 
 local function genTouchDownEvent(event, slot, x, y)
+    local is_finger = event.type == SDL.SDL_FINGERDOWN
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
-    genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, tonumber(event.tfinger.fingerId))
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, is_finger and tonumber(event.tfinger.fingerId) or slot)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)


### PR DESCRIPTION
Re. <https://github.com/koreader/koreader-base/pull/1599#discussion_r1167966679>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1600)
<!-- Reviewable:end -->
