### PR TITLE
Fix a number of `Makefile.third` rules

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -13,7 +13,7 @@ fetchthirdparty:
 		&& (cd thirdparty/kpvcrlib/crengine; git checkout .) \
 		|| echo warn: crengine folder not found
 
-$(FREETYPE_LIB) $(FREETYPE_DIR)/include: $(THIRDPARTY_DIR)/freetype2/*.*
+$(FREETYPE_LIB): $(THIRDPARTY_DIR)/freetype2/*.*
 	install -d $(FREETYPE_BUILD_DIR)
 	cd $(FREETYPE_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -27,7 +27,7 @@ $(FREETYPE_LIB) $(FREETYPE_DIR)/include: $(THIRDPARTY_DIR)/freetype2/*.*
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 	cp -fL $(FREETYPE_DIR)/$(if $(WIN32),bin,lib)/$(notdir $(FREETYPE_LIB)) $(FREETYPE_LIB)
 
-$(HARFBUZZ_LIB) $(HARFBUZZ_DIR)/include: $(THIRDPARTY_DIR)/harfbuzz/*.*
+$(HARFBUZZ_LIB): $(THIRDPARTY_DIR)/harfbuzz/*.*
 	install -d $(HARFBUZZ_BUILD_DIR)
 	cd $(HARFBUZZ_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -61,7 +61,7 @@ ifdef DARWIN
 		$(UTF8PROC_LIB)
 endif
 
-$(FRIBIDI_LIB) $(FRIBIDI_DIR)/include: $(THIRDPARTY_DIR)/fribidi/*.*
+$(FRIBIDI_LIB): $(THIRDPARTY_DIR)/fribidi/*.*
 	install -d $(FRIBIDI_BUILD_DIR)
 	cd $(FRIBIDI_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -74,7 +74,7 @@ $(FRIBIDI_LIB) $(FRIBIDI_DIR)/include: $(THIRDPARTY_DIR)/fribidi/*.*
 	cp -fL $(FRIBIDI_DIR)/lib/$(notdir $(FRIBIDI_LIB)) $(FRIBIDI_LIB)
 	chmod 755 $(FRIBIDI_LIB)
 
-$(LIBUNIBREAK_LIB) $(LIBUNIBREAK_DIR)/include: $(THIRDPARTY_DIR)/libunibreak/*.*
+$(LIBUNIBREAK_LIB): $(THIRDPARTY_DIR)/libunibreak/*.*
 	install -d $(LIBUNIBREAK_BUILD_DIR)
 	cd $(LIBUNIBREAK_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -88,7 +88,7 @@ $(LIBUNIBREAK_LIB) $(LIBUNIBREAK_DIR)/include: $(THIRDPARTY_DIR)/libunibreak/*.*
 	chmod 755 $(LIBUNIBREAK_LIB)
 
 # libjpeg-turbo and libjpeg
-$(TURBOJPEG_LIB) $(JPEG_LIB) $(JPEG_DIR)/include: $(THIRDPARTY_DIR)/libjpeg-turbo/*.*
+$(TURBOJPEG_LIB) $(JPEG_LIB): $(THIRDPARTY_DIR)/libjpeg-turbo/*.*
 	install -d $(JPEG_BUILD_DIR)
 	cd $(JPEG_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -105,7 +105,7 @@ ifdef DARWIN
 		$(TURBOJPEG_LIB)
 endif
 
-$(PNG_LIB) $(PNG_DIR)/include: $(ZLIB) $(THIRDPARTY_DIR)/libpng/*.*
+$(PNG_LIB): $(ZLIB) $(THIRDPARTY_DIR)/libpng/*.*
 	install -d $(PNG_BUILD_DIR)
 	cd $(PNG_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -434,7 +434,7 @@ $(GLIB): $(LIBICONV) $(LIBGETTEXT) $(THIRDPARTY_DIR)/glib/*.*
 		$(CURDIR)/$(THIRDPARTY_DIR)/glib && \
 		$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS)
 
-$(ZLIB) $(ZLIB_STATIC) $(ZLIB_DIR)/include: $(THIRDPARTY_DIR)/zlib/*.*
+$(ZLIB) $(ZLIB_STATIC): $(THIRDPARTY_DIR)/zlib/*.*
 	install -d $(ZLIB_BUILD_DIR)
 	-rm -f $(ZLIB_DIR)/../zlib-stamp/zlib-install $(ZLIB) $(ZLIB_STATIC)
 	cd $(ZLIB_BUILD_DIR) && \
@@ -451,7 +451,7 @@ else
 	cp -fL $(ZLIB_DIR)/lib/$(notdir $(ZLIB)) $(ZLIB)
 endif
 
-$(ZSTD_LIB) $(ZSTD_DESTDIR)/include: $(THIRDPARTY_DIR)/zstd/*.*
+$(ZSTD_LIB): $(THIRDPARTY_DIR)/zstd/*.*
 	install -d $(ZSTD_BUILD_DIR)
 	cd $(ZSTD_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
@@ -843,7 +843,7 @@ $(OUTPUT_DIR)/zsync2: $(THIRDPARTY_DIR)/zsync2/*.*
 	install -d $(ZSYNC2_BUILD_DIR)
 	cd $(ZSYNC2_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
-		-DCPPFLAGS='$(CPPFLAGS) -I$(ZLIB_DIR)/include -I$(OPENSSL_DIR)/include' \
+		-DCPPFLAGS='$(CPPFLAGS) -I$(ZLIB_DIR)/include -I$(OPENSSL_DIR)/includeg' \
 		-DCFLAGS='$(CFLAGS)' \
 		-DCXXFLAGS='$(CXXFLAGS)' \
 		-DLDFLAGS='$(LDFLAGS) -L$(CURL_DIR)/lib -L$(OPENSSL_DIR) -lssl -lcrypto' \

--- a/Makefile.third
+++ b/Makefile.third
@@ -843,7 +843,7 @@ $(OUTPUT_DIR)/zsync2: $(THIRDPARTY_DIR)/zsync2/*.*
 	install -d $(ZSYNC2_BUILD_DIR)
 	cd $(ZSYNC2_BUILD_DIR) && \
 		$(CMAKE) $(CMAKE_FLAGS) \
-		-DCPPFLAGS='$(CPPFLAGS) -I$(ZLIB_DIR)/include -I$(OPENSSL_DIR)/includeg' \
+		-DCPPFLAGS='$(CPPFLAGS) -I$(ZLIB_DIR)/include -I$(OPENSSL_DIR)/include' \
 		-DCFLAGS='$(CFLAGS)' \
 		-DCXXFLAGS='$(CXXFLAGS)' \
 		-DLDFLAGS='$(LDFLAGS) -L$(CURL_DIR)/lib -L$(OPENSSL_DIR) -lssl -lcrypto' \


### PR DESCRIPTION
Partially reverts 8c133b0 (from #1679).

The logic behind including them doesn't check out. The targets in question depend on the files that are to be written in those very /include directories. If they fail to be created properly the target fails. Therefore including them in Makefile.third in this manner doesn't make much sense.

I originally thought it was a bit weird but harmless, but as it turns out it's the exact opposite. So yeah, it has to go away ASAP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1699)
<!-- Reviewable:end -->
