### PR TITLE
fix luarocks' version check

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -35,7 +35,7 @@ else
 endif
 
 # Detect LuaRocks 3
-LR_VER_NUM := $(shell luarocks --version | grep -o [0-9].[0-9])
+LR_VER_NUM := $(shell luarocks --version | grep -Eo '[0-9]+.[0-9]+')
 LR_GT_3_0 := $(shell awk -v LR_VER_NUM=$(LR_VER_NUM) 'BEGIN { print (LR_VER_NUM >= 3.0); }')
 
 # Some CMake flags


### PR DESCRIPTION
Broke with a double digits minor number (luarocks 3.10).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1742)
<!-- Reviewable:end -->
