### PR TITLE
make: fix test rule on Arch Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -274,11 +274,7 @@ $(OUTPUT_DIR)/spec/base: | $(OUTPUT_DIR)/spec/
 	ln -sf ../../../spec $(OUTPUT_DIR)/spec/base
 
 test: all test-data
-	eval "$$($(LUAROCKS_BINARY) path)" && cd $(OUTPUT_DIR) && \
-		env TESSDATA_DIR=$(OUTPUT_DIR)/data \
-		./luajit "$$(which busted)" \
-		--exclude-tags=notest \
-		-o gtest ./spec/base/unit
+	cd $(OUTPUT_DIR) && $(BUSTED_LUAJIT) ./spec/base/unit
 
 test-data: $(OUTPUT_DIR)/.busted $(OUTPUT_DIR)/data/tessdata/eng.traineddata $(OUTPUT_DIR)/spec/base $(OUTPUT_DIR)/fonts/droid/DroidSansMono.ttf
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1010,3 +1010,23 @@ CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),curl,zsync2
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),fbink
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),kobo-usbms
 CMAKE_THIRDPARTY_LIBS := $(CMAKE_THIRDPARTY_LIBS),fribidi,libunibreak,utf8proc
+
+# Testing support.
+
+ifneq (,$(EMULATE_READER))
+
+define busted_fn
+busted() {(
+eval "$$($(LUAROCKS_BINARY) path)";
+export TESSDATA_DIR="$$PWD/data";
+./luajit -e 'require "busted.runner" {standalone = false}' /dev/null
+--exclude-tags=notest
+--output=gtest
+--sort-files
+"$$@";
+)}
+endef
+
+BUSTED_LUAJIT = $(strip $(busted_fn)); busted
+
+endif


### PR DESCRIPTION
I forgot I had worked around the fact that the `busted` launcher installed on Arch Linux is actually a shell script, not a LUA file.

Said script also messes with the LUA environment (forcibly using lua5.4).

Switch to invoking the busted runner manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1756)
<!-- Reviewable:end -->
