### PR TITLE
FB/sunxi: Don't nil w & h in the rotation hack

### DIFF
--- a/ffi/framebuffer_sunxi.lua
+++ b/ffi/framebuffer_sunxi.lua
@@ -120,8 +120,8 @@ local function disp_update(fb, ioc_cmd, ioc_data, no_merge, is_flashing, wavefor
     if fb._just_rotated then
         x = 0
         y = 0
-        w = nil
-        h = nil
+        w = fb:getWidth()
+        h = fb:getHeight()
         fb._just_rotated = nil
         no_merge = true
     end

--- a/input/input-kindle.h
+++ b/input/input-kindle.h
@@ -68,7 +68,7 @@ static void generateFakeEvent(int pipefd[2]) {
     /* listen power slider events (listen for ever for multiple events) */
     char *argv[] = {
         "lipc-wait-event", "-m", "-s", "0", "com.lab126.powerd",
-        "goingToScreenSaver,outOfScreenSaver,charging,notCharging,wakeupFromSuspend,readyToSuspend", (char *)NULL
+        "goingToScreenSaver,outOfScreenSaver,exitingScreenSaver,charging,notCharging,wakeupFromSuspend,readyToSuspend", (char *)NULL
     };
     /* @TODO  07.06 2012 (houqp)
      * plugin and out event can only be watched by:
@@ -95,6 +95,9 @@ static void generateFakeEvent(int pipefd[2]) {
             ev.value = strtol_d(std_out + sizeof("outOfScreenSaver"));
             sendEvent(pipefd[1], &ev);
             ev.value = 1;
+        } else if(std_out[0] == 'e') {
+            ev.code = CODE_FAKE_EXIT_SAVER;
+            sendEvent(pipefd[1], &ev);
         } else if((std_out[0] == 'u') && (std_out[7] == 'I')) {
             ev.code = CODE_FAKE_USB_PLUGGED_IN_TO_HOST;
             sendEvent(pipefd[1], &ev);

--- a/input/input.c
+++ b/input/input.c
@@ -37,6 +37,7 @@
 
 #define CODE_FAKE_IN_SAVER            10000
 #define CODE_FAKE_OUT_SAVER           10001
+#define CODE_FAKE_EXIT_SAVER          10002  // For Kindle's exitingScreenSaver
 // Device is plugged to USB host
 #define CODE_FAKE_USB_PLUGGED_IN_TO_HOST    10010
 #define CODE_FAKE_USB_PLUGGED_OUT_OF_HOST   10011


### PR DESCRIPTION
Compute the proper dimensions instead, as getBoundedRect no longer accepts nil ;).

Re: https://github.com/koreader/koreader/issues/11354

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1725)
<!-- Reviewable:end -->
