### PR TITLE
ffi/sdl: fix `batterystat` tests when running on battery

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -583,7 +583,9 @@ function S.getPrefPath(organization, appname)
 end
 
 function S.getPowerInfo()
-    local batt, plugged, charging
+    local batt = false
+    local plugged = false
+    local charging = false
     local ptr = ffi.new("int[1]", {0})
     local battery_info = SDL.SDL_GetPowerInfo(nil, ptr)
     if battery_info == SDL.SDL_POWERSTATE_UNKNOWN


### PR DESCRIPTION
The tests explicitly check for `true` or `false` (`nil` is invalid).

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1658)
<!-- Reviewable:end -->
