### PR TITLE
Bugfix: device property is a function

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -16,7 +16,7 @@ local function _getPhysicalRect(fb, x, y, w, h)
 end
 
 local function _adjustAreaColours(fb)
-    if fb.device.hasColorScreen then
+    if fb.device.hasColorScreen() then
         fb.debug("adjusting image color saturation")
 
         inkview.adjustAreaDefault(fb.data, fb._finfo.line_length, fb._vinfo.width, fb._vinfo.height)
@@ -42,7 +42,7 @@ local function _updateFull(fb, x, y, w, h, dither)
         _adjustAreaColours(fb)
     end
 
-    if fb.device.hasColorScreen then
+    if fb.device.hasColorScreen() then
         inkview.FullUpdateHQ()
     else
         inkview.FullUpdate()


### PR DESCRIPTION
Previous code was always returning true, even for B&W Pocketbooks. 

See https://github.com/koreader/koreader/blob/42c93a7623c6d04a2001f943ddc5b0b0638e3a24/frontend/device/pocketbook/device.lua#L16 for `yes` and `no` definitions.

Tested on Pocketbook Inkpad Color 3.