### PR TITLE
cre: add `setCacheFileStale` method

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -747,6 +747,12 @@ static int isCacheFileStale(lua_State *L) {
     return 1;
 }
 
+static int setCacheFileStale(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    doc->dom_doc->setCacheFileStale(lua_toboolean(L, 2));
+    return 0;
+}
+
 static int invalidateCacheFile(lua_State *L) {
     CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
     doc->dom_doc->invalidateCacheFile();
@@ -4026,6 +4032,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"isBuiltDomStale", isBuiltDomStale},
     {"hasCacheFile", hasCacheFile},
     {"isCacheFileStale", isCacheFileStale},
+    {"setCacheFileStale", setCacheFileStale},
     {"invalidateCacheFile", invalidateCacheFile},
     {"getCacheFilePath", getCacheFilePath},
     {"updateTocAndPageMap", updateTocAndPageMap},


### PR DESCRIPTION
To be used (`document:setCacheFileStale(false)`) to ensure the cache is not being updated when closing a document from a forked process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1696)
<!-- Reviewable:end -->
