### PR TITLE
Work around FriBiDi include Makefile.third problem

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -61,7 +61,7 @@ ifdef DARWIN
 		$(UTF8PROC_LIB)
 endif
 
-$(FRIBIDI_LIB) $(FRIBIDI_DIR)/include: $(THIRDPARTY_DIR)/fribidi/*.*
+$(FRIBIDI_LIB) $(FRIBIDI_DIR)/include/fribidi: $(THIRDPARTY_DIR)/fribidi/*.*
 	install -d $(FRIBIDI_BUILD_DIR)
 	cd $(FRIBIDI_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -253,7 +253,7 @@ endif
 # crengine, fetched via GIT as a submodule
 $(CRENGINE_LIB) $(CRENGINE_THIRDPARTY_LIBS): $(CRENGINE_SRC_FILES) \
 		$(FREETYPE_DIR)/include \
-		$(FRIBIDI_DIR)/include \
+		$(FRIBIDI_DIR)/include/fribidi \
 		$(HARFBUZZ_DIR)/include \
 		$(JPEG_DIR)/include \
 		$(LIBUNIBREAK_DIR)/include \


### PR DESCRIPTION
This is one potential solution to fixing the regression introduced by #1679. I don't support this solution, nor its friend of adding a `touch $(FRIBIDI_DIR)/include` at the bottom.

Including (hah!) most these `/include`s seems to be a mistake. They are to be generated by their relevant targets. Either they fail or they don't, simple, no weirdness. They're targets for the target!

--

~~Just as an fyi for archival purposes. Real PR in #1699.~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1698)
<!-- Reviewable:end -->
