### PR TITLE
Input: Ensure clearTimer won't compute a lower nfds value than one of our opened fds

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -172,11 +172,11 @@ static int openInputDevice(lua_State* L)
 
     // NOTE: Make sure the top member has the highest fd number, for clearTimer's sake when it recomputes nfds
     if (fd_idx > 0) {
+        int prev_fd   = inputfds[fd_idx - 1];
         int opened_fd = inputfds[fd_idx];
-        int top_fd    = inputfds[fd_idx - 1];
-        if (opened_fd < top_fd) {
+        if (opened_fd < prev_fd) {
             inputfds[fd_idx - 1] = opened_fd;
-            inputfds[fd_idx]     = top_fd;
+            inputfds[fd_idx]     = prev_fd;
         }
     }
 

--- a/input/input.c
+++ b/input/input.c
@@ -170,6 +170,16 @@ static int openInputDevice(lua_State* L)
         }
     }
 
+    // NOTE: Make sure the top member has the highest fd number, for clearTimer's sake when it recomputes nfds
+    if (fd_idx > 0) {
+        int opened_fd = inputfds[fd_idx];
+        int top_fd    = inputfds[fd_idx - 1];
+        if (opened_fd < top_fd) {
+            inputfds[fd_idx - 1] = opened_fd;
+            inputfds[fd_idx]     = top_fd;
+        }
+    }
+
     // We're done w/ inputdevice, pop it
     lua_settop(L, 0);
     // Pass the fd to Lua, we might need it for FFI ioctl shenanigans

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -172,8 +172,9 @@ static int clearTimer(lua_State* L)
     timerfd_list_delete_node(&timerfds, expired_node);
 
     // Re-compute nfds...
-    // FIXME: This assumes that inputfds are *sorted* in increasing order...
-    nfds = inputfds[fd_idx - 1U] + 1;  // NOTE: Assumes that we've got at least one fd open, which should always hold true.
+    // NOTE: Assumes that we've got at least one fd open, which should always hold true.
+    // NOTE: Also assumes that the top fd in the array is the one with the highest fd number, which openInputDevice makes sure of.
+    nfds = inputfds[fd_idx - 1U] + 1;
     for (timerfd_node_t* restrict node = timerfds.head; node != NULL; node = node->next) {
         if (node->fd >= nfds) {
             nfds = node->fd + 1;

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -172,6 +172,7 @@ static int clearTimer(lua_State* L)
     timerfd_list_delete_node(&timerfds, expired_node);
 
     // Re-compute nfds...
+    // FIXME: This assumes that inputfds are *sorted* in increasing order...
     nfds = inputfds[fd_idx - 1U] + 1;  // NOTE: Assumes that we've got at least one fd open, which should always hold true.
     for (timerfd_node_t* restrict node = timerfds.head; node != NULL; node = node->next) {
         if (node->fd >= nfds) {


### PR DESCRIPTION
By making sure in openInputDevice that the top member of the array also happens to be the highest fd number.

----

Initial draft below:

Mention that nfds computations assume the inputfds array is sorted in increasing fd numbers

This doesn't necessarily hold true in practice (e.g., if one were to first open an fd during a directory walk with a few dir/file fds open...)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1685)
<!-- Reviewable:end -->
