### PR TITLE
make: saner `fetchthirdparty`

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -5,13 +5,7 @@
 fetchthirdparty:
 	git submodule init
 	git submodule sync
-	git submodule foreach --recursive git reset --hard
 	git submodule update --jobs 3 $(if $(CI),--depth 1)
-	@echo "cleaning up crengine checkout..."
-	@rm -rf thirdparty/kpvcrlib/crengine/thirdparty
-	@test -d thirdparty/kpvcrlib/crengine \
-		&& (cd thirdparty/kpvcrlib/crengine; git checkout .) \
-		|| echo warn: crengine folder not found
 
 $(FREETYPE_LIB): $(THIRDPARTY_DIR)/freetype2/*.*
 	install -d $(FREETYPE_BUILD_DIR)


### PR DESCRIPTION
Avoid destructive operations.

The CIs don't rely on it.

It does not help that it can be triggered by `./kodev build` when using a sparse checkout that does not include all submodules (like `platform/ubuntu-touch/ubuntu-touch-sdl`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1777)
<!-- Reviewable:end -->
