### PR TITLE
bump crengine: various fixes, improved Russian typography

### DIFF
--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/adah1972/libunibreak.git
-    tags/libunibreak_6_0
+    tags/libunibreak_6_1
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
#### bump libunibreak to 6.1

#### bump crengine: various fixes, improved Russian typography

Includes:
- https://github.com/koreader/crengine/pull/558 : 
- In-page footnotes: avoid with '-cr-hint: noteref-ignore' 
- In-page footnotes: ensure they don't cross "flows"
- Tables: fix rendering when negative text-indent
- FB2 cover drawing: ensure _invertImages flag
- EPUB: fallback to look for a cover in the first fragment
- TextLang: Russian: add typography rules https://github.com/koreader/crengine/pull/557

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1743)
<!-- Reviewable:end -->
