### PR TITLE
RTC: Ignore obviously bogus alarm reads on dodgy RTCs

### DIFF
--- a/ffi/rtc.lua
+++ b/ffi/rtc.lua
@@ -307,7 +307,7 @@ function RTC:validateWakeupAlarmByProximity(task_alarm, proximity)
     -- On dodgy RTCs, some aging batteries are (supposedly) causing reads to report a bogus value...
     -- c.f., https://github.com/koreader/koreader/issues/7994 & https://github.com/koreader/koreader/issues/10996
     if self.dodgy_rtc and alarm_sys <= 1 then
-        print("Read back a bogus alarm value from a dodgy RTC, assuming our previously set alarm fired as expected anyway")
+        print("A dodgy RTC reported a bogus alarm value, assuming our previously set alarm fired as expected anyway")
         alarm_sys = alarm
     end
 

--- a/ffi/rtc.lua
+++ b/ffi/rtc.lua
@@ -307,7 +307,7 @@ function RTC:validateWakeupAlarmByProximity(task_alarm, proximity)
     -- On dodgy RTCs, some aging batteries are (supposedly) causing reads to report a bogus value...
     -- c.f., https://github.com/koreader/koreader/issues/7994 & https://github.com/koreader/koreader/issues/10996
     if self.dodgy_rtc and alarm_sys <= 1 then
-        print("Read back a bogus alarm value from RTC, assuming our previously set alarm will fire as expected anyway")
+        print("Read back a bogus alarm value from a dodgy RTC, assuming our previously set alarm will fire as expected anyway")
         alarm_sys = alarm
     end
 

--- a/ffi/rtc.lua
+++ b/ffi/rtc.lua
@@ -307,7 +307,7 @@ function RTC:validateWakeupAlarmByProximity(task_alarm, proximity)
     -- On dodgy RTCs, some aging batteries are (supposedly) causing reads to report a bogus value...
     -- c.f., https://github.com/koreader/koreader/issues/7994 & https://github.com/koreader/koreader/issues/10996
     if self.dodgy_rtc and alarm_sys <= 1 then
-        print("Read back a bogus alarm value from a dodgy RTC, assuming our previously set alarm will fire as expected anyway")
+        print("Read back a bogus alarm value from a dodgy RTC, assuming our previously set alarm fired as expected anyway")
         alarm_sys = alarm
     end
 


### PR DESCRIPTION
We've had a couple reports over the years of broken alarm reads on old NTX boards (in... every sense of the word; this only seems to affect old i.MX RTCs, true, but more specifically really old devices, with possibly dying batteries).

e.g., https://github.com/koreader/koreader/issues/7994 & https://github.com/koreader/koreader/issues/10996

While there *is* an ioctl that is supposed to help with this sort of stuff by reporting on the state of RTC's battery voltage, in my own testing on much less broken RTCs, it was extremely unreliable (especially when it matters most, i.e., right after a wakeup), so, that's kind of a no-go.

Thankfully, when this occurs, the returned alarm is *extremely* obviously bogus: `1`, as in, Epoch.

TL;DR: Just ignore such return values and assume the alarm did indeed fire properly, we already validate against both the task and the current time, double-checking the actual alarm is just a defensive and pedantic guard against... something... setting alarms behind our back, which should never really happen in the first place, least of all on the affected platform (Kobo) ;).

Also actually implement honoring WakeupMgr's character device selection, in case we ever need to actually use something other than rtc0 ;).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1669)
<!-- Reviewable:end -->
