### PR TITLE
ci: tweak circleci cache handling

### DIFF
--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -8,44 +8,27 @@ source "${CI_DIR}/common.sh"
 test -d "${HOME}/.ccache" || mkdir "${HOME}/.ccache"
 echo "using cache dir: ${HOME}/.ccache."
 
-travis_retry make fetchthirdparty
+travis_retry make fetchthirdparty TARGET=
 
-if [ "$TARGET" = "android" ] && [ -n "${DOCKER_IMG}" ]; then
+docker-make() {
+    local cmdlist=(
+        'source /home/ko/.bashrc'
+        'cd /home/ko/base'
+        'sudo chown -R ko:ko .'
+        "make $(printf '%q ' "$@")"
+    )
     sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
+    docker run --rm -t \
         -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=android all'
-elif [ "$TARGET" = "cervantes" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=cervantes all'
-elif [ "$TARGET" = "kobo" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=kobo all'
-elif [ "$TARGET" = "kindle" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c 'source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make TARGET=kindle all'
-elif [ "$TARGET" = "pocketbook" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make VERBOSE=1 TARGET=pocketbook all"
-elif [ "$TARGET" = "sony-prstux" ]; then
-    sudo chmod -R 777 "${HOME}/.ccache"
-    docker run -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
-        -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
-        /bin/bash -c "source /home/ko/.bashrc && cd /home/ko/base && sudo chown -R ko:ko . && make VERBOSE=1 TARGET=sony-prstux all"
+        /bin/bash -c "$(printf '%s && ' "${cmdlist[@]}")true"
+}
+
+makeargs=(
+    TARGET="${TARGET}"
+)
+if [[ -z "${DOCKER_IMG}" ]]; then
+    make "${makeargs[@]}" "$@"
 else
-    make all
+    docker-make "${makeargs[@]}" VERBOSE=1 "$@"
 fi

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -5,8 +5,12 @@ DOCKER_HOME=/home/ko
 # shellcheck source=/dev/null
 source "${CI_DIR}/common.sh"
 
-test -d "${HOME}/.ccache" || mkdir "${HOME}/.ccache"
-echo "using cache dir: ${HOME}/.ccache."
+if [[ -z "${CCACHE_DIR}" ]]; then
+    CCACHE_DIR="${HOME}/.ccache"
+fi
+
+mkdir -p "${CCACHE_DIR}"
+echo "using cache dir: ${CCACHE_DIR}"
 
 travis_retry make fetchthirdparty TARGET=
 
@@ -17,9 +21,9 @@ docker-make() {
         'sudo chown -R ko:ko .'
         "make $(printf '%q ' "$@")"
     )
-    sudo chmod -R 777 "${HOME}/.ccache"
+    sudo chmod -R 777 "${CCACHE_DIR}"
     docker run --rm -t \
-        -v "${HOME}/.ccache:${DOCKER_HOME}/.ccache" \
+        -v "${CCACHE_DIR}:${DOCKER_HOME}/.ccache" \
         -v "$(pwd):${DOCKER_HOME}/base" "${DOCKER_IMG}" \
         /bin/bash -c "$(printf '%s && ' "${cmdlist[@]}")true"
 }

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -19,6 +19,8 @@ docker-make() {
         'source /home/ko/.bashrc'
         'cd /home/ko/base'
         'sudo chown -R ko:ko .'
+        './.ci/cache_restore_post.sh'
+        "trap './.ci/cache_save_pre.sh' EXIT"
         "make $(printf '%q ' "$@")"
     )
     sudo chmod -R 777 "${CCACHE_DIR}"
@@ -32,6 +34,8 @@ makeargs=(
     TARGET="${TARGET}"
 )
 if [[ -z "${DOCKER_IMG}" ]]; then
+    './.ci/cache_restore_post.sh'
+    trap './.ci/cache_save_pre.sh' EXIT
     make "${makeargs[@]}" "$@"
 else
     docker-make "${makeargs[@]}" VERBOSE=1 "$@"

--- a/.ci/cache_restore_post.sh
+++ b/.ci/cache_restore_post.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -ex
+
+which ccache
+ccache --version
+ccache --zero-stats
+# TODO: reduce once a more recent version of ccache with
+# zstd support and compression enabled by default is used.
+ccache --max-size=1G
+ccache -p # `-p`: equivalent to `--show-config` (not supported with ancient versions)

--- a/.ci/cache_save_pre.sh
+++ b/.ci/cache_save_pre.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+ccache --cleanup >/dev/null
+ccache --show-stats


### PR DESCRIPTION
- more information: ccache version, configuration
- reduce maximum size to 256M (twice an emulator debug build use)
- reset statistics after restore and show them before saving
- cleanup cache before saving

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1759)
<!-- Reviewable:end -->
