### PR TITLE
FB/sunxi: Use the screen's dimensions, not the viewport

### DIFF
--- a/ffi/framebuffer_sunxi.lua
+++ b/ffi/framebuffer_sunxi.lua
@@ -120,8 +120,8 @@ local function disp_update(fb, ioc_cmd, ioc_data, no_merge, is_flashing, wavefor
     if fb._just_rotated then
         x = 0
         y = 0
-        w = fb:getWidth()
-        h = fb:getHeight()
+        w = bb:getWidth()
+        h = bb:getHeight()
         fb._just_rotated = nil
         no_merge = true
     end


### PR DESCRIPTION
Followup to the rotation hack fix from #1725

(Harmless in practice, as we don't have sunxi devices with a viewport ;p).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1726)
<!-- Reviewable:end -->
