### PR TITLE
Third-party bumps

### DIFF
--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://gitlab.com/koreader/freetype2.git
-    VER-2-13-1
+    VER-2-13-2
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -78,7 +78,7 @@ set(PATCH_CMD2 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/koreader-luajit-enable-t
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/LuaJIT/LuaJIT
-    8635cbabf3094c4d8bd00578c7d812bea87bb2d3
+    41fb94defa8f830ce69a8122b03f6ac3216d392a
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -33,12 +33,12 @@ set(CFG_CMD ${CFG_CMD} --disable-readline)
 set(CFG_CMD ${CFG_CMD} --disable-static-shell)
 
 include(ExternalProject)
-set(SQLITE_VER "3420000")
+set(SQLITE_VER "3430000")
 ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     URL https://www.sqlite.org/2023/sqlite-autoconf-${SQLITE_VER}.tar.gz
-    URL_MD5 0c5a92bc51cf07cae45b4a1e94653dea
+    URL_MD5 f321a958aed13fb5f8773ae2f3504c0b
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${KO_MAKE_RECURSIVE} -j${PARALLEL_JOBS}


### PR DESCRIPTION
* LuaJIT 20230830
* SQLite 3.43.0
* FreeType 2.13.2

----

There's a bunch of fixes in that one, so I'll let the release go through first ;). (FWIW, I have it deployed for rspamd without issues, and am currently running a KOReader build w/ it).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1648)
<!-- Reviewable:end -->
