### PR TITLE
MuPDF: Backport upstream Zip64 fixes

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -140,6 +140,9 @@ set(PATCH_CMD10 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/mupdf_cbz_chapter_suppo
 # don't try link with libraries when building generator helpers…
 set(PATCH_CMD11 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/fix_link_cmd.patch")
 
+# Backport https://github.com/ArtifexSoftware/mupdf/commit/50d80e509356784720ba8a7def5359f2673697ea (handle > 2GB Zop64) to fix #10829
+set(PATCH_CMD12 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/read_large_zip.patch")
+
 # TODO: ignore shared git submodules built outside of mupdf by ourselves
 # https://git.ghostscript.com/mupdf.git is slow, so we use the official mirror on GitHub
 ep_get_source_dir(SOURCE_DIR)
@@ -156,7 +159,7 @@ ExternalProject_Add(
     ${PROJECT_NAME}
     DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
     BUILD_IN_SOURCE 1
-    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6} COMMAND ${PATCH_CMD7} COMMAND ${PATCH_CMD8} COMMAND ${PATCH_CMD9} COMMAND ${PATCH_CMD10} COMMAND ${PATCH_CMD11}
+    PATCH_COMMAND COMMAND ${PATCH_CMD1} COMMAND ${PATCH_CMD2} COMMAND ${PATCH_CMD3} COMMAND ${PATCH_CMD4} COMMAND ${PATCH_CMD5} COMMAND ${PATCH_CMD6} COMMAND ${PATCH_CMD7} COMMAND ${PATCH_CMD8} COMMAND ${PATCH_CMD9} COMMAND ${PATCH_CMD10} COMMAND ${PATCH_CMD11} COMMAND ${PATCH_CMD12}
     # skip configure
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${BUILD_CMD_GENERATE} COMMAND ${STATIC_BUILD_CMD} COMMAND ${SHARED_BUILD_CMD}

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -140,7 +140,7 @@ set(PATCH_CMD10 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/mupdf_cbz_chapter_suppo
 # don't try link with libraries when building generator helpers…
 set(PATCH_CMD11 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/fix_link_cmd.patch")
 
-# Backport https://github.com/ArtifexSoftware/mupdf/commit/50d80e509356784720ba8a7def5359f2673697ea (handle > 2GB Zop64) to fix #10829
+# Backport https://github.com/ArtifexSoftware/mupdf/commit/50d80e509356784720ba8a7def5359f2673697ea (handle > 2GB Zip64)
 set(PATCH_CMD12 "${KO_PATCH} ${CMAKE_CURRENT_SOURCE_DIR}/read_large_zip.patch")
 
 # TODO: ignore shared git submodules built outside of mupdf by ourselves

--- a/thirdparty/mupdf/read_large_zip.patch
+++ b/thirdparty/mupdf/read_large_zip.patch
@@ -1,0 +1,256 @@
+diff --git a/source/fitz/unzip.c b/source/fitz/unzip.c
+index 720b5505b..6fc80218f 100644
+--- a/source/fitz/unzip.c
++++ b/source/fitz/unzip.c
+@@ -47,7 +47,7 @@ typedef struct fz_zip_archive_s fz_zip_archive;
+ struct zip_entry_s
+ {
+ 	char *name;
+-	int offset, csize, usize;
++	uint64_t offset, csize, usize;
+ 	int crypted;
+ };
+ 
+@@ -55,7 +55,7 @@ struct fz_zip_archive_s
+ {
+ 	fz_archive super;
+ 
+-	int count;
++	uint64_t count;
+ 	zip_entry *entries;
+ 
+ 	int crypted;
+@@ -87,12 +87,14 @@ static void drop_zip_archive(fz_context *ctx, fz_archive *arch)
+ 	fz_free(ctx, zip->entries);
+ }
+ 
+-static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_offset)
++static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int64_t start_offset)
+ {
+ 	fz_stream *file = zip->super.file;
+-	int sig;
+-	int i, count, offset, csize, usize;
++	uint32_t sig;
++	int i;
+ 	int namesize, metasize, commentsize;
++	uint64_t count, offset;
++	uint64_t csize, usize;
+ 	char *name;
+ 	size_t n;
+ 	int general;
+@@ -101,16 +103,16 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ 
+ 	fz_seek(ctx, file, start_offset, 0);
+ 
+-	sig = fz_read_int32_le(ctx, file);
++	sig = fz_read_uint32_le(ctx, file);
+ 	if (sig != ZIP_END_OF_CENTRAL_DIRECTORY_SIG)
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip end of central directory signature (0x%x)", sig);
+ 
+-	(void) fz_read_int16_le(ctx, file); /* this disk */
+-	(void) fz_read_int16_le(ctx, file); /* start disk */
+-	(void) fz_read_int16_le(ctx, file); /* entries in this disk */
+-	count = fz_read_int16_le(ctx, file); /* entries in central directory disk */
+-	(void) fz_read_int32_le(ctx, file); /* size of central directory */
+-	offset = fz_read_int32_le(ctx, file); /* offset to central directory */
++	(void) fz_read_uint16_le(ctx, file); /* this disk */
++	(void) fz_read_uint16_le(ctx, file); /* start disk */
++	(void) fz_read_uint16_le(ctx, file); /* entries in this disk */
++	count = fz_read_uint16_le(ctx, file); /* entries in central directory disk */
++	(void) fz_read_uint32_le(ctx, file); /* size of central directory */
++	offset = fz_read_uint32_le(ctx, file); /* offset to central directory */
+ 
+ 	/* ZIP64 */
+ 	if (count == 0xFFFF || offset == 0xFFFFFFFF)
+@@ -119,30 +121,28 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ 
+ 		fz_seek(ctx, file, start_offset - 20, 0);
+ 
+-		sig = fz_read_int32_le(ctx, file);
++		sig = fz_read_uint32_le(ctx, file);
+ 		if (sig != ZIP64_END_OF_CENTRAL_DIRECTORY_LOCATOR_SIG)
+ 			fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip64 end of central directory locator signature (0x%x)", sig);
+ 
+-		(void) fz_read_int32_le(ctx, file); /* start disk */
+-		offset64 = fz_read_int64_le(ctx, file); /* offset to end of central directory record */
+-		if (offset64 > INT32_MAX)
+-			fz_throw(ctx, FZ_ERROR_GENERIC, "zip64 files larger than 2 GB aren't supported");
++		(void) fz_read_uint32_le(ctx, file); /* start disk */
++		offset64 = fz_read_uint64_le(ctx, file); /* offset to end of central directory record */
+ 
+ 		fz_seek(ctx, file, offset64, 0);
+ 
+-		sig = fz_read_int32_le(ctx, file);
++		sig = fz_read_uint32_le(ctx, file);
+ 		if (sig != ZIP64_END_OF_CENTRAL_DIRECTORY_SIG)
+ 			fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip64 end of central directory signature (0x%x)", sig);
+ 
+-		(void) fz_read_int64_le(ctx, file); /* size of record */
+-		(void) fz_read_int16_le(ctx, file); /* version made by */
+-		(void) fz_read_int16_le(ctx, file); /* version to extract */
+-		(void) fz_read_int32_le(ctx, file); /* disk number */
+-		(void) fz_read_int32_le(ctx, file); /* disk number start */
+-		count64 = fz_read_int64_le(ctx, file); /* entries in central directory disk */
+-		(void) fz_read_int64_le(ctx, file); /* entries in central directory */
+-		(void) fz_read_int64_le(ctx, file); /* size of central directory */
+-		offset64 = fz_read_int64_le(ctx, file); /* offset to central directory */
++		(void) fz_read_uint64_le(ctx, file); /* size of record */
++		(void) fz_read_uint16_le(ctx, file); /* version made by */
++		(void) fz_read_uint16_le(ctx, file); /* version to extract */
++		(void) fz_read_uint32_le(ctx, file); /* disk number */
++		(void) fz_read_uint32_le(ctx, file); /* disk number start */
++		count64 = fz_read_uint64_le(ctx, file); /* entries in central directory disk */
++		(void) fz_read_uint64_le(ctx, file); /* entries in central directory */
++		(void) fz_read_uint64_le(ctx, file); /* size of central directory */
++		offset64 = fz_read_uint64_le(ctx, file); /* offset to central directory */
+ 
+ 		if (count == 0xFFFF)
+ 		{
+@@ -152,8 +152,6 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ 		}
+ 		if (offset == 0xFFFFFFFF)
+ 		{
+-			if (offset64 > INT32_MAX)
+-				fz_throw(ctx, FZ_ERROR_GENERIC, "zip64 files larger than 2 GB aren't supported");
+ 			offset = offset64;
+ 		}
+ 	}
+@@ -162,26 +160,26 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ 
+ 	for (i = 0; i < count; i++)
+ 	{
+-		sig = fz_read_int32_le(ctx, file);
++		sig = fz_read_uint32_le(ctx, file);
+ 		if (sig != ZIP_CENTRAL_DIRECTORY_SIG)
+ 			fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip central directory signature (0x%x)", sig);
+ 
+-		(void) fz_read_int16_le(ctx, file); /* version made by */
+-		(void) fz_read_int16_le(ctx, file); /* version to extract */
+-		general = fz_read_int16_le(ctx, file); /* general */
+-		(void) fz_read_int16_le(ctx, file); /* method */
+-		(void) fz_read_int16_le(ctx, file); /* last mod file time */
+-		(void) fz_read_int16_le(ctx, file); /* last mod file date */
+-		(void) fz_read_int32_le(ctx, file); /* crc-32 */
+-		csize = fz_read_int32_le(ctx, file);
+-		usize = fz_read_int32_le(ctx, file);
+-		namesize = fz_read_int16_le(ctx, file);
+-		metasize = fz_read_int16_le(ctx, file);
+-		commentsize = fz_read_int16_le(ctx, file);
+-		(void) fz_read_int16_le(ctx, file); /* disk number start */
+-		(void) fz_read_int16_le(ctx, file); /* int file atts */
+-		(void) fz_read_int32_le(ctx, file); /* ext file atts */
+-		offset = fz_read_int32_le(ctx, file);
++		(void) fz_read_uint16_le(ctx, file); /* version made by */
++		(void) fz_read_uint16_le(ctx, file); /* version to extract */
++		general = fz_read_uint16_le(ctx, file); /* general */
++		(void) fz_read_uint16_le(ctx, file); /* method */
++		(void) fz_read_uint16_le(ctx, file); /* last mod file time */
++		(void) fz_read_uint16_le(ctx, file); /* last mod file date */
++		(void) fz_read_uint32_le(ctx, file); /* crc-32 */
++		csize = fz_read_uint32_le(ctx, file);
++		usize = fz_read_uint32_le(ctx, file);
++		namesize = fz_read_uint16_le(ctx, file);
++		metasize = fz_read_uint16_le(ctx, file);
++		commentsize = fz_read_uint16_le(ctx, file);
++		(void) fz_read_uint16_le(ctx, file); /* disk number start */
++		(void) fz_read_uint16_le(ctx, file); /* int file atts */
++		(void) fz_read_uint32_le(ctx, file); /* ext file atts */
++		offset = fz_read_uint32_le(ctx, file);
+ 
+ 		if (namesize < 0 || metasize < 0 || commentsize < 0)
+ 			fz_throw(ctx, FZ_ERROR_GENERIC, "invalid size in zip entry");
+@@ -194,24 +192,25 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ 
+ 		while (metasize > 0)
+ 		{
+-			int type = fz_read_int16_le(ctx, file);
+-			int size = fz_read_int16_le(ctx, file);
++			int type = fz_read_uint16_le(ctx, file);
++			int size = fz_read_uint16_le(ctx, file);
++
+ 			if (type == ZIP64_EXTRA_FIELD_SIG)
+ 			{
+ 				int sizeleft = size;
+-				if (usize == 0xFFFFFFFF && sizeleft >= 8)
++				if (usize == -1 && sizeleft >= 8)
+ 				{
+-					usize = fz_read_int64_le(ctx, file);
++					usize = fz_read_uint64_le(ctx, file);
+ 					sizeleft -= 8;
+ 				}
+-				if (csize == 0xFFFFFFFF && sizeleft >= 8)
++				if (csize == -1 && sizeleft >= 8)
+ 				{
+-					csize = fz_read_int64_le(ctx, file);
++					csize = fz_read_uint64_le(ctx, file);
+ 					sizeleft -= 8;
+ 				}
+-				if (offset == 0xFFFFFFFF && sizeleft >= 8)
++				if (offset == -1 && sizeleft >= 8)
+ 				{
+-					offset = fz_read_int64_le(ctx, file);
++					offset = fz_read_uint64_le(ctx, file);
+ 					sizeleft -= 8;
+ 				}
+ 				fz_seek(ctx, file, sizeleft - size, 1);
+@@ -245,7 +244,8 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry *ent)
+ {
+ 	fz_stream *file = zip->super.file;
+-	int sig, general, method, namelength, extralength;
++	uint32_t sig;
++	int general, method, namelength, extralength;
+ 	int i, headerid, datasize, crc32, modtime, chk;
+ 
+ 	unsigned char source[12];
+@@ -253,20 +253,20 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+ 
+ 	fz_seek(ctx, file, ent->offset, 0);
+ 
+-	sig = fz_read_int32_le(ctx, file);
++	sig = fz_read_uint32_le(ctx, file);
+ 	if (sig != ZIP_LOCAL_FILE_SIG)
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip local file signature (0x%x)", sig);
+ 
+-	(void) fz_read_int16_le(ctx, file); /* version */
++	(void) fz_read_uint16_le(ctx, file); /* version */
+ 	general = fz_read_uint16_le(ctx, file); /* general */
+ 	method = fz_read_uint16_le(ctx, file);
+ 	modtime = fz_read_uint16_le(ctx, file); /* file time */
+-	(void) fz_read_int16_le(ctx, file); /* file date */
++	(void) fz_read_uint16_le(ctx, file); /* file date */
+ 	crc32 = fz_read_uint32_le(ctx, file); /* crc-32 */
+-	(void) fz_read_int32_le(ctx, file); /* csize */
+-	(void) fz_read_int32_le(ctx, file); /* usize */
+-	namelength = fz_read_int16_le(ctx, file);
+-	extralength = fz_read_int16_le(ctx, file);
++	(void) fz_read_uint32_le(ctx, file); /* csize */
++	(void) fz_read_uint32_le(ctx, file); /* usize */
++	namelength = fz_read_uint16_le(ctx, file);
++	extralength = fz_read_uint16_le(ctx, file);
+ 
+ 	fz_seek(ctx, file, namelength, 1);
+ 
+@@ -276,10 +276,10 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+ 				headerid = fz_read_uint16_le(ctx, file);
+ 				datasize = fz_read_uint16_le(ctx, file);
+ 				if (headerid == 0x9901) {
+-					zip->aes_version = fz_read_int16_le(ctx, file);
+-					(void) fz_read_int16_le(ctx, file); /* "AE" */
++					zip->aes_version = fz_read_uint16_le(ctx, file);
++					(void) fz_read_uint16_le(ctx, file); /* "AE" */
+ 					zip->aes_encryption_mode = fz_read_byte(ctx, file);
+-					zip->aes_compression_method = fz_read_int16_le(ctx, file);
++					zip->aes_compression_method = fz_read_uint16_le(ctx, file);
+ 				}
+ 				extralength -= 2 + 2 + datasize;
+ 			}
+@@ -345,7 +345,7 @@ static void ensure_zip_entries(fz_context *ctx, fz_zip_archive *zip)
+ 		for (i = n - 4; i > 0; i--)
+ 			if (!memcmp(buf + i, "PK\5\6", 4))
+ 			{
+-				read_zip_dir_imp(ctx, zip, (int)(size - back + i));
++				read_zip_dir_imp(ctx, zip, size - back + i);
+ 				return;
+ 			}
+ 		back += sizeof buf - 4;


### PR DESCRIPTION
Allow reading files over 2GB (assuming you've got the RAM ;p).

(Fix https://github.com/koreader/koreader/issues/10829)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1649)
<!-- Reviewable:end -->
