### PR TITLE
harfbuzz: fix ccache 4.9.1 errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,6 @@ jobs:
             makedepend
             nasm
             pkg-config
-            ragel
             wget
 
       - name: Update PATH

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -17,6 +17,21 @@ assert_var_defined(FREETYPE_DIR)
 ep_get_source_dir(SOURCE_DIR)
 ep_get_binary_dir(BINARY_DIR)
 
+# Get rid of a bunch of `#line` directives that trip ccache 4.9.1.
+# NOTE: this has also the nice effect of "touching" each file, so
+# the build system does not try to regenerate them (and building
+# without ragel is consistently possible).
+list(APPEND PATCH_CMD COMMAND ${ISED} "/^#line/d"
+    src/hb-ot-shaper-khmer-machine.hh
+    src/hb-ot-shaper-use-machine.hh
+    src/hb-ot-shaper-myanmar-machine.hh
+    src/hb-buffer-deserialize-json.hh
+    src/hb-buffer-deserialize-text-glyphs.hh
+    src/hb-number-parser.hh
+    src/hb-ot-shaper-indic-machine.hh
+    src/hb-buffer-deserialize-text-unicode.hh
+)
+
 list(APPEND PATCH_CMD COMMAND env NOCONFIGURE=1 ./autogen.sh)
 
 # No build rpath


### PR DESCRIPTION
Additionally, fix possible build error if ragel is not installed and some of the ragel source files end up with a more recent timestamp than their pre-generated results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1760)
<!-- Reviewable:end -->
