### PR TITLE
fix crengine compilation cache

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -752,7 +752,7 @@ CRENGINE_SRC_FILES+=$(wildcard $(CRENGINE_SRC_DIR)/crengine/src/*_h.*)
 CRENGINE_LIB = $(CRENGINE_BUILD_DIR)/libcrengine.a
 CRENGINE_THIRDPARTY_LIBS = $(addprefix $(CRENGINE_BUILD_DIR)/crengine/thirdparty/, antiword/libantiword.a chmlib/libchmlib.a)
 CRENGINE_CFLAGS = \
-		--include '$(CRENGINE_BUILD_DIR)/crsetup.h' \
+		-include '$(CRENGINE_BUILD_DIR)/crsetup.h' \
 		'-I$(CRENGINE_SRC_DIR)/crengine/include' \
 		'-I$(FREETYPE_DIR)/include/freetype2' \
 		'-I$(HARFBUZZ_DIR)/include/harfbuzz' \

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -70,7 +70,7 @@ configure_file(crsetup.h.cmake crsetup.h)
 # Some source files use `#include "crsetup.h"`, others
 # `#include "../include/crsetup.h"`, so use the brute
 # force approach…
-add_definitions(--include "${CMAKE_CURRENT_BINARY_DIR}/crsetup.h")
+add_definitions(-include "${CMAKE_CURRENT_BINARY_DIR}/crsetup.h")
 
 message("Will build LIBCHM library")
 add_subdirectory(${CR_3RDPARTY_DIR}/chmlib)


### PR DESCRIPTION
Use `-include […]/crsetup.h` instead of `--include […]/crsetup.h`, as the later would result in 0% cacheable calls when building with ccache (cf. [ccache issue #1324](https://github.com/ccache/ccache/issues/1324))…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1691)
<!-- Reviewable:end -->
