### PR TITLE
Ship libfbink_input to provide input device classification

### DIFF
--- a/Makefile.third
+++ b/Makefile.third
@@ -479,6 +479,7 @@ $(OUTPUT_DIR)/fbink: $(THIRDPARTY_DIR)/fbink/*.*
 		-S $(THIRDPARTY_DIR)/fbink -B $(FBINK_BUILD_DIR)
 	$(CMAKE_MAKE_PROGRAM) $(CMAKE_MAKE_PROGRAM_FLAGS) -C $(FBINK_BUILD_DIR)
 	cp $(FBINK_DIR)/fbink $(OUTPUT_DIR)/
+	cp $(FBINK_DIR)/libfbink_input.so.1 $(OUTPUT_DIR)/libs
 ifdef KOBO
 	cp $(FBINK_DIR)/fbdepth $(OUTPUT_DIR)/
 endif

--- a/ffi/fbink_input_h.lua
+++ b/ffi/fbink_input_h.lua
@@ -1,0 +1,42 @@
+-- cdecl available at https://github.com/NiLuJe/FBInk/blob/master/ffi/fbink_input_decl.c
+local ffi = require("ffi")
+
+ffi.cdef[[
+typedef enum {
+  INPUT_UNKNOWN = 0,
+  INPUT_POINTINGSTICK = 1,
+  INPUT_MOUSE = 2,
+  INPUT_TOUCHPAD = 4,
+  INPUT_TOUCHSCREEN = 8,
+  INPUT_JOYSTICK = 16,
+  INPUT_TABLET = 32,
+  INPUT_KEY = 64,
+  INPUT_KEYBOARD = 128,
+  INPUT_ACCELEROMETER = 256,
+  INPUT_POWER_BUTTON = 65536,
+  INPUT_SLEEP_COVER = 131072,
+  INPUT_PAGINATION_BUTTONS = 262144,
+  INPUT_HOME_BUTTON = 524288,
+  INPUT_LIGHT_BUTTON = 1048576,
+  INPUT_MENU_BUTTON = 2097152,
+  INPUT_DPAD = 4194304,
+  INPUT_ROTATION_EVENT = 8388608,
+} __attribute__((packed)) INPUT_DEVICE_TYPE_E;
+typedef uint32_t INPUT_DEVICE_TYPE_T;
+typedef enum {
+  SCAN_ONLY = 1,
+  OPEN_BLOCKING = 2,
+  MATCH_ALL = 4,
+  EXCLUDE_ALL = 8,
+} __attribute__((packed)) INPUT_SETTINGS_TYPE_E;
+typedef uint32_t INPUT_SETTINGS_TYPE_T;
+typedef struct {
+  INPUT_DEVICE_TYPE_T type;
+  int fd;
+  bool matched;
+  char name[256];
+  char path[4096];
+} FBInkInputDevice;
+FBInkInputDevice *fbink_input_scan(INPUT_DEVICE_TYPE_T, INPUT_DEVICE_TYPE_T, INPUT_SETTINGS_TYPE_T, size_t *);
+FBInkInputDevice *fbink_input_check(const char *, INPUT_DEVICE_TYPE_T, INPUT_DEVICE_TYPE_T, INPUT_SETTINGS_TYPE_T);
+]]

--- a/ffi/fbink_input_h.lua
+++ b/ffi/fbink_input_h.lua
@@ -21,6 +21,7 @@ typedef enum {
   INPUT_MENU_BUTTON = 2097152,
   INPUT_DPAD = 4194304,
   INPUT_ROTATION_EVENT = 8388608,
+  INPUT_SCALED_TABLET = 16777216,
 } __attribute__((packed)) INPUT_DEVICE_TYPE_E;
 typedef uint32_t INPUT_DEVICE_TYPE_T;
 typedef enum {

--- a/ffi/fbink_input_h.lua
+++ b/ffi/fbink_input_h.lua
@@ -29,6 +29,7 @@ typedef enum {
   OPEN_BLOCKING = 2,
   MATCH_ALL = 4,
   EXCLUDE_ALL = 8,
+  NO_RECAP = 16,
 } __attribute__((packed)) INPUT_SETTINGS_TYPE_E;
 typedef uint32_t INPUT_SETTINGS_TYPE_T;
 typedef struct {

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    0a675d4a85f4cad32a51a5d80343513e67ac2270
+    365b119a71f0c5739d9971028bde32f5808a5767
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    2775e6fa795cc01451aa4edcd9b374201b64af33
+    cbaf922ce13799f70190572ec9a3f90f1af1d685
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -14,21 +14,42 @@ set(BINARY_DIR ${SOURCE_DIR})
 # Choose your own adventure!
 if(DEFINED ENV{LEGACY})
     set(FBINK_TARGET legacy)
+    set(INPUT_TARGET inputlib KINDLE=1 LEGACY=1)
 elseif(DEFINED ENV{KINDLE})
     set(FBINK_TARGET kindle)
+    set(INPUT_TARGET inputlib KINDLE=1)
 elseif(DEFINED ENV{CERVANTES})
     set(FBINK_TARGET cervantes)
+    set(INPUT_TARGET inputlib CERVANTES=1)
 elseif(DEFINED ENV{KOBO})
     set(FBINK_TARGET strip KOBO=1)
     set(FBDEPTH_TARGET fbdepth KOBO=1)
+    set(INPUT_TARGET inputlib KOBO=1)
 elseif(DEFINED ENV{REMARKABLE})
     set(FBINK_TARGET remarkable)
     set(FBDEPTH_TARGET fbdepth REMARKABLE=1)
+    set(INPUT_TARGET inputlib REMARKABLE=1)
 elseif(DEFINED ENV{POCKETBOOK})
     set(FBINK_TARGET pocketbook)
     set(FBDEPTH_TARGET fbdepth POCKETBOOK=1)
+    set(INPUT_TARGET inputlib POCKETBOOK=1)
 else()
     set(FBINK_TARGET strip)
+    # Would technically run just fine on plain Linux...
+    #set(INPUT_TARGET inputlib LINUX=1)
+endif()
+
+# The input lib can be built standalone, so start with that
+if(INPUT_TARGET)
+    list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE} clean)
+    list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE} "CFLAGS=${CFLAGS}" "LDFLAGS=${LDFLAGS}" ${INPUT_TARGET})
+
+    # That does mean we need to stash it somewhere a clean won't scrap it, though...
+    if(DEFINED ENV{DEBUG})
+        list(APPEND BUILD_CMD COMMAND ${CMAKE_COMMAND} -E rename ${SOURCE_DIR}/Debug/libfbink_input.so.1.0.0 ${INSTALL_DIR}/libfbink_input.so.1)
+    else()
+        list(APPEND BUILD_CMD COMMAND ${CMAKE_COMMAND} -E rename ${SOURCE_DIR}/Release/libfbink_input.so.1.0.0 ${INSTALL_DIR}/libfbink_input.so.1)
+    endif()
 endif()
 
 # FBDepth can afford to link to a very minimal library, so we need to start from scratch...
@@ -58,7 +79,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    a60c6c814b910d24be5b9be43d1b4514a8ef6aef
+    455847425d08a5c101663eaac3b53f03a375b2b2
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    cbaf922ce13799f70190572ec9a3f90f1af1d685
+    0a675d4a85f4cad32a51a5d80343513e67ac2270
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/fbink/CMakeLists.txt
+++ b/thirdparty/fbink/CMakeLists.txt
@@ -79,7 +79,7 @@ endif()
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/NiLuJe/FBInk.git
-    455847425d08a5c101663eaac3b53f03a375b2b2
+    2775e6fa795cc01451aa4edcd9b374201b64af33
     ${SOURCE_DIR}
 )
 

--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -16,7 +16,7 @@ list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE} "CFLAGS=${CFLAGS}" "LDFLAGS=$
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME
     https://github.com/koreader/KoboUSBMS.git
-    ef5b3a4f13565b0b282ce377517b6da252884597
+    b847b3c32e932937278c9e7db0a1a3778ee59ffb
     ${SOURCE_DIR}
 )
 


### PR DESCRIPTION
* Update FBInk so that the feature actually exist ;p
* Update KoboUSBMS to a build that also uses it internally
* Build & ship a very minimal shared library variant on FBInk that *only* provides this facility (it's 10K), that we'll be able to poke at via FFI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1782)
<!-- Reviewable:end -->
