### PR TITLE
curl: make certificates bundle generation more robust

### DIFF
--- a/thirdparty/curl/CMakeLists.txt
+++ b/thirdparty/curl/CMakeLists.txt
@@ -112,11 +112,15 @@ list(APPEND CFG_OPTS --without-zsh-functions-dir)
 
 list(APPEND CFG_CMD COMMAND env ${CFG_ENV_VAR} ${SOURCE_DIR}/configure ${CFG_OPTS})
 
-list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE} ca-bundle)
+# Don't use the default build system rule to create the certificates
+# bundle: connections to `hg.mozilla.org` from CIs seem to be flaky,
+# resulting in regular failures.
+set(CA_BUNDLE_CMD ${CMAKE_CURRENT_LIST_DIR}/fetch-ca-bundle.sh ${KO_DOWNLOAD_DIR}/ca-bundle.crt)
+
 list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE})
 
 list(APPEND INSTALL_CMD COMMAND ${KO_MAKE_RECURSIVE} install)
-list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} -E rename ${SOURCE_DIR}/lib/ca-bundle.crt ${BINARY_DIR}/ca-bundle.crt)
+list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} -E copy ${KO_DOWNLOAD_DIR}/ca-bundle.crt ${BINARY_DIR}/ca-bundle.crt)
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
@@ -128,7 +132,7 @@ ko_write_gitclone_script(
 include(ExternalProject)
 ExternalProject_Add(
     ${PROJECT_NAME}
-    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME}
+    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -P ${GIT_CLONE_SCRIPT_FILENAME} COMMAND ${CA_BUNDLE_CMD}
     BUILD_IN_SOURCE 1
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/curl/fetch-ca-bundle.sh
+++ b/thirdparty/curl/fetch-ca-bundle.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+output="$1"
+outdir="$(dirname "${output}")"
+
+mkdir -p "${outdir}" && curl \
+    --etag-compare "${output}.etag" \
+    --etag-save "${output}.etag" \
+    --output "${output}" \
+    --retry 3 \
+    https://curl.se/ca/cacert.pem
+code=$?
+
+if [ ${code} -ne 0 ]; then
+    if [ -r "${output}" ]; then
+        code=0
+        severity=WARNING
+    else
+        severity=ERROR
+    fi
+    printf '\033[31;1m%s:\033[0m failed to fetch “%s”\n' "${severity}" "${output}" 1>&2
+fi
+
+exit ${code}
+
+# vim: sw=4


### PR DESCRIPTION
Don't use the default build system rule to create the certificates bundle: connections to `hg.mozilla.org` from CIs seem to be flaky, resulting in regular failures.

Cf. https://curl.se/docs/caextract.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1778)
<!-- Reviewable:end -->
