### PR TITLE
fix most freetype/harfbuzz related memory leaks

### DIFF
--- a/ffi-cdecl/freetype2_decl.c
+++ b/ffi-cdecl/freetype2_decl.c
@@ -3,12 +3,13 @@
 #include "ffi-cdecl.h"
 
 #include <freetype/freetype.h>
-#include <freetype/ftsynth.h>
+#include <freetype/ftmodapi.h>
 #include <freetype/ftoutln.h>
 #include <freetype/ftsnames.h>
+#include <freetype/ftsynth.h>
+#include <freetype/ttnameid.h>
 #include <freetype/tttables.h>
 #include <freetype/tttags.h>
-#include <freetype/ttnameid.h>
 
 cdecl_type(FT_String)
 cdecl_type(FT_Byte)
@@ -94,6 +95,8 @@ cdecl_type(FT_Encoding)
 cdecl_struct(FT_CharMapRec_)
 
 cdecl_func(FT_Init_FreeType)
+cdecl_func(FT_Reference_Library)
+cdecl_func(FT_Done_Library)
 
 cdecl_func(FT_New_Face)
 cdecl_func(FT_Set_Pixel_Sizes)

--- a/ffi/freetype_h.lua
+++ b/ffi/freetype_h.lua
@@ -232,6 +232,8 @@ struct FT_CharMapRec_ {
   FT_UShort encoding_id;
 };
 FT_Error FT_Init_FreeType(FT_Library *) __attribute__((visibility("default")));
+FT_Error FT_Reference_Library(FT_Library) __attribute__((visibility("default")));
+FT_Error FT_Done_Library(FT_Library) __attribute__((visibility("default")));
 FT_Error FT_New_Face(FT_Library, const char *, FT_Long, FT_Face *) __attribute__((visibility("default")));
 FT_Error FT_Set_Pixel_Sizes(FT_Face, FT_UInt, FT_UInt) __attribute__((visibility("default")));
 FT_Error FT_Done_Face(FT_Face) __attribute__((visibility("default")));

--- a/ffi/harfbuzz.lua
+++ b/ffi/harfbuzz.lua
@@ -95,7 +95,7 @@ end
 
 -- preprocess the script/language tables into HB range sets
 local function make_set(tab)
-    local set = hb.hb_set_create()
+    local set = ffi.gc(hb.hb_set_create(), hb.hb_set_destroy)
     local first = 0
     local seen = 0
     for i=1, #tab, 2 do


### PR DESCRIPTION
There's still one small leak remaining due to using `FT_Done_Library` instead of `FT_Done_FreeType` to handle the Freetype's library lifecycle: its memory object is not freed on exit.

This is also the precursor to some [memory optimizations](https://github.com/koreader/koreader/commit/59f982c65bb9e11dde50fe8b729e7433aa037d8c).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1618)
<!-- Reviewable:end -->
