### PR TITLE
setHWRotation: nil guard self.forced_rotation

### DIFF
--- a/ffi/framebuffer_linux.lua
+++ b/ffi/framebuffer_linux.lua
@@ -201,7 +201,7 @@ end
 
 function framebuffer:setHWRotation(mode)
     local vinfo = self._vinfo
-    vinfo.rotate = self.forced_rotation[mode+1] or mode
+    vinfo.rotate = self.forced_rotation and self.forced_rotation[mode+1] or mode
     assert(C.ioctl(self.fd, C.FBIOPUT_VSCREENINFO, vinfo) == 0,
            "cannot set variable screen info")
 end

--- a/input/input-kindle.h
+++ b/input/input-kindle.h
@@ -112,7 +112,7 @@ static void generateFakeEvent(int pipefd[2]) {
             sendEvent(pipefd[1], &ev);
         } else if(std_out[0] == 'w') {
             ev.code = CODE_FAKE_WAKEUP_FROM_SUSPEND;
-            // Pass along the timestamp
+            // Pass along the time spent in suspend
             ev.value = strtol_d(std_out + sizeof("wakeupFromSuspend"));
             sendEvent(pipefd[1], &ev);
             ev.value = 1;


### PR DESCRIPTION
will be needed to test kindle rotate shenanigans where we do not set forced_rotation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1728)
<!-- Reviewable:end -->
