### PR TITLE
PB: make sure libinkview-compat actually ends up w/ inkview as a DT_NEEDED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ libs: \
 	$(OUTPUT_DIR)/libs/libwrap-mupdf.so
 
 $(OUTPUT_DIR)/libs/libinkview-compat.so: input/inkview-compat.c
-	$(CC) $(DYNLIB_CFLAGS) $(LDFLAGS) -linkview -o $@ $<
+	$(CC) $(DYNLIB_CFLAGS) -linkview $(LDFLAGS) -o $@ $<
 
 $(OUTPUT_DIR)/libs/libkoreader-input.so: input/*.c input/*.h $(if $(or $(KINDLE),$(REMARKABLE)),$(POPEN_NOSHELL_LIB),)
 	@echo "Building koreader input module..."


### PR DESCRIPTION
The TC is old enough that the order of flags matters, a lot.

Regression since #1638
Re: https://github.com/koreader/koreader/issues/11172

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1734)
<!-- Reviewable:end -->
