### PR TITLE
cmake: fix `ko_write_gitclone_script` function

### DIFF
--- a/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_git.cmake
@@ -170,7 +170,9 @@ function(ko_write_gitclone_script script_filename git_repository git_tag build_s
     set(work_dir ${CMAKE_CURRENT_BINARY_DIR}/git_checkout)
     set(tmp_dir ${work_dir}/tmp)
     set(stamp_dir ${work_dir}/stamp)
-    set(git_submodules ${ARGV4})
+    if(ARGC GREATER 4)
+        set(git_submodules ${ARGV4})
+    endif()
 
     set(${script_filename} ${tmp_dir}/${PROJECT_NAME}-gitclone-${git_tag}.cmake)
     set(${script_filename} ${${script_filename}} PARENT_SCOPE)


### PR DESCRIPTION
The value of `ARGV4` is undefined when the number of arguments passed to the function is less than 5.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1702)
<!-- Reviewable:end -->
