### PR TITLE
Return size of PDF page document

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -496,6 +496,7 @@ function page_mt.__index:getPageText()
     -- now we analyze the data returned by the device and bring it
     -- into the format we want to return
     local lines = {}
+    local size = 0
 
     local block = text_page.first_block
     while block ~= nil do
@@ -550,6 +551,7 @@ function page_mt.__index:getPageText()
                             x0 = word_bbox[0].x0, y0 = word_bbox[0].y0,
                             x1 = word_bbox[0].x1, y1 = word_bbox[0].y1,
                         })
+                        size = size + 5 * 8 + textlen
 
                         if ch == nil then
                             break
@@ -560,6 +562,7 @@ function page_mt.__index:getPageText()
 
                     line.x0, line.y0 = line_bbox[0].x0, line_bbox[0].y0
                     line.x1, line.y1 = line_bbox[0].x1, line_bbox[0].y1
+                    size = size + 5 * 8
 
                     table.insert(lines, line)
                 end
@@ -570,6 +573,9 @@ function page_mt.__index:getPageText()
 
         block = block.next
     end
+
+    -- Rough approximation of size for caching
+    lines.size = size
 
     M.fz_drop_stext_page(context(), text_page)
 


### PR DESCRIPTION
This is a rough approximation to be used by the caching mechanism. I assume one byte per character and a small constant size for coordinates. I don't know how much overhead the table and individual structures require.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1612)
<!-- Reviewable:end -->
