### PR TITLE
sunxi: Minor comment updates

### DIFF
--- a/ffi/framebuffer_ion.lua
+++ b/ffi/framebuffer_ion.lua
@@ -30,6 +30,8 @@ local framebuffer = {
 
     _finfo = nil,
     _vinfo = nil,
+
+    _just_rotated = nil,
 }
 
 --[[
@@ -297,7 +299,13 @@ function framebuffer:reinit()
     self.bb:fill(BB.COLOR_WHITE)
 
     -- Ask framebuffer_sunxi to make sure the next update is full-screen, in order to avoid layer blending glitches...
-    -- (e.g., CRe loading bar)
+    -- (e.g., CRe loading bar, a very small refresh region, into the actual full-screen page refresh at the end).
+    -- NOTE: This cannot be reproduced with Wi-Fi enabled, in yet another weird EPDC power management quirk...
+    -- NOTE: It will *not* prevent tripping the "refresh in staggered quadrants" issue on the actual page refresh,
+    --       but at least the actual page content will not be garbled ;).
+    --       (Fun fact: much like the above, the staggered refresh thing doesn't happen with Wi-Fi enabled...)
+    -- The good news is that this scenario doesn't really happen anymore with CRe progressive rendering,
+    -- as a rotation is now very unlikely to require a progress bar, so the first refresh is natively full-screen already ;).
     self._just_rotated = true
 end
 

--- a/ffi/framebuffer_sunxi.lua
+++ b/ffi/framebuffer_sunxi.lua
@@ -35,9 +35,6 @@ local framebuffer = {
     area = nil,
     update = nil,
     ioc_cmd = nil,
-
-    -- Used to arbitrarily request an EINK_NO_MERGE update
-    no_merge_next_update = false,
 }
 
 
@@ -143,12 +140,6 @@ local function disp_update(fb, ioc_cmd, ioc_data, no_merge, is_flashing, wavefor
     -- Wake the EPDC up manually, in the vague hope it'll help with missed refreshes after a wakeup from standby...
     if fb.mech_poweron then
         fb:mech_poweron()
-    end
-
-    -- If we've requested no_merge for the next update, regardless of its actual mode, do that.
-    if fb.no_merge_next_update then
-        no_merge = true
-        fb.no_merge_next_update = false
     end
 
     -- We've got the final region, update the area_info struct


### PR DESCRIPTION
Finally had time to see if I could find a workaround for the missing post-standby refreshes on sunxi, but that didn't pan out, so we're just left with comment cleanups ;p.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1714)
<!-- Reviewable:end -->
