### PR TITLE
Input: Forward the suspend/wakeup source on Kindle

### DIFF
--- a/input/input-kindle.h
+++ b/input/input-kindle.h
@@ -37,9 +37,9 @@ static int strtol_d(const char* str)
     char* endptr;
     errno = 0;
     long int val = strtol(str, &endptr, 10);
-    // NOTE: The string we're fed will have trailing garbage (a space followed by an LF) (because lipc & fgets), so ignore endptr...
+    // NOTE: The string we're fed will have trailing garbage (a space followed by an LF) (because lipc & fgets), so we mostly ignore endptr...
     if (errno || endptr == str || (int) val != val) {
-        // strtol failure || no digits were found || trailing garbage || cast truncation
+        // strtol failure || no digits were found || cast truncation
         return -1; // this will conveniently never match a real powerd constant ;).
     }
 

--- a/input/input-kobo.h
+++ b/input/input-kobo.h
@@ -106,11 +106,13 @@ static void generateFakeEvent(int pipefd[2])
                     // Pass along the evdev number
                     ev.value = strtol_d(uev.devname + sizeof("input/event") - 1U); // i.e., start right after the t of event
                     sendEvent(pipefd[1], &ev);
+                    ev.value = 1;
                     break;
                 case UEVENT_ACTION_REMOVE:
                     ev.code = CODE_FAKE_USB_DEVICE_PLUGGED_OUT;
                     ev.value = strtol_d(uev.devname + sizeof("input/event") - 1U);
                     sendEvent(pipefd[1], &ev);
+                    ev.value = 1;
                     break;
                 default:
                     // NOP

--- a/input/input-remarkable.h
+++ b/input/input-remarkable.h
@@ -73,7 +73,7 @@ static void generateFakeEventRM2(int pipefd) {
 
     fflush(fp);
 
-    while (fgets(std_out, sizeof(std_out)-1, fp)) {
+    while (fgets(std_out, sizeof(std_out), fp)) {
         if (!strncmp(std_out, "   boolean false", 16)) {
             gettimeofday(&ev.time, NULL);
             if (write(pipefd, &ev, sizeof(struct input_event)) == -1) {
@@ -105,7 +105,7 @@ static void generateFakeEventRM1(int pipefd) {
 
     re = ue_init_listener(&listener);
     if (re < 0) {
-        fprintf(stderr, "[remarkable-fake-event] Failed to initilize libue listener (%d)\n", re);
+        fprintf(stderr, "[remarkable-fake-event] Failed to initialize libue listener (%d)\n", re);
         return;
     }
 

--- a/input/input-sony-prstux.h
+++ b/input/input-sony-prstux.h
@@ -78,7 +78,7 @@ static void generateFakeEvent(int pipefd[2]) {
 
     re = ue_init_listener(&listener);
     if (re < 0) {
-        fprintf(stderr, "[sony-prstux-fake-event] Failed to initilize libue listener (%d)\n", re);
+        fprintf(stderr, "[sony-prstux-fake-event] Failed to initialize libue listener (%d)\n", re);
         return;
     }
 


### PR DESCRIPTION
Also, fix a minor issue on Kobo, where evdev events would stomp the event value (not that we do anything with it, but, still).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1723)
<!-- Reviewable:end -->
