### PR TITLE
Build: Don't create the legacy history dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ ifeq ($(DO_STRIP),1)
 		xargs $(STRIP) --strip-unneeded
 endif
 	# set up some needed paths and links
-	install -d $(OUTPUT_DIR)/{cache,history,clipboard,fonts}
+	install -d $(OUTPUT_DIR)/{cache,clipboard,fonts}
 	ln -sf $(CURDIR)/$(THIRDPARTY_DIR)/kpvcrlib/cr3.css $(OUTPUT_DIR)/data/
 
 $(OUTPUT_DIR)/libs:


### PR DESCRIPTION
It's no longer in use, and gets deleted at runtime if empty, but its presence here means it makes it into the list of mandatory files in the `package.index` file used by OTAs, which means the *first* OTA after a fresh install will fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1643)
<!-- Reviewable:end -->
