### PR TITLE
minor Makefile cleanups

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -230,14 +230,7 @@ USE_LUAJIT_LIB=$(or $(DARWIN),$(ANDROID),$(WIN32))
 
 SKIP_LUAJIT_BIN=$(or $(ANDROID),$(MACOS))
 
-# handle utility params on different host systems
-ifdef DARWINHOST
-	RCP:=cp -R
-	ISED:=sed -i '' -e
-else
-	RCP:=cp -r
-	ISED:=sed -i -e
-endif
+RCP := cp -R
 
 # unknown device
 ifdef SBOX_UNAME_MACHINE


### PR DESCRIPTION
- `RCP`: use `cp -R` (supported on all systems we care about)
- `ISED`: get rid of it (none of the makefiles use it)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1687)
<!-- Reviewable:end -->
