### PR TITLE
ffi/framebuffer_mxcfb.lua: Fix Night Mode on Kobo Elipsa 2E

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -935,8 +935,8 @@ function framebuffer:init()
             -- REAGL is *always* available
             self.waveform_partial = C.HWTCON_WAVEFORM_MODE_GLR16
             -- Eclipse waveform modes are *always* available
-            self.waveform_night = C.HWTCON_WAVEFORM_MODE_GLKW16
-            self.waveform_flashnight = C.HWTCON_WAVEFORM_MODE_GCK16
+            self.waveform_night = C.HWTCON_WAVEFORM_MODE_AUTO
+            self.waveform_flashnight = C.HWTCON_WAVEFORM_MODE_AUTO
 
             self.mech_poweron = kobo_mtk_wakeup_epdc
         end


### PR DESCRIPTION
This commit "fixes" reported graphical problems caused by switching to Night Mode on Elipsa 2E.

Mentioned here: https://github.com/koreader/koreader/pull/10719#issuecomment-1693425726

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1768)
<!-- Reviewable:end -->
