### PR TITLE
xtext: fix possible linking issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,12 +171,12 @@ $(OUTPUT_DIR)/libs/libkoreader-xtext.so: xtext.cpp \
 	-I$(FRIBIDI_DIR)/include/fribidi \
 	-I$(LIBUNIBREAK_DIR)/include \
 	$(DYNLIB_CXXFLAGS) $(SYMVIS_FLAGS) \
+	-Wall -o $@ xtext.cpp \
 	$(FREETYPE_LIB_LINK_FLAG) \
 	$(FRIBIDI_LIB_LINK_FLAG) \
 	$(HARFBUZZ_LIB_LINK_FLAG) \
 	$(LIBUNIBREAK_LIB_LINK_FLAG) \
-	$(LUAJIT_LIB_LINK_FLAG) \
-	-Wall -o $@ xtext.cpp
+	$(LUAJIT_LIB_LINK_FLAG)
 ifdef DARWIN
 	install_name_tool -change \
 		`otool -L "$@" | grep "libluajit" | awk '{print $$1}'` \


### PR DESCRIPTION
On some environment, putting the `-l` arguments after `-o $@ xtext.cpp` results in a library that does *not* depend on freetype, harfbuzz, etc…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1629)
<!-- Reviewable:end -->
