### PR TITLE
sqlite: don't set `HAVE_LOG2=0` on Android

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -799,7 +799,7 @@ $(SQLITE_LIB): $(THIRDPARTY_DIR)/sqlite/*.*
 		$(CMAKE) $(CMAKE_FLAGS) \
 		-DCC='$(CC)' \
 		-DCHOST='$(CHOST)' \
-		-DCPPFLAGS='$(CPPFLAGS) $(if $(ANDROID),-DHAVE_LOG2=0,)' \
+		-DCPPFLAGS='$(CPPFLAGS)' \
 		-DCFLAGS='$(CFLAGS)' \
 		-DLDFLAGS='$(LDFLAGS)' \
 		$(CURDIR)/thirdparty/sqlite && \


### PR DESCRIPTION
It's available starting with API level 18, our minimum supported version.

```c
#if __ANDROID_API__ >= 18
double log2(double __x) __INTRODUCED_IN(18);
float log2f(float __x) __INTRODUCED_IN(18);
long double log2l(long double __x) __RENAME_LDBL(log2, 18, 18);
#endif /* __ANDROID_API__ >= 18 */

```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1703)
<!-- Reviewable:end -->
