### PR TITLE
Fix Kindle swipe_direction in D-orientation in framebuffer_mxcfb.lua

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -604,6 +604,10 @@ end
 -- Set the swipe animation direction. This is sticky
 function framebuffer:_MTK_SetSwipeDirection(left)
     local swipe_direction = left and C.MTK_SWIPE_LEFT or C.MTK_SWIPE_RIGHT
+    -- If device was started in D orientation, rotate swipe_direction by 180 deg.
+    if self.native_rotation_mode == self.DEVICE_ROTATED_UPSIDE_DOWN then
+        swipe_direction = bxor(swipe_direction, 1)
+    end
     -- Account for KOReader rotation not matching the FB rotation with some bit trickery.
     -- Alternatively here is a LUT:
     -- local lut = { -- L R D U


### PR DESCRIPTION
Closes #11180 (if accepted)

@yparitcher @NiLuJe 
I have been using this solution (https://github.com/koreader/koreader/issues/11180#issuecomment-1869083861) for a few days on Kindle Scribe - no issues! Swipe-direction is correct in both `U` and `D` orientation startups.

I tried to fix Kindle at `U` at the start, but it didn't help with swipe-direction.
I don't know how this behaves on other MTK devices (PW5 only?).

If there is no other better solution, would you guys agree to accept this PR?

Thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1719)
<!-- Reviewable:end -->
