### PR TITLE
Fix dowload android sdk

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -25,7 +25,7 @@ $(TOOLCHAIN_DIR)/$(SDK_DIR):
 	pushd $(SDK_DIR)/tools/bin && \
 		yes | ./sdkmanager --update && \
 		yes | ./sdkmanager --licenses && \
-		./sdkmanager "platform-tools" "build-tools;30.0.2" "platforms;android-30" "patcher;v4" && \
+		./sdkmanager "platform-tools" "build-tools;30.0.2" "platforms;android-30" && \
 		popd
 	rm -f $(SDK_DIR)/$(SDK_TARBALL)
 


### PR DESCRIPTION
java -version
openjdk version "1.8.0_392"
OpenJDK Runtime Environment (build 1.8.0_392-b08)
OpenJDK 64-Bit Server VM (build 25.392-b08, mixed mode)

./sdkmanager --list --verbose | grep patcher
empty result

Build fails here:

./sdkmanager "platform-tools" "build-tools;30.0.2" "platforms;android-30" "patcher;v4" Warning: Failed to find package patcher;v4

Besides the fact I use arch linux and messed up with my system from time to time is only me facing this problem?

Can someone test whether the patcher is available? ./sdkmanager --list --verbose | grep patcher

I had to remove "patcher;v4" from the Makefile so the build could proceed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1713)
<!-- Reviewable:end -->
