### PR TITLE
Add ffi definitions for libcrypto

### DIFF
--- a/ffi-cdecl/crypto_decl.c
+++ b/ffi-cdecl/crypto_decl.c
@@ -1,0 +1,5 @@
+#include <openssl/evp.h>
+
+#include "ffi-cdecl.h"
+
+cdecl_func(PKCS5_PBKDF2_HMAC_SHA1)

--- a/ffi/crypto.lua
+++ b/ffi/crypto.lua
@@ -1,0 +1,28 @@
+--[[--
+LuaJIT FFI wrapper for libcrypto (OpenSSL).
+
+@module ffi.crypto
+]]
+
+local ffi = require("ffi")
+require("ffi/crypto_h")
+
+local libcrypto
+if ffi.os == "Windows" then
+    libcrypto = ffi.load("libs/libcrypto.dll")
+elseif ffi.os == "OSX" then
+    libcrypto = ffi.load("libs/libcrypto.1.1.dylib")
+else
+    libcrypto = ffi.load("libs/libcrypto.so.1.1")
+end
+
+local crypto = {}
+
+function crypto.pbkdf2_hmac_sha1(pass, salt, iterations, key_len)
+    local buf = ffi.new("char[?]", key_len)
+    local res = libcrypto.PKCS5_PBKDF2_HMAC_SHA1(pass, #pass, salt, #salt, iterations, key_len, buf)
+    assert(res == 1)
+    return ffi.string(buf, key_len)
+end
+
+return crypto

--- a/ffi/crypto_h.lua
+++ b/ffi/crypto_h.lua
@@ -1,0 +1,7 @@
+local ffi = require("ffi")
+
+ffi.cdef[[
+int PKCS5_PBKDF2_HMAC_SHA1(const char *pass, int passlen,
+                           const unsigned char *salt, int saltlen, int iter,
+                           int keylen, unsigned char *out);
+]]


### PR DESCRIPTION
PBKDF2 with HMAC-SHA1 is used by WPA to derive the PSK. We currently use wpa_passphrase to calculate this PSK. Since we already bundle OpenSSL, and OpenSSL has a function for PBKDF2 with HMAC-SHA1, we can replace wpa_passphrase with a direct function call.

See koreader/koreader#11089 where the function is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1693)
<!-- Reviewable:end -->
