### PR TITLE
Use high quality refresh for flash updates on color Pocketbooks

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -23,7 +23,8 @@ local function _adjustAreaColours(fb)
     end
 end
 
-local function _updatePartial(fb, x, y, w, h, dither)
+local function _updatePartial(fb, x, y, w, h, dither, hq)
+    -- Use "hq" argument to trigger high quality refresh for color Pocketbook devices.
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
     fb.debug("refresh: inkview partial", x, y, w, h, dither)
@@ -32,7 +33,11 @@ local function _updatePartial(fb, x, y, w, h, dither)
         _adjustAreaColours(fb)
     end
 
-    inkview.PartialUpdate(x, y, w, h)
+    if fb.device.hasColorScreen and hq then
+        inkview.PartialUpdateHQ(x, y, w, h)
+    else
+        inkview.PartialUpdate(x, y, w, h)
+    end
 end
 
 local function _updateFull(fb, x, y, w, h, dither)
@@ -123,19 +128,19 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, false)
 end
 
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, true)
 end
 
 function framebuffer:refreshUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, false)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, true)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h, dither)

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -33,7 +33,7 @@ local function _updatePartial(fb, x, y, w, h, dither, hq)
         _adjustAreaColours(fb)
     end
 
-    if fb.device.hasColorScreen and hq then
+    if fb.device.hasColorScreen() and hq then
         inkview.PartialUpdateHQ(x, y, w, h)
     else
         inkview.PartialUpdate(x, y, w, h)


### PR DESCRIPTION
Color Pocketbooks are especially prone to ghosting and normal refresh functions aren't helpful.

This change doesn't fix ghosting in all cases, but whenever one of `refreshFlash...` functions is called, there will be less (if no) ghosting.

For the cases where we still have ghosting, we should switch to calling one of `refreshFlash...` API methods.

Tested on Pocketbook Inkpad Color 3.

Fixes https://github.com/koreader/koreader/issues/11416

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1755)
<!-- Reviewable:end -->
