### PR TITLE
Add initial RGB painting support to C blitbuffer

### DIFF
--- a/blitbuffer.h
+++ b/blitbuffer.h
@@ -132,7 +132,9 @@ typedef struct BlitBufferRGB32 {
 
 DLL_PUBLIC void BB_fill(BlitBuffer * restrict bb, uint8_t v);
 DLL_PUBLIC void BB_fill_rect(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h, uint8_t v);
+DLL_PUBLIC void BB_fill_rect_color(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h, ColorRGB32 * restrict color);
 DLL_PUBLIC void BB_blend_rect(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h, Color8A * restrict color);
+DLL_PUBLIC void BB_blend_rect_color(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h, ColorRGB32 * restrict color);
 DLL_PUBLIC void BB_invert_rect(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h);
 DLL_PUBLIC void BB_hatch_rect(BlitBuffer * restrict bb, unsigned int x, unsigned int y, unsigned int w, unsigned int h, unsigned int stripe_width, Color8 * restrict color, uint8_t alpha);
 DLL_PUBLIC void BB_blit_to_BB8(const BlitBuffer * restrict src, BlitBuffer * restrict dst,


### PR DESCRIPTION
Add new BB_fill_rect_color and BB_blend_rect_color functions taking a ColorRGB32.
Use a new is_rgb flag in Color structs for lua wrapper to decide which BB_ function to call.
If a ColorRGB32 is passed to fillRect/lightenRect then the new path will be taken. Otherwise original Color8A/uint8_t code is called.

No changes should occur for existing code paths. Callers must be patched to provide RGB colors if desired.
Lua blitbuffer implementation has not been changed.