### PR TITLE
FB: Refactor refresh rectangle bounding checks

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1067,7 +1067,7 @@ i.e., make sure that x & y don't go OOB on either side, and that x+w & y+h don't
 
 @return rect strictly bounded inside the bb
 --]]
-function BB_mt:getBoundedRect(x, y, w, h, alignment)
+function BB_mt.__index:getBoundedRect(x, y, w, h, alignment)
     local max_w = self:getWidth()
     local max_h = self:getHeight()
 

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1468,8 +1468,7 @@ invert a rectangle within the buffer
 @param h height
 --]]
 function BB_mt.__index:invertRect(x, y, w, h)
-    w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+    x, y, w, h = self:getBoundedRect(x, y, w, h)
     if w <= 0 or h <= 0 then return end
     if self:canUseCbb() then
         cblitbuffer.BB_invert_rect(ffi.cast(P_BlitBuffer, self),
@@ -1575,8 +1574,7 @@ paint a rectangle onto this buffer
 function BB_mt.__index:paintRect(x, y, w, h, value, setter)
     setter = setter or self.setPixel
     value = value or Color8(0)
-    w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+    x, y, w, h = self:getBoundedRect(x, y, w, h)
     if w <= 0 or h <= 0 then return end
     if self:canUseCbb() and setter == self.setPixel then
         cblitbuffer.BB_fill_rect(ffi.cast(P_BlitBuffer, self),
@@ -1684,8 +1682,7 @@ end
 function BB4_mt.__index:paintRect(x, y, w, h, value, setter)
     setter = setter or self.setPixel
     value = value or Color8(0)
-    w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+    x, y, w, h = self:getBoundedRect(x, y, w, h)
     if w <= 0 or h <= 0 then return end
     for tmp_y = y, y+h-1 do
         for tmp_x = x, x+w-1 do
@@ -1926,8 +1923,7 @@ Paint hatches in a rectangle
 @a:  alpha
 --]]
 function BB_mt.__index:hatchRect(x, y, w, h, sw, c, a)
-    w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+    x, y, w, h = self:getBoundedRect(x, y, w, h)
     if w <= 0 or h <= 0 then return end
     a = (a or 1)*0xFF
     if a <= 0 then return end -- fully transparent
@@ -1991,8 +1987,7 @@ dim color values in rectangular area
 function BB_mt.__index:dimRect(x, y, w, h, by)
     local color = Color8A(0xFF, 0xFF*(by or 0.5))
     if self:canUseCbb() then
-        w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-        h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+        x, y, w, h = self:getBoundedRect(x, y, w, h)
         if w <= 0 or h <= 0 then return end
         cblitbuffer.BB_blend_rect(ffi.cast(P_BlitBuffer, self),
             x, y, w, h, color)
@@ -2013,8 +2008,7 @@ lighten color values in rectangular area
 function BB_mt.__index:lightenRect(x, y, w, h, by)
     local color = Color8A(0, 0xFF*(by or 0.5))
     if self:canUseCbb() then
-        w, x = BB.checkBounds(w, x, 0, self:getWidth(), 0xFFFF)
-        h, y = BB.checkBounds(h, y, 0, self:getHeight(), 0xFFFF)
+        x, y, w, h = self:getBoundedRect(x, y, w, h)
         if w <= 0 or h <= 0 then return end
         cblitbuffer.BB_blend_rect(ffi.cast(P_BlitBuffer, self),
             x, y, w, h, color)

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1097,7 +1097,8 @@ function BB_mt:getBoundedRect(x, y, w, h, alignment)
     w = ceil(w)
     h = ceil(h)
 
-    -- Honor alignment constraints, if any
+    -- Honor alignment constraints, if any.
+    -- coordinates can only go down, but never below 0, so there's no risk of it invalidating our previous OOB checks.
     -- NOTE: c.f., dithering comments in framebuffer_mxcfb for a potential use-case
     if alignment then
         local x_orig = x
@@ -1110,7 +1111,7 @@ function BB_mt:getBoundedRect(x, y, w, h, alignment)
         h = ALIGN_UP(h + y_fixup, alignment)
     end
 
