### PR TITLE
cre.cpp: add overrideDocumentProp()

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -816,6 +816,14 @@ static int getDocumentProps(lua_State *L) {
 	return 1;
 }
 
+static int overrideDocumentProp(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    const char *prop = luaL_checkstring(L, 2);
+    const char *value = luaL_checkstring(L, 3);
+    doc->text_view->getDocProps()->setString(prop, value);
+    return 0;
+}
+
 static int getDocumentRenderingHash(lua_State *L) {
 	CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
 	bool extended = false;
@@ -4054,6 +4062,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"getStringProperty", getStringProperty},
     {"getDocumentFormat", getDocumentFormat},
     {"getDocumentProps", getDocumentProps},
+    {"overrideDocumentProp", overrideDocumentProp},
     {"getDocumentRenderingHash", getDocumentRenderingHash},
     {"canBePartiallyRerendered", canBePartiallyRerendered},
     {"isPartialRerenderingEnabled", isPartialRerenderingEnabled},


### PR DESCRIPTION
May allow crengine's top status bar to display our customized frontend metadata.
See https://github.com/koreader/koreader/issues/11461#issuecomment-1937056085

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1736)
<!-- Reviewable:end -->
