### PR TITLE
CRE: avoid assert failure in sub-processes

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -4108,6 +4108,13 @@ static int freeImage(lua_State *L) {
     return 0;
 }
 
+static bool skip_teardown = false;
+
+static int setSkipTearDown(lua_State *L) {
+    skip_teardown = lua_toboolean(L, 1);
+    return 0;
+}
+
 static const struct luaL_Reg cre_func[] = {
     {"initCache", initCache},
     {"initHyphDict", initHyphDict},
@@ -4133,6 +4140,7 @@ static const struct luaL_Reg cre_func[] = {
     {"renderImageData", renderImageData},
     {"smoothScaleBlitBuffer", smoothScaleBlitBuffer},
     {"setImageReplacementChar", setImageReplacementChar},
+    {"setSkipTearDown", setSkipTearDown},
     {NULL, NULL}
 };
 
@@ -4302,6 +4310,8 @@ int luaopen_cre(lua_State *L) {
 
 // Library finalizer (c.f., dlopen(3)). This serves no real purpose except making Valgrind's output slightly more useful.
 __attribute__((destructor)) static void cre_teardown(void) {
+    if (skip_teardown)
+        return;
     if (cre_callback_forwarder) {
         delete cre_callback_forwarder;
         cre_callback_forwarder = NULL;


### PR DESCRIPTION
Will allow frontend to disable CRE finalizers when running code in a subprocess and explicitely exiting quickly without any proper cleanup.
See https://github.com/koreader/koreader-base/pull/1679#issuecomment-1809377704 and followups.

Buddy frontend addition:
```diff
--- a/frontend/document/credocument.lua
+++ b/frontend/document/credocument.lua
@@ -116,6 +116,15 @@ end
 function CreDocument:engineInit()
     if not engine_initialized then
         cre = require("libs/libkoreader-cre")
+
+        -- When forking to execute any stuff in a sub-process,
+        -- as that stuff may not care about properly closing
+        -- the document, skip cre.cpp finalizer to avoid any
+        -- assertion failure.
+        require("ffi/util").addRunInSubProcessAfterForkFunc("cre_skip_teardown", function()
+            cre.setSkipTearDown(true)
+        end)
+
         -- initialize cache
         self:cacheInit()
```



Pinging @benoit-pierre .
(A mix of the 2 ideas: a rough "skip tear down", but with some generic way to add/remove funcs. Would be more complicated to add stuff referencing the document to do setCacheFileStale() and close() - and I didn't really like the idea of having to do that and I prefer the carefree approach.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1766)
<!-- Reviewable:end -->
