### PR TITLE
SDL: Unbreak window state save & restore

### DIFF
--- a/ffi-cdecl/SDL2_0_decl.c
+++ b/ffi-cdecl/SDL2_0_decl.c
@@ -142,6 +142,8 @@ cdecl_func(SDL_CreateTexture)
 cdecl_func(SDL_UpdateTexture)
 cdecl_func(SDL_DestroyTexture)
 cdecl_func(SDL_SetWindowTitle)
+cdecl_func(SDL_GetWindowPosition)
+cdecl_func(SDL_SetWindowPosition)
 
 cdecl_type(SDL_blit)
 cdecl_func(SDL_CreateRGBSurface)

--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -60,6 +60,7 @@ local SDL_TOUCH_MOUSEID = ffi.cast('uint32_t', -1);
 
 local S = {
     w = 0, h = 0,
+    win_w = 0, win_h = 0,
     screen = nil,
     renderer = nil,
     texture = nil,
@@ -67,8 +68,6 @@ local S = {
 }
 
 local function openGameController()
-    print("openGameController")
-    print(debug.traceback())
     local num_joysticks = SDL.SDL_NumJoysticks()
 
     if num_joysticks < 1 then
@@ -94,7 +93,6 @@ end
 
 -- initialization for both input and eink output
 function S.open(w, h, x, y)
-    print("S.open", w, h, x, y)
     if SDL.SDL_WasInit(SDL.SDL_INIT_VIDEO) ~= 0 then
         -- already initialized
         return true
@@ -117,13 +115,8 @@ function S.open(w, h, x, y)
         end
         S.win_w, S.win_h = mode.w, mode.h
     else
-        -- FIXME
-        --[[
         S.win_w = tonumber(os.getenv("EMULATE_READER_W")) or w or 600
         S.win_h = tonumber(os.getenv("EMULATE_READER_H")) or h or 800
-        --]]
-        S.win_w = w or 600
-        S.win_h = h or 800
     end
 
     -- Disable to work around an SDL issue in 2.0.22.
@@ -144,8 +137,8 @@ function S.open(w, h, x, y)
         S.win_w, S.win_h,
         bit.bor(full_screen and SDL.SDL_WINDOW_FULLSCREEN or 0, SDL.SDL_WINDOW_RESIZABLE, SDL.SDL_WINDOW_ALLOW_HIGHDPI)
     )
-    print("CreateWindow @", pos_x, pos_y)
     -- For some mysterious reason, CreateWindow doesn't give a damn about the initial position, and will enforce top-left (we get an SDL_WINDOWEVENT_MOVED), so, force its hand...
+    -- What's even more curious is that we still only get a single SDL_WINDOWEVENT_MOVED on startup, except that way it's at the requested coordinates...
     SDL.SDL_SetWindowPosition(S.screen, pos_x, pos_y)
 
     S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)

--- a/ffi/SDL2_0_h.lua
+++ b/ffi/SDL2_0_h.lua
@@ -805,6 +805,8 @@ SDL_Texture *SDL_CreateTexture(SDL_Renderer *, Uint32, int, int, int) __attribut
 int SDL_UpdateTexture(SDL_Texture *, const SDL_Rect *, const void *, int) __attribute__((visibility("default")));
 void SDL_DestroyTexture(SDL_Texture *) __attribute__((visibility("default")));
 void SDL_SetWindowTitle(SDL_Window *, const char *) __attribute__((visibility("default")));
+void SDL_GetWindowPosition(SDL_Window * window, int *x, int *y) __attribute__((visibility("default")));
+void SDL_SetWindowPosition(SDL_Window * window, int x, int y) __attribute__((visibility("default")));
 typedef int (*SDL_blit)(struct SDL_Surface *, SDL_Rect *, struct SDL_Surface *, SDL_Rect *);
 SDL_Surface *SDL_CreateRGBSurface(Uint32, int, int, int, Uint32, Uint32, Uint32, Uint32) __attribute__((visibility("default")));
 SDL_Surface *SDL_CreateRGBSurfaceFrom(void *, int, int, int, int, Uint32, Uint32, Uint32, Uint32) __attribute__((visibility("default")));

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -10,7 +10,7 @@ local framebuffer = {
 
 function framebuffer:init()
     if not self.dummy then
-        SDL.open(self.win_w, self.win_h, self.x, self.y)
+        SDL.open(self.w, self.h, self.x, self.y)
         self:_newBB()
     else
         self.bb = BB.new(600, 800)

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -10,7 +10,10 @@ local framebuffer = {
 
 function framebuffer:init()
     if not self.dummy then
+        -- Input dimensions are *window* sizes
         SDL.open(self.w, self.h, self.x, self.y)
+        -- Open might fudge them a bit on the emu, so, resync
+        self.w, self.h = SDL.win_w, SDL.win_h
         self:_newBB()
     else
         self.bb = BB.new(600, 800)


### PR DESCRIPTION
Fix https://github.com/koreader/koreader/issues/10502, regression since #1610

Well, only the size is a regression (plus, it was sortof an ffi/framebuffer API break, even if SDL is quirky in that fb.h / fb.w might not match fb.bb's dimensions because HiDPI shenanigans).

The position one is a bit of a mystery, we get an initial move event no matter what, for some reason, and without the explicit set, it's at the top left despite passing the right stuff to CreateWindow o_O.

Also dropped a duplicate openGameController call, as we handle it via an SDL_CONTROLLERDEVICEADDED event already.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1627)
<!-- Reviewable:end -->
