### PR TITLE
mxcfb_kindle: add temp ioctl constants

### DIFF
--- a/ffi-cdecl/mxcfb_kindle_decl.c
+++ b/ffi-cdecl/mxcfb_kindle_decl.c
@@ -46,6 +46,9 @@ cdecl_const(TEMP_USE_AUTO)
 
 cdecl_const(TEMP_USE_ZELDA_AUTO)
 
+cdecl_const(MXCFB_SET_TEMPERATURE)
+cdecl_const(MXCFB_GET_TEMPERATURE)
+
 cdecl_const(EPDC_FLAG_ENABLE_INVERSION)
 cdecl_const(EPDC_FLAG_FORCE_MONOCHROME)
 cdecl_const(EPDC_FLAG_USE_CMAP)
@@ -120,6 +123,7 @@ cdecl_enum(MTK_SWIPE_DIRECTION_ENUM)
 cdecl_struct(mxcfb_swipe_data)
 
 cdecl_struct(mxcfb_update_data_mtk)
+cdecl_struct(mxcfb_panel_info)
 cdecl_struct(mxcfb_halftone_data)
 cdecl_type(mxcfb_markers_data)
 
@@ -128,6 +132,7 @@ cdecl_const(UPDATE_FLAGS_MODE_FAST_FLAG)
 
 cdecl_const(MXCFB_SEND_UPDATE_MTK)
 cdecl_const(MXCFB_SET_NIGHTMODE_MTK)
+cdecl_const(MXCFB_GET_PANEL_INFO_MTK)
 cdecl_const(MXCFB_SET_HALFTONE_MTK)
 cdecl_const(MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE_MTK)
 cdecl_const(MXCFB_SET_UPDATE_FLAGS_MTK)

--- a/ffi/mxcfb_kindle_h.lua
+++ b/ffi/mxcfb_kindle_h.lua
@@ -34,6 +34,8 @@ static const int TEMP_USE_AMBIENT = 4096;
 static const int TEMP_USE_PAPYRUS = 4097;
 static const int TEMP_USE_AUTO = 4097;
 static const int TEMP_USE_ZELDA_AUTO = 4096;
+static const int MXCFB_SET_TEMPERATURE = 1074021932;
+static const int MXCFB_GET_TEMPERATURE = 2147763768;
 static const int EPDC_FLAG_ENABLE_INVERSION = 1;
 static const int EPDC_FLAG_FORCE_MONOCHROME = 2;
 static const int EPDC_FLAG_USE_CMAP = 4;
@@ -176,6 +178,12 @@ struct mxcfb_update_data_mtk {
   uint32_t ts_pxp;
   uint32_t ts_epdc;
 };
+struct mxcfb_panel_info {
+  char wf_file_name[100];
+  int vcom_value;
+  int temp;
+  int temp_zone;
+};
 struct mxcfb_halftone_data {
   struct mxcfb_rect region[2];
   int halftone_mode;
@@ -188,6 +196,7 @@ static const int UPDATE_FLAGS_FAST_MODE = -2147483648;
 static const int UPDATE_FLAGS_MODE_FAST_FLAG = 1;
 static const int MXCFB_SEND_UPDATE_MTK = 1080051246;
 static const int MXCFB_SET_NIGHTMODE_MTK = 2148550218;
+static const int MXCFB_GET_PANEL_INFO_MTK = 2154841904;
 static const int MXCFB_SET_HALFTONE_MTK = 1076119115;
 static const int MXCFB_WAIT_FOR_ANY_UPDATE_COMPLETE_MTK = 3221505591;
 static const int MXCFB_SET_UPDATE_FLAGS_MTK = 1074021947;


### PR DESCRIPTION
My PW5 is experiencing black -> white ghosting esp. on resume from suspend. It does not happen every time, and i suspect it is temperature dependent (it hapens most when switching climate indoors <-> outdoors) and my kindle's thermometer does not work so well :)
I adapted @poire-z footer patch from [here](https://github.com/koreader/koreader/issues/10231#issuecomment-1477138340) and indeed the temp is ~10°F above ambient, it is annoying to `ffi.cdef` the ioctl constants everywhere i need them, so let us just make the public here. also add the `mxcfb_panel_info` while i am at it.
I plan on integrating this into my SS plugin to auto adjust the temp a few degrees to compensate, and being as we pass `TEMP_USE_AMBIENT` everywhere it will go back to that with no long term effect. This approach appears to be working so far, but i need some more field testing

```lua
local ReaderFooter = require("apps/reader/modules/readerfooter")
local Screen = require("device").screen
local logger = require("logger")
local util = require("util")
local ffi = require("ffi")
local C = ffi.C
require("ffi/posix_h")
ffi.cdef[[
static const int MXCFB_SET_TEMPERATURE = 1074021932;
static const int MXCFB_GET_TEMPERATURE = 2147763768;
]]

TEMP_COUNT = "custom_text"
ReaderFooter.textGeneratorMap[TEMP_COUNT] = function(footer)
    local temp_c = ffi.new("uint32_t[1]")
    C.ioctl(Screen.fd, C.MXCFB_GET_TEMPERATURE, temp_c)
    local temp_f = (temp_c[0] * 1.8) + 32
    return temp_f .. "°"
end
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1614)
<!-- Reviewable:end -->