-    -- Make sure the rect still fits strictly inside the bb
+    -- Make sure the rect fits strictly inside the bb
     if x + w > max_w then
         w = max_w - x
     end

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1122,7 +1122,6 @@ function BB_mt.__index:getBoundedRect(x, y, w, h, alignment)
     return x, y, w, h
 end
 
-
 function BB_mt.__index:blitDefault(dest, dest_x, dest_y, offs_x, offs_y, width, height, setter, set_param)
     -- slow default variant:
     local o_y = offs_y

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -308,40 +308,11 @@ function fb:calculateRealCoordinates(x, y, w, h)
         recalculate the offsets.
     --]]
 
-    -- Do a lite version of getBoundedRect, to ensure OOB coordinates do not allow requesting a refresh large enough to spill *outside* of the viewport...
-    -- NOTE: This is duplicated here, instead of calling getBoundedRect on the *viewport* in the public refresh*() methods,
+    -- Ensure OOB coordinates do not allow requesting a refresh large enough to spill *outside* of the viewport...
+    -- NOTE: This is done here, instead of in the public refresh*() methods (where we'd explicitly run it on the viewport bb),
     --       because implementations may prefer to bound to the *full* screen, instead of the viewport's dimensions,
     --       especially if an alignment constraint is at play...
-    -- NOTE: We need rotation-aware dimensions, not the cached screen_size/viewport table...
-    local max_w = self.bb:getWidth()
-    local max_h = self.bb:getHeight()
-    -- Deal with OOB coordinates
-    if x >= max_w then
-        x = 0
-        w = 0
-    end
-    if y >= max_h then
-        y = 0
-        h = 0
-    end
-
-    -- Deal with negative coordinates
-    if x < 0 then
-        w = w + x
-        x = 0
-    end
-    if y < 0 then
-        h = h + y
-        y = 0
-    end
-
-    -- Make sure the rect fits strictly inside the viewport
-    if x + w > max_w then
-        w = max_w - x
-    end
-    if y + h > max_h then
-        h = max_h - y
-    end
+    x, y, w, h = self.bb:getBoundedRect(x, y, w, h)
 
     local mode = self:getRotationMode()
     local vx2 = self.screen_size.w - (self.viewport.x + self.viewport.w)

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -421,10 +421,22 @@ function fb:getRotationMode()
     return self.cur_rotation_mode
 end
 
+--- This reflects how the screen *looks* like, not the screen layout relative to its native orientation...
 function fb:getScreenMode()
     if self:getWidth() > self:getHeight() then
         return "landscape"
     else
+        return "portrait"
+    end
+end
+
+--- This reflects the current layout in terms of *rotation* modes
+function fb:getScreenOrientation()
+    if bit.band(self:getRotationMode(), 1) == 1 then
+        -- LinuxFB constants, Landscapes are odds
+        return "landscape"
+    else
+        -- And Portraits are even
         return "portrait"
     end
 end

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -203,39 +203,39 @@ end
 -- these should not be overridden, they provide the external refresh API:
 --- @note: x, y, w, h are *mandatory*, even for refreshFull! (UIManager guarantees it).
 function fb:refreshFull(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshFullImp(x, y, w, h, d)
 end
 function fb:refreshPartial(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshPartialImp(x, y, w, h, d)
 end
 function fb:refreshNoMergePartial(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshNoMergePartialImp(x, y, w, h, d)
 end
 function fb:refreshFlashPartial(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshFlashPartialImp(x, y, w, h, d)
 end
 function fb:refreshUI(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshUIImp(x, y, w, h, d)
 end
 function fb:refreshNoMergeUI(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshNoMergeUIImp(x, y, w, h, d)
 end
 function fb:refreshFlashUI(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshFlashUIImp(x, y, w, h, d)
 end
 function fb:refreshFast(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshFastImp(x, y, w, h, d)
 end
 function fb:refreshA2(x, y, w, h, d)
-    x, y, w, h = self:calculateRealCoordinates(x, y, w, h)
+    x, y = self:calculateRealCoordinates(x, y)
     return self:refreshA2Imp(x, y, w, h, d)
 end
 function fb:refreshWaitForLast()
@@ -275,8 +275,8 @@ function fb:setViewport(viewport)
     self:refreshFull(0, 0, self:getWidth(), self:getHeight())
 end
 
-function fb:calculateRealCoordinates(x, y, w, h)
-    if not self.viewport then return x, y, w, h end
+function fb:calculateRealCoordinates(x, y)
+    if not self.viewport then return x, y end
 
     -- TODO: May need to implement refresh translations for HW rotate on broken drivers.
     --       For now those should just avoid using HW mode altogether.
@@ -329,7 +329,7 @@ function fb:calculateRealCoordinates(x, y, w, h)
         y = y + vx2
     end
 
-    return x, y, w, h
+    return x, y
 end
 
 function fb:getRawSize()

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -13,7 +13,7 @@ local fb = {
     debug = function(...) --[[ NOP ]] end,
 
     bb = nil, -- should be set by implementations
-    full_bb = nil, -- will hold a saved reference when a viewport is set
+    full_bb = nil, -- will hold a reference to the full-size native buffer when a viewport is set
     viewport = nil,
     screen_size = nil,
     native_rotation_mode = nil,

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -312,12 +312,15 @@ function fb:calculateRealCoordinates(x, y, w, h)
     -- NOTE: This is duplicated here, instead of calling getBoundedRect on the *viewport* in the public refresh*() methods,
     --       because implementations may prefer to bound to the *full* screen, instead of the viewport's dimensions,
     --       especially if an alignment constraint is at play...
+    -- NOTE: We need rotation-aware dimensions, not the cached screen_size/viewport table...
+    local max_w = self.bb:getWidth()
+    local max_h = self.bb:getHeight()
     -- Deal with OOB coordinates
-    if x >= self.viewport.w then
+    if x >= max_w then
         x = 0
         w = 0
     end
-    if y >= self.viewport.h then
+    if y >= max_h then
         y = 0
         h = 0
     end
@@ -333,13 +336,12 @@ function fb:calculateRealCoordinates(x, y, w, h)
     end
 
     -- Make sure the rect fits strictly inside the viewport
-    if x + w > self.viewport.w then
-        w = self.viewport.w - x
+    if x + w > max_w then
+        w = max_w - x
     end
-    if y + h > self.viewport.h then
-        h = self.viewport.h - y
+    if y + h > max_h then
+        h = max_h - y
     end
-
 
     local mode = self:getRotationMode()
     local vx2 = self.screen_size.w - (self.viewport.x + self.viewport.w)

--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -275,6 +275,7 @@ function fb:setViewport(viewport)
     self:refreshFull(0, 0, self:getWidth(), self:getHeight())
 end
 
+-- If there is a viewport in place, spit out adjusted coordinates for the native buffer that account for it
 function fb:calculateRealCoordinates(x, y)
     if not self.viewport then return x, y end
 

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -24,7 +24,7 @@ function framebuffer:init()
     end
 
     self.bb:fill(BB.COLOR_WHITE)
-    self:refreshFull()
+    self:refreshFull(0, 0, self:getWidth(), self:getHeight())
 
     framebuffer.parent.init(self)
 end
@@ -63,7 +63,7 @@ function framebuffer:resize(w, h)
     SDL.texture = SDL.createTexture(w, h)
 
     self.bb:fill(BB.COLOR_WHITE)
-    self:refreshFull()
+    self:refreshFull(0, 0, self:getWidth(), self:getHeight())
 end
 
 local bb_emu = os.getenv("EMULATE_BB_TYPE")

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -105,8 +105,7 @@ function framebuffer:_newBB(w, h)
 end
 
 function framebuffer:_render(bb, x, y, w, h)
-    w, x = BB.checkBounds(w or bb:getWidth(), x or 0, 0, bb:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h or bb:getHeight(), y or 0, 0, bb:getHeight(), 0xFFFF)
+    x, y, w, h = bb:getBoundedRect(x, y, w, h)
 
     -- x, y, w, h without rotation for SDL rectangle
     local px, py, pw, ph = bb:getPhysicalRect(x, y, w, h)

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -137,25 +137,16 @@ end
 
 function framebuffer:refreshFullImp(x, y, w, h)
     if self.dummy then return end
-
-    local bb = self.full_bb or self.bb
-
-    if not (x and y and w and h) then
-        x = 0
-        y = 0
-        w = bb:getWidth()
-        h = bb:getHeight()
-    end
-
     self.debug("refresh on physical rectangle", x, y, w, h)
 
+    local bb = self.full_bb or self.bb
     local flash = os.getenv("EMULATE_READER_FLASH")
     if flash then
+        self.sdl_bb:setRotation(bb:getRotation())
+        self.sdl_bb:setInverse(bb:getInverse())
         self.sdl_bb:invertRect(x, y, w, h)
         self:_render(self.sdl_bb, x, y, w, h)
         util.usleep(tonumber(flash)*1000)
-        self.sdl_bb:setRotation(bb:getRotation())
-        self.sdl_bb:setInverse(bb:getInverse())
         self.sdl_bb:blitFrom(bb, x, y, x, y, w, h)
     end
     self:_render(bb, x, y, w, h)

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -19,8 +19,7 @@ local framebuffer = {}
 -- update a region of the screen
 function framebuffer:_updatePartial(mode, delay, x, y, w, h)
     local bb = self.full_bb or self.bb
-    w, x = BB.checkBounds(w or bb:getWidth(), x or 0, 0, bb:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h or bb:getHeight(), y or 0, 0, bb:getHeight(), 0xFFFF)
+    x, y, w, h = bb:getBoundedRect(x, y, w, h)
     x, y, w, h = bb:getPhysicalRect(x, y, w, h)
 
     android.einkUpdate(mode, delay, x, y, (x + w), (y + h))

--- a/ffi/framebuffer_einkfb.lua
+++ b/ffi/framebuffer_einkfb.lua
@@ -1,5 +1,4 @@
 local ffi = require("ffi")
-local BB = require("ffi/blitbuffer")
 require("ffi/posix_h")
 require("ffi/einkfb_h")
 local C = ffi.C
@@ -7,8 +6,7 @@ local C = ffi.C
 local framebuffer = {}
 
 local function einkfb_update(fb, refreshtype, x, y, w, h)
-    w, x = BB.checkBounds(w or fb.bb:getWidth(), x or 0, 0, fb.bb:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h or fb.bb:getHeight(), y or 0, 0, fb.bb:getHeight(), 0xFFFF)
+    x, y, w, h = fb.bb:getBoundedRect(x, y, w, h)
     x, y, w, h = fb.bb:getPhysicalRect(x, y, w, h)
 
     local refarea = ffi.new("struct update_area_t[1]")

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -11,8 +11,7 @@ local framebuffer = {
 
 local function _getPhysicalRect(fb, x, y, w, h)
     local bb = fb.full_bb or fb.bb
-    w, x = BB.checkBounds(w or bb:getWidth(), x or 0, 0, bb:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h or bb:getHeight(), y or 0, 0, bb:getHeight(), 0xFFFF)
+    x, y, w, h = bb:getBoundedRect(x, y, w, h)
     return bb:getPhysicalRect(x, y, w, h)
 end
 

--- a/ffi/framebuffer_sunxi.lua
+++ b/ffi/framebuffer_sunxi.lua
@@ -1,7 +1,6 @@
 local bit = require("bit")
 local ffi = require("ffi")
 local ffiUtil = require("ffi/util")
-local BB = require("ffi/blitbuffer")
 local C = ffi.C
 
 require("ffi/posix_h")
@@ -127,8 +126,8 @@ local function disp_update(fb, ioc_cmd, ioc_data, no_merge, is_flashing, wavefor
         no_merge = true
     end
 
-    w, x = BB.checkBounds(w or bb:getWidth(), x or 0, 0, bb:getWidth(), 0xFFFF)
-    h, y = BB.checkBounds(h or bb:getHeight(), y or 0, 0, bb:getHeight(), 0xFFFF)
+    -- Sanitize refresh rect
+    x, y, w, h = bb:getBoundedRect(x, y, w, h)
     x, y, w, h = bb:getPhysicalRect(x, y, w, h)
 
     -- Discard empty or bogus regions


### PR DESCRIPTION
https://github.com/koreader/koreader/issues/11303 showed that the current alignment trickery for HW dithering on mxcfb was a bit shoddy, so refactor the whole thing to do everything at once, in a function actually designed for that use case, instead of re-purposing a blitting helper...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1718)
<!-- Reviewable:end -->
