### PR TITLE
add fallback URLs for gettext, libiconv & tar downloads

### DIFF
--- a/thirdparty/gettext/CMakeLists.txt
+++ b/thirdparty/gettext/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.7)
 project(gettext LANGUAGES)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
@@ -31,6 +31,7 @@ include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
     URL http://ftpmirror.gnu.org/gettext/gettext-${GETTEXT_VER}.tar.gz
+    http://ftp.gnu.org/pub/gnu/gettext/gettext-${GETTEXT_VER}.tar.gz
     URL_MD5 28b1cd4c94a74428723ed966c38cf479
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     PATCH_COMMAND ${PATCH_CMD}

--- a/thirdparty/libiconv/CMakeLists.txt
+++ b/thirdparty/libiconv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.7)
 project(libiconv LANGUAGES)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
@@ -18,6 +18,7 @@ include(ExternalProject)
 ExternalProject_Add(
     libiconv
     URL http://ftpmirror.gnu.org/libiconv/libiconv-${GETTEXT_VER}.tar.gz
+    http://ftp.gnu.org/pub/gnu/libiconv/libiconv-${GETTEXT_VER}.tar.gz
     URL_MD5 ace8b5f2db42f7b3b3057585e80d9808
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.7)
 project(tar LANGUAGES)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/../cmake_modules")
@@ -53,6 +53,7 @@ set(TAR_VER "1.34")
 ExternalProject_Add(
     ${PROJECT_NAME}
     URL http://ftpmirror.gnu.org/tar/tar-${TAR_VER}.tar.gz
+    http://ftp.gnu.org/pub/gnu/tar/tar-${TAR_VER}.tar.gz
     URL_MD5 9d5949e4c2d9665546ac65dafc0e726a
     DOWNLOAD_DIR ${KO_DOWNLOAD_DIR}
     PATCH_COMMAND ${PATCH_CMD}


### PR DESCRIPTION
Note: this does increase the minimum CMake version to 3.7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1711)
<!-- Reviewable:end -->
