### PR TITLE
make: speedup `fetchthirdparty`

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -6,7 +6,7 @@ fetchthirdparty:
 	git submodule init
 	git submodule sync
 	git submodule foreach --recursive git reset --hard
-	git submodule update
+	git submodule update --jobs 3 $(if $(CI),--depth 1)
 	@echo "cleaning up crengine checkout..."
 	@rm -rf thirdparty/kpvcrlib/crengine/thirdparty
 	@test -d thirdparty/kpvcrlib/crengine \


### PR DESCRIPTION
- on CI, always clone with a shallow depth of 1
- use 3 jobs

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1770)
<!-- Reviewable:end -->
