### PR TITLE
bump crengine: CSS caption-side, SVG, CSS and table fixes

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -2619,8 +2619,12 @@ static int getHTMLFromXPointers(lua_State *L) {
 static int getStylesheetsMatchingRulesets(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     lUInt32 nodeDataIndex = (lUInt32) lua_tointeger(L, 2);
+    bool with_m_stylesheet = true;
+    if (lua_isboolean(L, 3)) {
+        with_m_stylesheet = lua_toboolean(L, 3);
+    }
     lString8Collection matches;
-    doc->text_view->gatherStylesheetsMatchingRulesets(nodeDataIndex, matches);
+    doc->text_view->gatherStylesheetsMatchingRulesets(nodeDataIndex, matches, with_m_stylesheet);
     lua_createtable(L, matches.length(), 0);
     for (int i = 0; i < matches.length(); i++) {
         lua_pushstring(L, matches[i].c_str());


### PR DESCRIPTION
Includes https://github.com/koreader/crengine/pull/524:
- SVG: support embedded base64 images when no doc
- epub.css: hide <nav hidden="">
- Tables: fix possible specified width overflow
- Tables: fix caption and table width interactions
- CSS/Tables: add support for "caption-side: top/bottom"
- gatherNodeMatchingRulesets(): avoid messing document cache
- gatherStylesheetsMatchingRulesets(): add with_m_stylesheet param

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1644)
<!-- Reviewable:end -->
