### PR TITLE
android: update SDK command line tools and tweak NDK install

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -1,48 +1,63 @@
-SHELL:=/bin/bash
+.DELETE_ON_ERROR:
+.ONESHELL:
+
+SHELL := /bin/bash
+.SHELLFLAGS := -xec
 
 TOOLCHAIN_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
 # Sdk tools 26.1.1
-SDK_TARBALL=sdk-tools-linux-4333796.zip
-SDK_DL_URL=https://dl.google.com/android/repository/$(SDK_TARBALL)
+SDK_TARBALL = commandlinetools-linux-10406996_latest.zip
+SDK_DL_URL = https://dl.google.com/android/repository/$(SDK_TARBALL)
 
-SDK_SUM="aa190cfd7299cd6a1c687355bb2764e4"
-SDK_DIR=android-sdk-linux
+.SECONDARY: $(SDK_TARBALL)
 
-WGET?=wget --progress=dot:giga
+SDK_SUM = 87b485c7283cba69e41c10f05bf832d2fd691552
+SDK_DIR = android-sdk-linux
+
+WGET ?= wget --progress=dot:giga
 
 android-sdk: $(TOOLCHAIN_DIR)/$(SDK_DIR)
 
-$(TOOLCHAIN_DIR)/$(SDK_DIR):
-	[ -e $(SDK_TARBALL) ] || $(WGET) $(SDK_DL_URL)
-	CHECKSUM=`md5sum $(SDK_TARBALL) | awk '{ print $$1 }'`; \
-		 [[ "$$CHECKSUM" = $(SDK_SUM) ]] || \
-		 { echo "$(SDK_TARBALL) has the wrong checksum!"; exit 1; }
+$(SDK_TARBALL):
+	$(WGET) '$(SDK_DL_URL)'
+	echo '$(SDK_SUM) $(SDK_TARBALL)' | sha1sum -c -
 
-	mkdir -pv $(SDK_DIR)
-	mv -v $(SDK_TARBALL) $(SDK_DIR)
-	unzip $(SDK_DIR)/$(SDK_TARBALL) -d $(SDK_DIR)
-	pushd $(SDK_DIR)/tools/bin && \
-		yes | ./sdkmanager --update && \
-		yes | ./sdkmanager --licenses && \
-		./sdkmanager "platform-tools" "build-tools;30.0.2" "platforms;android-30" && \
-		popd
-	rm -f $(SDK_DIR)/$(SDK_TARBALL)
+$(TOOLCHAIN_DIR)/$(SDK_DIR): $(SDK_TARBALL)
+	mkdir -p $(SDK_DIR)/cmdline-tools
+	cd $(SDK_DIR)/cmdline-tools
+	unzip $(TOOLCHAIN_DIR)/$(SDK_TARBALL)
+	mv cmdline-tools latest
+	cd latest/bin
+	yes | ./sdkmanager --update
+	yes | ./sdkmanager --licenses
+	./sdkmanager 'platform-tools' 'build-tools;30.0.2' 'platforms;android-30'
+	./sdkmanager --uninstall 'emulator' # Installed automatically but we don't need it.
+	rm -f $(TOOLCHAIN_DIR)/$(SDK_TARBALL)
 
 # NDK r15c
-NDK_DIR=android-ndk-r23c
-NDK_TARBALL=$(NDK_DIR)-linux.zip
-NDK_DL_URL=https://dl.google.com/android/repository/$(NDK_TARBALL)
-NDK_SUM="e5053c126a47e84726d9f7173a04686a71f9a67a"
+NDK_DIR = android-ndk-r23c
+NDK_TARBALL = $(NDK_DIR)-linux.zip
+NDK_DL_URL = https://dl.google.com/android/repository/$(NDK_TARBALL)
+NDK_SUM = e5053c126a47e84726d9f7173a04686a71f9a67a
+
+.SECONDARY: $(NDK_TARBALL)
 
 android-ndk: $(TOOLCHAIN_DIR)/$(NDK_DIR)
 
-$(TOOLCHAIN_DIR)/$(NDK_DIR):
-	[ -e $(NDK_TARBALL) ] || $(WGET) $(NDK_DL_URL)
-	CHECKSUM=`sha1sum $(NDK_TARBALL) | awk '{ print $$1 }'`; \
-		 [[ "$$CHECKSUM" = $(NDK_SUM) ]] || \
-		 { echo "$(NDK_TARBALL) has the wrong checksum!"; exit 1; }
+$(NDK_TARBALL):
+	$(WGET) '$(NDK_DL_URL)'
+	echo '$(NDK_SUM) $(NDK_TARBALL)' | sha1sum -c -
+
+$(TOOLCHAIN_DIR)/$(NDK_DIR): $(NDK_TARBALL)
 	unzip $(NDK_TARBALL)
+	# Trim the fat.
+	rm -vrf $(NDK_DIR)/toolchains/renderscript
+	rm -vrf $(NDK_DIR)/toolchains/llvm/prebuilt/linux-x86_64/bin/*1[67]-clang*
+	rm -vrf $(NDK_DIR)/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/*/1[67]
+	if which hardlink; then
+	  hardlink $(NDK_DIR)
+	fi
 	rm -f $(NDK_TARBALL)
 
 android: android-sdk android-ndk


### PR DESCRIPTION
To allow updating the OpenJDK Java version to 17.

Cf. https://github.com/koreader/android-luajit-launcher/pull/445. Next step will be to try to update the Android Docker image to 22.04 again, and if that does not work, it looks like `openjdk-17-jdk-headless` is available on Bionic, so fallback to that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1682)
<!-- Reviewable:end -->
