### PR TITLE
[fix] Uncomment accidentally commented out SDL_TOUCH_MOUSEID check

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -366,7 +366,7 @@ function S.waitForEvent(sec, usec)
         genEmuEvent(C.EV_KEY, event.key.keysym.sym, 0)
     elseif event.type == SDL.SDL_TEXTINPUT then
         genEmuEvent(C.EV_SDL, SDL.SDL_TEXTINPUT, ffi.string(event.text.text))
-    elseif event.type == SDL.SDL_MOUSEMOTION --and event.motion.which ~= SDL_TOUCH_MOUSEID
+    elseif event.type == SDL.SDL_MOUSEMOTION and event.motion.which ~= SDL_TOUCH_MOUSEID
         or event.type == SDL.SDL_FINGERMOTION then
         local is_finger = event.type == SDL.SDL_FINGERMOTION
         local slot


### PR DESCRIPTION
Presumably fairly harmless except in wasted processing because for motion the two are identical or close to it regardless.

Noticed in https://github.com/koreader/koreader/issues/10417#issue-1704432636

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1607)
<!-- Reviewable:end -->
