### PR TITLE
ffi/sdl: ensure correct order of SDL_DestroyRenderer followed by SDL_Quit

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -141,7 +141,7 @@ function S.open(w, h, x, y)
     -- What's even more curious is that we still only get a single SDL_WINDOWEVENT_MOVED on startup, except that way it's at the requested coordinates...
     SDL.SDL_SetWindowPosition(S.screen, pos_x, pos_y)
 
-    S.renderer = ffi.gc(SDL.SDL_CreateRenderer(S.screen, -1, 0), SDL.SDL_DestroyRenderer)
+    S.renderer = SDL.SDL_CreateRenderer(S.screen, -1, 0)
     local output_w = ffi.new("int[1]", 0)
     local output_h = ffi.new("int[1]", 0)
     if SDL.SDL_GetRendererOutputSize(S.renderer, output_w, output_h) == 0 and tonumber(output_w[0]) ~= w then

--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -165,6 +165,7 @@ function framebuffer:setWindowIcon(icon)
 end
 
 function framebuffer:close()
+    SDL.SDL.SDL_DestroyRenderer(SDL.renderer)
     SDL.SDL.SDL_Quit()
 end
 


### PR DESCRIPTION
When running in Wayland, calling SDL_DestroyRenderer after SDL_Quit can cause a segmentation fault.

Fixes <https://github.com/koreader/koreader/issues/11371>.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1730)
<!-- Reviewable:end -->
