### PR TITLE
tweak `patch-wrapper.sh`

### DIFF
--- a/thirdparty/cmake_modules/patch-wrapper.sh
+++ b/thirdparty/cmake_modules/patch-wrapper.sh
@@ -1,17 +1,18 @@
 #!/bin/sh
 
+set -e
+
 if [ $# -eq 0 ]; then
-    echo "Patch file required as argument."
+    echo "Patch file(s) required as argument(s)."
     exit 1
 fi
 
-PATCH_FILE="$1"
-echo "* Applying ${PATCH_FILE} . . ."
-
-# Reverse patch will succeed if the patch is already applied.
-# In case of failure, it means we should try to apply the patch.
-if ! patch -R -p1 -N --dry-run <"${PATCH_FILE}" >/dev/null 2>&1; then
-    # Now patch for real.
-    patch -p1 -N <"${PATCH_FILE}"
-    exit $?
-fi
+for patch in "$@"; do
+    echo "* Applying ${patch} . . ."
+    # Reverse patch will succeed if the patch is already applied.
+    # In case of failure, it means we should try to apply the patch.
+    if ! patch -R -p1 -N --dry-run --input="${patch}" >/dev/null 2>&1; then
+        # Now patch for real.
+        patch -p1 -N --input="${patch}"
+    fi
+done


### PR DESCRIPTION
To support multiple patches in argument. Better than ignoring extra arguments after the first (e.g. in case of missing `COMMAND` in an external project patch command list).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1746)
<!-- Reviewable:end -->
