### PR TITLE
make: improve test rules

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -10,24 +10,11 @@ if [ "$TARGET" = "android" ]; then
         exit 1
     fi
 elif [ "$EMULATE_READER" = "1" ]; then
-    cp build/*/luajit "${HOME}/.luarocks/bin"
-    # install tesseract trained language data for testing OCR functionality
-    travis_retry wget https://src.fedoraproject.org/repo/pkgs/tesseract/tesseract-ocr-3.02.eng.tar.gz/3562250fe6f4e76229a329166b8ae853/tesseract-ocr-3.02.eng.tar.gz
-    tar zxf tesseract-ocr-3.02.eng.tar.gz
-    export TESSDATA_PREFIX
-    cd build/* && TESSDATA_PREFIX=$(pwd)/data && mkdir -p data/tessdata
-    mv ../../tesseract-ocr/tessdata/* data/tessdata/ && cd ../../ || exit
-    # fetch font for base test
-    travis_retry wget https://github.com/koreader/koreader-fonts/raw/master/droid/DroidSansMono.ttf
-    export OUTPUT_DIR
-    if [ -n "${KODEBUG+x}" ]; then
-        KODEBUG_SUFFIX=-debug
-    fi
-    OUTPUT_DIR=$(ls -d ./build/x86_64-*linux-gnu${KODEBUG_SUFFIX})
-    mkdir -p "${OUTPUT_DIR}/fonts/droid/"
-    cp DroidSansMono.ttf "${OUTPUT_DIR}/fonts/droid/DroidSansMono.ttf"
+    cp build/*/luajit "${HOME}/.luarocks/bin/"
+    # install test data
+    travis_retry make test-data
     # finally make test
-    travis_retry make test
+    travis_retry make --assume-old=all test
 fi
 
 echo "test passed."

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -231,6 +231,13 @@ USE_LUAJIT_LIB=$(or $(DARWIN),$(ANDROID),$(WIN32))
 SKIP_LUAJIT_BIN=$(or $(ANDROID),$(MACOS))
 
 RCP := cp -R
+WGET ?= wget --progress=dot:giga
+
+define wget_and_validate
+	$(WGET) -O '$1' '$2' \
+	&& echo '$3 $1' | sha1sum -c - \
+	|| { code=$$?; rm -f '$1'; exit $$code; }
+endef
 
 # unknown device
 ifdef SBOX_UNAME_MACHINE


### PR DESCRIPTION
To automatically install the necessary test suite dependencies and ensure `make test` work out of the box.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1747)
<!-- Reviewable:end -->
