### PR TITLE
Call `FullUpdateHQ` to eliminate ghosting on Pocketbook

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -42,7 +42,7 @@ local function _updateFull(fb, x, y, w, h, dither)
         _adjustAreaColours(fb)
     end
 
-    inkview.FullUpdate()
+    inkview.FullUpdateHQ()
 end
 
 local function _updateFast(fb, x, y, w, h, dither)

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -42,7 +42,11 @@ local function _updateFull(fb, x, y, w, h, dither)
         _adjustAreaColours(fb)
     end
 
-    inkview.FullUpdateHQ()
+    if fb.device.hasColorScreen then
+        inkview.FullUpdateHQ()
+    else
+        inkview.FullUpdate()
+    end
 end
 
 local function _updateFast(fb, x, y, w, h, dither)


### PR DESCRIPTION
This makes rendering slightly slower but removes all ghosting artifacts.

See my tests below. I have "Always flash on pages with images" setting ON.

| With `FullUpdate()` | With `FullUpdateHQ()` |
|--------|--------|
| <img src="https://github.com/koreader/koreader-base/assets/483357/6f9e7e3e-dd22-49bc-be3e-4d33b9f84953" width="400"> | <img src="https://github.com/koreader/koreader-base/assets/483357/0ba75d4c-6afa-40db-92d5-e5019eaa3147" width="400"> |
| <img src="https://github.com/koreader/koreader-base/assets/483357/71f7fc79-8f5e-47f0-94e1-ce38b0a87129" width="400"> | <img src="https://github.com/koreader/koreader-base/assets/483357/9e822a28-9e03-48e6-85e0-c2b09c1f839b" width="400"> | 

Ghosting is especially visible on the light parts of the images.

This should also help with the issues similar to https://github.com/koreader/koreader/issues/11233#issuecomment-1929536127.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1752)
<!-- Reviewable:end -->
