### PR TITLE
cmake: fix warnings about `cmake_minimum_required(…)`

### DIFF
--- a/thirdparty/curl/CMakeLists.txt
+++ b/thirdparty/curl/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(curl)
 cmake_minimum_required(VERSION 3.5.1)
+project(curl)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(czmq)
 cmake_minimum_required(VERSION 3.5.1)
+project(czmq)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(djvulibre)
 cmake_minimum_required(VERSION 3.5.1)
+project(djvulibre)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(dropbear)
 cmake_minimum_required(VERSION 3.5.1)
+project(dropbear)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(fbink)
 cmake_minimum_required(VERSION 3.5.1)
+project(fbink)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(freetype2)
 cmake_minimum_required(VERSION 3.5.1)
+project(freetype2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/fribidi/CMakeLists.txt
+++ b/thirdparty/fribidi/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(fribidi)
 cmake_minimum_required(VERSION 3.5.1)
+project(fribidi)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(gettext)
 cmake_minimum_required(VERSION 3.5.1)
+project(gettext)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/giflib/CMakeLists.txt
+++ b/thirdparty/giflib/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(giflib)
 cmake_minimum_required(VERSION 3.5.1)
+project(giflib)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/glib/CMakeLists.txt
+++ b/thirdparty/glib/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(glib)
 cmake_minimum_required(VERSION 3.5.1)
+project(glib)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(harfbuzz)
 cmake_minimum_required(VERSION 3.5.1)
+project(harfbuzz)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(kobo-usbms)
 cmake_minimum_required(VERSION 3.5.1)
+project(kobo-usbms)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(kpvcrlib)
 cmake_minimum_required(VERSION 3.5.1)
+project(kpvcrlib)
 enable_language(C CXX ASM)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")

--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(leptonica)
 cmake_minimum_required(VERSION 3.5.1)
+project(leptonica)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libffi/CMakeLists.txt
+++ b/thirdparty/libffi/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libffi)
 cmake_minimum_required(VERSION 3.5.1)
+project(libffi)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libiconv/CMakeLists.txt
+++ b/thirdparty/libiconv/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libiconv)
 cmake_minimum_required(VERSION 3.5.1)
+project(libiconv)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libjpeg-turbo)
 cmake_minimum_required(VERSION 3.5.1)
+project(libjpeg-turbo)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libk2pdfopt)
 cmake_minimum_required(VERSION 3.5.1)
+project(libk2pdfopt)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libpng/CMakeLists.txt
+++ b/thirdparty/libpng/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libpng)
 cmake_minimum_required(VERSION 3.5.1)
+project(libpng)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libunibreak)
 cmake_minimum_required(VERSION 3.5.1)
+project(libunibreak)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libwebp/CMakeLists.txt
+++ b/thirdparty/libwebp/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libwebp)
 cmake_minimum_required(VERSION 3.5.1)
+project(libwebp)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/libzmq/CMakeLists.txt
+++ b/thirdparty/libzmq/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(libzmq)
 cmake_minimum_required(VERSION 3.5.1)
+project(libzmq)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lj-wpaclient/CMakeLists.txt
+++ b/thirdparty/lj-wpaclient/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lj-wpaclient)
 cmake_minimum_required(VERSION 3.5.1)
+project(lj-wpaclient)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lodepng/CMakeLists.txt
+++ b/thirdparty/lodepng/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lodepng)
 cmake_minimum_required(VERSION 3.5.1)
+project(lodepng)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lpeg/CMakeLists.txt
+++ b/thirdparty/lpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lpeg)
 cmake_minimum_required(VERSION 3.5.1)
+project(lpeg)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lua-Spore/CMakeLists.txt
+++ b/thirdparty/lua-Spore/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lua-Spore)
 cmake_minimum_required(VERSION 3.5.1)
+project(lua-Spore)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lua-htmlparser/CMakeLists.txt
+++ b/thirdparty/lua-htmlparser/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lua-htmlparser)
 cmake_minimum_required(VERSION 3.5.1)
+project(lua-htmlparser)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lua-rapidjson/CMakeLists.txt
+++ b/thirdparty/lua-rapidjson/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lua-rapidjson)
 cmake_minimum_required(VERSION 3.5.1)
+project(lua-rapidjson)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(luajit)
 cmake_minimum_required(VERSION 3.5.1)
+project(luajit)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luasec/CMakeLists.txt
+++ b/thirdparty/luasec/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(luasec)
 cmake_minimum_required(VERSION 3.5.1)
+project(luasec)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/luasocket/CMakeLists.txt
+++ b/thirdparty/luasocket/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(luasocket)
 cmake_minimum_required(VERSION 3.5.1)
+project(luasocket)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/lunasvg/CMakeLists.txt
+++ b/thirdparty/lunasvg/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(lunasvg)
 cmake_minimum_required(VERSION 3.5.1)
+project(lunasvg)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(minizip)
 cmake_minimum_required(VERSION 3.5.1)
+project(minizip)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(mupdf)
 cmake_minimum_required(VERSION 3.5.1)
+project(mupdf)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/nanosvg/CMakeLists.txt
+++ b/thirdparty/nanosvg/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(nanosvg)
 cmake_minimum_required(VERSION 3.5.1)
+project(nanosvg)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/openssh/CMakeLists.txt
+++ b/thirdparty/openssh/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(openssh)
 cmake_minimum_required(VERSION 3.5.1)
+project(openssh)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(openssl)
 cmake_minimum_required(VERSION 3.5.1)
+project(openssl)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/popen-noshell/CMakeLists.txt
+++ b/thirdparty/popen-noshell/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(popen-noshell)
 cmake_minimum_required(VERSION 3.5.1)
+project(popen-noshell)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(sdcv)
 cmake_minimum_required(VERSION 3.5.1)
+project(sdcv)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(sdl2)
 cmake_minimum_required(VERSION 3.5.1)
+project(sdl2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(sqlite)
 cmake_minimum_required(VERSION 3.5.1)
+project(sqlite)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(tar)
 cmake_minimum_required(VERSION 3.5.1)
+project(tar)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/tesseract/CMakeLists.txt
+++ b/thirdparty/tesseract/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(tesseract)
 cmake_minimum_required(VERSION 3.5.1)
+project(tesseract)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(turbo)
 cmake_minimum_required(VERSION 3.5.1)
+project(turbo)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/utf8proc/CMakeLists.txt
+++ b/thirdparty/utf8proc/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(utf8proc)
 cmake_minimum_required(VERSION 3.5.1)
+project(utf8proc)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(zlib)
 cmake_minimum_required(VERSION 3.5.1)
+project(zlib)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zstd/CMakeLists.txt
+++ b/thirdparty/zstd/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(zstd)
 cmake_minimum_required(VERSION 3.5.1)
+project(zstd)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")

--- a/thirdparty/zsync2/CMakeLists.txt
+++ b/thirdparty/zsync2/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(zsync2)
 cmake_minimum_required(VERSION 3.5.1)
+project(zsync2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
 include("koreader_thirdparty_common")


### PR DESCRIPTION
```
CMake Warning (dev) at CMakeLists.txt:1 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1684)
<!-- Reviewable:end -->
