### PR TITLE
CI improvements

### DIFF
--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -21,7 +21,7 @@ docker-make() {
         'sudo chown -R ko:ko .'
         './.ci/cache_restore_post.sh'
         "trap './.ci/cache_save_pre.sh' EXIT"
-        "make $(printf '%q ' "$@")"
+        "env MAKEFLAGS='${MAKEFLAGS}' make $(printf '%q ' "$@")"
     )
     sudo chmod -R 777 "${CCACHE_DIR}"
     docker run --rm -t \

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -19,8 +19,6 @@ docker-make() {
         'source /home/ko/.bashrc'
         'cd /home/ko/base'
         'sudo chown -R ko:ko .'
-        './.ci/cache_restore_post.sh'
-        "trap './.ci/cache_save_pre.sh' EXIT"
         "env MAKEFLAGS='${MAKEFLAGS}' make $(printf '%q ' "$@")"
     )
     sudo chmod -R 777 "${CCACHE_DIR}"
@@ -31,8 +29,6 @@ docker-make() {
 }
 
 if [[ -z "${DOCKER_IMG}" ]]; then
-    './.ci/cache_restore_post.sh'
-    trap './.ci/cache_save_pre.sh' EXIT
     make TARGET="${TARGET}" "$@"
 else
     docker-make TARGET="${TARGET}" VERBOSE=1 "$@"

--- a/.ci/build_script.sh
+++ b/.ci/build_script.sh
@@ -12,8 +12,6 @@ fi
 mkdir -p "${CCACHE_DIR}"
 echo "using cache dir: ${CCACHE_DIR}"
 
-travis_retry make fetchthirdparty TARGET=
-
 docker-make() {
     local cmdlist=(
         'source /home/ko/.bashrc'

--- a/.ci/cache_restore_post.sh
+++ b/.ci/cache_restore_post.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-which ccache
-ccache --version
-ccache --zero-stats
-ccache -p # `-p`: equivalent to `--show-config` (not supported with ancient versions)

--- a/.ci/cache_restore_post.sh
+++ b/.ci/cache_restore_post.sh
@@ -5,7 +5,4 @@ set -ex
 which ccache
 ccache --version
 ccache --zero-stats
-# TODO: reduce once a more recent version of ccache with
-# zstd support and compression enabled by default is used.
-ccache --max-size=1G
 ccache -p # `-p`: equivalent to `--show-config` (not supported with ancient versions)

--- a/.ci/cache_save_pre.sh
+++ b/.ci/cache_save_pre.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -ex
-
-ccache --cleanup >/dev/null
-ccache --show-stats

--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -5,12 +5,12 @@ CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common.sh"
 
 if [ "$TARGET" = "android" ]; then
-    if [ -f build/arm-linux-androideabi/luajit ]; then
+    if [ -f build/luajit ]; then
         echo "ERROR: android build should not include luajit binary."
         exit 1
     fi
 elif [ "$EMULATE_READER" = "1" ]; then
-    cp build/*/luajit "${HOME}/.luarocks/bin/"
+    cp build/luajit "${HOME}/.luarocks/bin/"
     # install test data
     travis_retry make test-data
     # finally make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
 
   lint:
     executor: base
+    resource_class: small
     environment:
       BASH_ENV: "~/.bashrc"
     steps:
@@ -125,6 +126,7 @@ jobs:
         type: string
         default: "256M"
     executor: << parameters.executor >>
+    resource_class: medium
     environment:
       BASH_ENV: "~/.bashrc"
       CCACHE_MAXSIZE: << parameters.ccache_maxsize >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,9 @@ jobs:
       ccache_maxsize:
         type: string
         default: "256M"
+      always_test:
+        type: boolean
+        default: false
     executor: << parameters.executor >>
     resource_class: medium
     environment:
@@ -132,12 +135,28 @@ jobs:
       CCACHE_MAXSIZE: << parameters.ccache_maxsize >>
       MAKEFLAGS: "OUTPUT_DIR=build"
     steps:
-      # Checkout.
+      # Checkout / fetch. {{{
       - checkout
-      # Restore / setup cache. {{{
+      - run:
+          name: Fetch
+          command: make fetchthirdparty
+      # }}}
+      # Restore / setup caches. {{{
       - run:
           name: Generate cache key
           command: make TARGET= cache-key
+      - restore_cache:
+          name: Restore build directory
+          keys:
+            - &CACHE_KEY_BUILD_DIR '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-build-{{ arch }}-{{ checksum "cache-key" }}'
+      # If we already have a build, and nothing
+      # to test, just skip the rest of the job.
+      - unless:
+          condition: << parameters.always_test >>
+          steps:
+              - run:
+                  name: Skip job?
+                  command: if test -d build; then circleci-agent step halt; fi
       - restore_cache:
           name: Restore build cache
           keys:
@@ -155,13 +174,15 @@ jobs:
       # Build.
       - run:
           name: Build
-          command: source .ci/build_script.sh
-      # Clean / save cache. {{{
+          command: test -d build || source .ci/build_script.sh
+      # Clean / save caches. {{{
       - run:
-          name: Clean build cache
+          name: Clean caches
           when: always
           command: |
             set -x
+            # Trim the build directory.
+            rm -rf build/thirdparty
             ccache --cleanup >/dev/null
             ccache --show-stats
       - save_cache:
@@ -169,6 +190,11 @@ jobs:
           key: *CACHE_KEY_BUILD_CACHE
           paths:
             - /home/ko/.ccache
+      - save_cache:
+          name: Save build directory
+          key: *CACHE_KEY_BUILD_DIR
+          paths:
+            - build
       # }}}
       # Tests. {{{
       - run:
@@ -202,6 +228,7 @@ workflows:
               only: master
           requires:
             - lint
+          always_test: true
 
       - build_and_test:
           name: emu_gcc_ninja_debug
@@ -211,6 +238,7 @@ workflows:
           # TODO: reduce once a more recent version of ccache with
           # zstd support and compression enabled by default is used.
           ccache_maxsize: "1G"
+          always_test: true
 
       - build_and_test:
           name: emu_gcc_make
@@ -220,12 +248,14 @@ workflows:
               only: master
           requires:
             - lint
+          always_test: true
 
       - build_and_test:
           name: emu_clang_ninja
           executor: emu_clang_ninja
           requires:
             - lint
+          always_test: true
 
       # }}}
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,7 @@ jobs:
     environment:
       BASH_ENV: "~/.bashrc"
       CCACHE_MAXSIZE: << parameters.ccache_maxsize >>
+      CLICOLOR_FORCE: "1"
       MAKEFLAGS: "OUTPUT_DIR=build"
     steps:
       # Checkout / fetch. {{{

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,16 +15,85 @@ parameters:
 
 executors:
 
-  base:
+  base: &BASE_EXE
     docker:
       - image: koreader/kobase:0.3.2-20.04
 
-  base-clang:
+  # Emulators. {{{
+
+  emu_gcc_ninja:
+    <<: *BASE_EXE
+    environment: &EMU_ENV_LST
+      EMULATE_READER: "1"
+      CC: "gcc"
+
+  emu_gcc_ninja_debug:
+    <<: *BASE_EXE
+    environment:
+      <<: *EMU_ENV_LST
+      KODEBUG: "1"
+
+  emu_gcc_make:
+    <<: *BASE_EXE
+    environment:
+      <<: *EMU_ENV_LST
+      USE_MAKE: "1"
+
+  emu_clang_ninja:
     docker:
       - image: koreader/kobase-clang:0.3.3-20.04
+    environment:
+      <<: *EMU_ENV_LST
+      CC: "clang"
+      CXX: "clang++"
 
-  xcompile:
-    machine: true
+  # }}}
+
+  # Platforms. {{{
+
+  android-arm: &ANDROID_EXE
+    docker:
+      - image: koreader/koandroid:0.8.1-20.04
+    environment:
+      TARGET: "android"
+
+  android-x86:
+    <<: *ANDROID_EXE
+    environment:
+      TARGET: "android"
+      ANDROID_ARCH: "x86"
+
+  cervantes:
+    docker:
+      - image: koreader/kocervantes:0.3.2-20.04
+    environment:
+      TARGET: "cervantes"
+
+  kindle:
+    docker:
+      - image: koreader/kokindle:0.3.2-20.04
+    environment:
+      TARGET: "kindle"
+
+  kobo:
+    docker:
+      - image: koreader/kokobo:0.3.2-20.04
+    environment:
+      TARGET: "kobo"
+
+  pocketbook:
+    docker:
+      - image: koreader/kopb:0.4.1-20.04
+    environment:
+      TARGET: "pocketbook"
+
+  sony-prstux:
+    docker:
+      - image: koreader/kobase-22.04:0.3.0
+    environment:
+      TARGET: "sony-prstux"
+
+  # }}}
 
 # }}}
 
@@ -48,18 +117,22 @@ jobs:
 
   # Build & Test. {{{
 
-  build: &BUILD_TPL
-    executor: base
-    environment: &BUILD_ENV_LST
-      BASH_ENV: "~/.bashrc"
-      CCACHE_MAXSIZE: "256M"
-      MAKEFLAGS: "OUTPUT_DIR=build"
+  build_and_test:
     parameters:
-      cache_path:
+      executor:
+        type: executor
+      ccache_maxsize:
         type: string
-        default: "/home/ko/.ccache"
+        default: "256M"
+    executor: << parameters.executor >>
+    environment:
+      BASH_ENV: "~/.bashrc"
+      CCACHE_MAXSIZE: << parameters.ccache_maxsize >>
+      MAKEFLAGS: "OUTPUT_DIR=build"
     steps:
+      # Checkout.
       - checkout
+      # Restore / setup cache. {{{
       - run:
           name: Generate cache key
           command: make TARGET= cache-key
@@ -68,116 +141,23 @@ jobs:
           keys:
             - &CACHE_KEY_BUILD_CACHE '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-{{ checksum "cache-key" }}'
             - '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-'
+      # }}}
+      # Build.
       - run:
           name: Build
           command: source .ci/build_script.sh
+      # Clean / save cache. {{{
       - save_cache:
           name: Save build cache
           key: *CACHE_KEY_BUILD_CACHE
           paths:
-            - << parameters.cache_path >>
+            - /home/ko/.ccache
+      # }}}
+      # Tests. {{{
       - run:
           name: Test
           command: source .ci/test_script.sh
-
-  # }}}
-
-  # Emulator. {{{
-
-  emu: &EMU_TPL
-    <<: *BUILD_TPL
-    environment: &EMU_ENV_LST
-      <<: *BUILD_ENV_LST
-      EMULATE_READER: "1"
-      CC: "gcc"
-
-  emu_gcc_ninja:
-    <<: *EMU_TPL
-
-  emu_gcc_ninja_debug:
-    <<: *EMU_TPL
-    environment:
-      <<: *EMU_ENV_LST
-      KODEBUG: "1"
-      # TODO: reduce once a more recent version of ccache with
-      # zstd support and compression enabled by default is used.
-      CCACHE_MAXSIZE: "1G"
-
-  emu_gcc_make:
-    <<: *EMU_TPL
-    environment:
-      <<: *EMU_ENV_LST
-      USE_MAKE: "1"
-
-  emu_clang_ninja:
-    <<: *EMU_TPL
-    executor: base-clang
-    environment:
-      <<: *EMU_ENV_LST
-      CC: "clang"
-      CXX: "clang++"
-
-  # }}}
-
-  # Platforms. {{{
-
-  xcompile: &XCOMPILE_TPL
-    <<: *BUILD_TPL
-    executor: xcompile
-    parameters:
-      cache_path:
-        type: string
-        default: "/home/circleci/.ccache"
-
-  android-arm: &ANDROID_TPL
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "android"
-      DOCKER_IMG: koreader/koandroid:0.8.1-20.04
-
-  android-x86:
-    <<: *ANDROID_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "android"
-      ANDROID_ARCH: "x86"
-      DOCKER_IMG: koreader/koandroid:0.8.1-20.04
-
-  cervantes:
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "cervantes"
-      DOCKER_IMG: koreader/kocervantes:0.3.2-20.04
-
-  kindle:
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "kindle"
-      DOCKER_IMG: koreader/kokindle:0.3.2-20.04
-
-  kobo:
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "kobo"
-      DOCKER_IMG: koreader/kokobo:0.3.2-20.04
-
-  pocketbook:
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "pocketbook"
-      DOCKER_IMG: koreader/kopb:0.4.1-20.04
-
-  sony-prstux:
-    <<: *XCOMPILE_TPL
-    environment:
-      <<: *BUILD_ENV_LST
-      TARGET: "sony-prstux"
-      DOCKER_IMG: koreader/kobase-22.04:0.3.0
+      # }}}
 
   # }}}
 
@@ -197,25 +177,36 @@ workflows:
 
       # Emulators. {{{
 
-      - emu_gcc_ninja:
+      - build_and_test:
+          name: emu_gcc_ninja
+          executor: emu_gcc_ninja
           filters:
             branches:
               only: master
           requires:
             - lint
 
-      - emu_gcc_ninja_debug:
+      - build_and_test:
+          name: emu_gcc_ninja_debug
+          executor: emu_gcc_ninja_debug
           requires:
             - lint
+          # TODO: reduce once a more recent version of ccache with
+          # zstd support and compression enabled by default is used.
+          ccache_maxsize: "1G"
 
-      - emu_gcc_make:
+      - build_and_test:
+          name: emu_gcc_make
+          executor: emu_gcc_make
           filters:
             branches:
               only: master
           requires:
             - lint
 
-      - emu_clang_ninja:
+      - build_and_test:
+          name: emu_clang_ninja
+          executor: emu_clang_ninja
           requires:
             - lint
 
@@ -223,34 +214,48 @@ workflows:
 
       # Platforms. {{{
 
-      - android-arm:
+      - build_and_test:
+          name: android-arm
+          executor: android-arm
           requires:
             - emu_gcc_ninja_debug
 
-      - android-x86:
+      - build_and_test:
+          name: android-x86
+          executor: android-x86
           filters:
             branches:
               only: master
           requires:
             - emu_gcc_ninja_debug
 
-      - cervantes:
+      - build_and_test:
+          name: cervantes
+          executor: cervantes
           requires:
             - emu_gcc_ninja_debug
 
-      - kindle:
+      - build_and_test:
+          name: kindle
+          executor: kindle
           requires:
             - emu_gcc_ninja_debug
 
-      - kobo:
+      - build_and_test:
+          name: kobo
+          executor: kobo
           requires:
             - emu_gcc_ninja_debug
 
-      - pocketbook:
+      - build_and_test:
+          name: pocketbook
+          executor: pocketbook
           requires:
             - emu_gcc_ninja_debug
 
-      - sony-prstux:
+      - build_and_test:
+          name: sony-prstux
+          executor: sony-prstux
           requires:
             - emu_gcc_ninja_debug
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,96 +1,95 @@
-version: 2
+version: "2.1"
 
-workflows:
-  version: 2
-  lint_build_test:
-    jobs:
-      - lint
-      - emu_gcc_ninja:
-          filters:
-            branches:
-              only: master
-          requires:
-            - lint
-      - emu_gcc_ninja_debug:
-          requires:
-            - lint
-      - emu_gcc_make:
-          filters:
-            branches:
-              only: master
-          requires:
-            - lint
-      - emu_clang_ninja:
-          requires:
-            - lint
-      - kindle:
-          requires:
-            - emu_gcc_ninja_debug
-      - kobo:
-          requires:
-            - emu_gcc_ninja_debug
-      - pocketbook:
-          requires:
-            - emu_gcc_ninja_debug
-      - sony-prstux:
-          requires:
-            - emu_gcc_ninja_debug
-      - cervantes:
-          requires:
-            - emu_gcc_ninja_debug
-      - android-arm:
-          requires:
-            - emu_gcc_ninja_debug
-      - android-x86:
-          filters:
-            branches:
-              only: master
-          requires:
-            - emu_gcc_ninja_debug
+# Parameters. {{{
 
+parameters:
 
-jobs:
-  lint:
+    # Bump this to reset all caches.
+    cache_epoch:
+      type: integer
+      default: 0
+
+# }}}
+
+# Executors. {{{
+
+executors:
+
+  base:
     docker:
       - image: koreader/kobase:0.3.2-20.04
+
+  base-clang:
+    docker:
+      - image: koreader/kobase-clang:0.3.3-20.04
+
+  xcompile:
+    machine: true
+
+# }}}
+
+# Jobs. {{{
+
+jobs:
+
+  # Lint. {{{
+
+  lint:
+    executor: base
     environment:
       BASH_ENV: "~/.bashrc"
     steps:
       - checkout
       - run:
           name: lint
-          command: |
-            source .ci/lint_script.sh
+          command: source .ci/lint_script.sh
 
-  emu: &EMU_TPL
-    docker:
-      - image: koreader/kobase:0.3.2-20.04
-    environment: &EMU_ENV_LST
+  # }}}
+
+  # Build & Test. {{{
+
+  build: &BUILD_TPL
+    executor: base
+    environment: &BUILD_ENV_LST
       BASH_ENV: "~/.bashrc"
-      EMULATE_READER: "1"
-      CC: "gcc"
+      CCACHE_MAXSIZE: "256M"
+      MAKEFLAGS: "OUTPUT_DIR=build"
+    parameters:
+      cache_path:
+        type: string
+        default: "/home/ko/.ccache"
     steps:
       - checkout
-
+      - run:
+          name: Generate cache key
+          command: make TARGET= cache-key
       - restore_cache:
+          name: Restore build cache
           keys:
-            - "{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-"
-            - "master-{{ .Environment.CIRCLE_JOB }}-"
-
+            - &CACHE_KEY_BUILD_CACHE '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-{{ checksum "cache-key" }}'
+            - '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-'
       - run:
-          name: build
-          command: |
-            source .ci/build_script.sh
-
+          name: Build
+          command: source .ci/build_script.sh
       - save_cache:
-          key: "{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}"
+          name: Save build cache
+          key: *CACHE_KEY_BUILD_CACHE
           paths:
-            - "/home/ko/.ccache"
-
+            - << parameters.cache_path >>
       - run:
-          name: test
-          command: |
-            source .ci/test_script.sh
+          name: Test
+          command: source .ci/test_script.sh
+
+  # }}}
+
+  # Emulator. {{{
+
+  emu: &EMU_TPL
+    <<: *BUILD_TPL
+    environment: &EMU_ENV_LST
+      <<: *BUILD_ENV_LST
+      EMULATE_READER: "1"
+      CC: "gcc"
 
   emu_gcc_ninja:
     <<: *EMU_TPL
@@ -100,6 +99,9 @@ jobs:
     environment:
       <<: *EMU_ENV_LST
       KODEBUG: "1"
+      # TODO: reduce once a more recent version of ccache with
+      # zstd support and compression enabled by default is used.
+      CCACHE_MAXSIZE: "1G"
 
   emu_gcc_make:
     <<: *EMU_TPL
@@ -109,79 +111,151 @@ jobs:
 
   emu_clang_ninja:
     <<: *EMU_TPL
-    docker:
-      - image: koreader/kobase-clang:0.3.3-20.04
+    executor: base-clang
     environment:
       <<: *EMU_ENV_LST
       CC: "clang"
       CXX: "clang++"
 
+  # }}}
 
+  # Platforms. {{{
 
   xcompile: &XCOMPILE_TPL
-    machine: true
-    steps:
-      - checkout
-
-      - restore_cache:
-          keys:
-            - "{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-"
-            - "master-{{ .Environment.CIRCLE_JOB }}-"
-
-      - run:
-          name: build
-          command: |
-            source .ci/build_script.sh
-
-      - save_cache:
-          key: "{{ .Branch }}-{{ .Environment.CIRCLE_JOB }}-{{ epoch }}"
-          paths:
-            - "/home/circleci/.ccache"
-
-      - run:
-          name: test
-          command: |
-            source .ci/test_script.sh
-
-  kindle:
-    <<: *XCOMPILE_TPL
-    environment:
-      TARGET: "kindle"
-      DOCKER_IMG: koreader/kokindle:0.3.2-20.04
-
-  kobo:
-    <<: *XCOMPILE_TPL
-    environment:
-      TARGET: "kobo"
-      DOCKER_IMG: koreader/kokobo:0.3.2-20.04
-
-  pocketbook:
-    <<: *XCOMPILE_TPL
-    environment:
-      TARGET: "pocketbook"
-      DOCKER_IMG: koreader/kopb:0.4.1-20.04
-
-  sony-prstux:
-    <<: *XCOMPILE_TPL
-    environment:
-      TARGET: "sony-prstux"
-      DOCKER_IMG: koreader/kobase-22.04:0.3.0
-
-  cervantes:
-    <<: *XCOMPILE_TPL
-    environment:
-      TARGET: "cervantes"
-      DOCKER_IMG: koreader/kocervantes:0.3.2-20.04
+    <<: *BUILD_TPL
+    executor: xcompile
+    parameters:
+      cache_path:
+        type: string
+        default: "/home/circleci/.ccache"
 
   android-arm: &ANDROID_TPL
     <<: *XCOMPILE_TPL
     environment:
+      <<: *BUILD_ENV_LST
       TARGET: "android"
       DOCKER_IMG: koreader/koandroid:0.8.1-20.04
 
   android-x86:
     <<: *ANDROID_TPL
     environment:
+      <<: *BUILD_ENV_LST
       TARGET: "android"
       ANDROID_ARCH: "x86"
       DOCKER_IMG: koreader/koandroid:0.8.1-20.04
+
+  cervantes:
+    <<: *XCOMPILE_TPL
+    environment:
+      <<: *BUILD_ENV_LST
+      TARGET: "cervantes"
+      DOCKER_IMG: koreader/kocervantes:0.3.2-20.04
+
+  kindle:
+    <<: *XCOMPILE_TPL
+    environment:
+      <<: *BUILD_ENV_LST
+      TARGET: "kindle"
+      DOCKER_IMG: koreader/kokindle:0.3.2-20.04
+
+  kobo:
+    <<: *XCOMPILE_TPL
+    environment:
+      <<: *BUILD_ENV_LST
+      TARGET: "kobo"
+      DOCKER_IMG: koreader/kokobo:0.3.2-20.04
+
+  pocketbook:
+    <<: *XCOMPILE_TPL
+    environment:
+      <<: *BUILD_ENV_LST
+      TARGET: "pocketbook"
+      DOCKER_IMG: koreader/kopb:0.4.1-20.04
+
+  sony-prstux:
+    <<: *XCOMPILE_TPL
+    environment:
+      <<: *BUILD_ENV_LST
+      TARGET: "sony-prstux"
+      DOCKER_IMG: koreader/kobase-22.04:0.3.0
+
+  # }}}
+
+# }}}
+
+# Workflows. {{{
+
+workflows:
+
+  version: 2
+
+  lint_build_test:
+
+    jobs:
+
+      - lint
+
+      # Emulators. {{{
+
+      - emu_gcc_ninja:
+          filters:
+            branches:
+              only: master
+          requires:
+            - lint
+
+      - emu_gcc_ninja_debug:
+          requires:
+            - lint
+
+      - emu_gcc_make:
+          filters:
+            branches:
+              only: master
+          requires:
+            - lint
+
+      - emu_clang_ninja:
+          requires:
+            - lint
+
+      # }}}
+
+      # Platforms. {{{
+
+      - android-arm:
+          requires:
+            - emu_gcc_ninja_debug
+
+      - android-x86:
+          filters:
+            branches:
+              only: master
+          requires:
+            - emu_gcc_ninja_debug
+
+      - cervantes:
+          requires:
+            - emu_gcc_ninja_debug
+
+      - kindle:
+          requires:
+            - emu_gcc_ninja_debug
+
+      - kobo:
+          requires:
+            - emu_gcc_ninja_debug
+
+      - pocketbook:
+          requires:
+            - emu_gcc_ninja_debug
+
+      - sony-prstux:
+          requires:
+            - emu_gcc_ninja_debug
+
+      # }}}
+
+# }}}
+
+# vim: foldmethod=marker foldlevel=0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,12 +141,27 @@ jobs:
           keys:
             - &CACHE_KEY_BUILD_CACHE '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-{{ checksum "cache-key" }}'
             - '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-'
+      - run:
+          name: Setup build cache
+          command: |
+            set -x
+            which ccache
+            ccache --version
+            ccache --zero-stats
+            ccache --show-config
       # }}}
       # Build.
       - run:
           name: Build
           command: source .ci/build_script.sh
       # Clean / save cache. {{{
+      - run:
+          name: Clean build cache
+          when: always
+          command: |
+            set -x
+            ccache --cleanup >/dev/null
+            ccache --show-stats
       - save_cache:
           name: Save build cache
           key: *CACHE_KEY_BUILD_CACHE

--- a/.github/actions/brew_cache/action.yml
+++ b/.github/actions/brew_cache/action.yml
@@ -3,10 +3,10 @@ inputs:
   packages:
     required: true
 
-  # Internal.
-
   cache_epoch:
     default: '1' # increment to reset cache
+
+  # Internal.
 
   shell:
     default: bash --noprofile --norc -e {0}
@@ -55,8 +55,7 @@ runs:
       with:
         path: ${{ env.BREW_CACHE_DIR }}/cache
         key: ${{ inputs.cache_epoch }}-${{ runner.os }}-brew-cache-${{ env.BREW_CACHE_KEY }}
-        restore-keys: |
-          ${{ inputs.cache_epoch }}-${{ runner.os }}-brew-cache-
+        restore-keys: ${{ inputs.cache_epoch }}-${{ runner.os }}-brew-cache-
 
     - shell: ${{ inputs.shell }}
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       # Bump number to reset all caches.
       CACHE_EPOCH: '0'
+      CLICOLOR_FORCE: '1'
       MACOSX_DEPLOYMENT_TARGET: '11'
       MAKEFLAGS: 'OUTPUT_DIR=build'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,14 +11,24 @@ defaults:
     shell: bash
 
 jobs:
-  build:
+
+  macos:
+
     runs-on: macos-11
+
+    env:
+      # Bump number to reset all caches.
+      CACHE_EPOCH: '0'
+      MACOSX_DEPLOYMENT_TARGET: '11'
+      MAKEFLAGS: 'OUTPUT_DIR=build'
 
     steps:
       - name: XCode version
         run: xcode-select -p
 
-      - name: Check out Git repository
+      # Checkout / fetch. {{{
+
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           clean: false
@@ -26,20 +36,59 @@ jobs:
           filter: tree:0
           show-progress: false
 
-      - uses: actions/setup-python@v5
+      - name: Fetch
+        run: make fetchthirdparty
+
+      # }}}
+
+      # Restore / setup caches. {{{
+
+      - name: Generate cache key
+        run: make TARGET= cache-key
+
+      # Note: if we get a hit on the primary key, then the rest of the job can be skipped:
+      # there's no point in building the same version, and we don't have any tests to run.
+      - name: Restore build cache
+        id: ccache-restore
+        uses: actions/cache/restore@v4
         with:
-          # Note: Python 3.12 removal of `distutils` breaks GLib's build.
-          python-version: '3.11'
+          path: /Users/runner/Library/Caches/ccache
+          key: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-ccache-${{ hashFiles('cache-key') }}
+          restore-keys: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-ccache-
 
       - name: Install ccache
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
         run: |
           wget --progress=dot:mega https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1-darwin.tar.gz
           tar xf ccache-4.9.1-darwin.tar.gz
           printf '%s\n' "$PWD/ccache-4.9.1-darwin" >>"${GITHUB_PATH}"
 
-      - name: Homebrew install dependencies
+      - name: Setup build cache
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
+        run: |
+          set -x
+          which ccache
+          ccache --version
+          ccache --zero-stats
+          ccache --max-size=256M
+          ccache --show-config
+
+      # }}}
+
+      # Install dependencies. {{{
+
+      - name: Setup Python
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
+        uses: actions/setup-python@v5
+        with:
+          # Note: Python 3.12 removal of `distutils` breaks GLib's build.
+          python-version: '3.11'
+
+      - name: Install homebrew dependencies
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
         uses: ./.github/actions/brew_cache
         with:
+          cache_epoch: '${{ env.CACHE_EPOCH }}'
           # Compared to the README, removes sh5sum to prevent some conflict with coreutils, and gnu-getopt because we're not using kodev.
           packages: >
             autoconf
@@ -61,50 +110,42 @@ jobs:
             wget
 
       - name: Update PATH
-        run: |
-          printf '%s\n' \
-            "$(brew --prefix)/opt/bison/bin" \
-            "$(brew --prefix)/opt/gettext/bin" \
-            "$(brew --prefix)/opt/gnu-getopt/bin" \
-            "$(brew --prefix)/opt/grep/libexec/gnubin" \
-            "$(brew --prefix)/opt/make/libexec/gnubin" \
-            >>"${GITHUB_PATH}"
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
+        run: >
+          printf '%s\n'
+          "$(brew --prefix)/opt/bison/bin"
+          "$(brew --prefix)/opt/gettext/bin"
+          "$(brew --prefix)/opt/gnu-getopt/bin"
+          "$(brew --prefix)/opt/grep/libexec/gnubin"
+          "$(brew --prefix)/opt/make/libexec/gnubin"
+          | tee "${GITHUB_PATH}"
 
-      - name: Build cache restore
-        id: build-cache-restore
-        uses: actions/cache/restore@v4
-        with:
-          path: /Users/runner/Library/Caches/ccache
-          key: ${{ runner.os }}-build-cache-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-build-cache-${{ github.sha }}-
-            ${{ runner.os }}-build-cache-
+      # }}}
 
-      - name: Build cache post-restore
-        run: |
-          set -x
-          which ccache
-          ccache --version
-          ccache --zero-stats
-          ccache --max-size=256M
-          ccache --show-config
+      # Build. {{{
 
-      - name: Building in progress…
-        id: build
-        run: |
-          export MACOSX_DEPLOYMENT_TARGET=11;
-          make fetchthirdparty && make
+      - name: Build
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
+        run: make
 
-      - name: Build cache pre-save
-        if: always()
+      # }}}
+
+      # Clean / save caches. {{{
+
+      - name: Clean build cache
+        if: steps.ccache-restore.outputs.cache-hit != 'true' && always()
         run: |
           set -x
           ccache --cleanup >/dev/null
           ccache --show-stats --verbose
 
-      - name: Build cache save
+      - name: Save build cache
         uses: actions/cache/save@v4
-        if: always() && steps.build-cache-restore.outputs.cache-hit != 'true'
+        if: steps.ccache-restore.outputs.cache-hit != 'true'
         with:
           path: /Users/runner/Library/Caches/ccache
-          key: ${{ steps.build-cache-restore.outputs.cache-primary-key }}${{ steps.build.outcome != 'success' && format('-{0}', github.run_attempt) || '' }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
+      # }}}
+
+# vim: foldmethod=marker foldlevel=0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ concurrency:
 
 on: [push, pull_request]
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: macos-11

--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,25 @@ endif
 
 # }}}
 
+# CI helpers. {{{
+
+define cache_key_ignores
+':!*.lua'
+':!*/.*'
+':!/.*'
+':!/COPYING'
+':!/README.md'
+':!/ffi-cdecl/*'
+':!/spec/*'
+':!/toolchain/*'
+':!/utils/*'
+endef
+
+cache-key: Makefile
+	git ls-files -z $(strip $(cache_key_ignores)) | xargs -0 git ls-tree @ | tee $@
+
+# }}}
+
 .PHONY: all clean distclean dist-clean test
 
 # vim: foldmethod=marker foldlevel=0


### PR DESCRIPTION
Mostly fix CircleCI's caching, again.

Unlike Github Actions, a PR target repository does not matter (unless environment sharing is enabled), which mean that PR from a fork don't have access to the master's branch cache. So keying by branch will result in most PRs starting with a cache miss.

Switch to 2 caches (build directory and ccache), keyed on part of the source tree (ignoring LUA files, tests, cdecl, etc…).

Note: I tweaked the CircleCI resource classes because for some reason my builds were using the large ones by default (on my fork, instead of medium).

Example CI runs:
- miss on both caches: [CircleCI](https://app.circleci.com/pipelines/github/benoit-pierre/koreader-base/126/workflows/da066080-a863-4b24-9606-40bacc9ae834) / [macOS](https://github.com/benoit-pierre/koreader-base/actions/runs/9047736656/job/24860052633)
- partial hit on ccache: [CircleCI](https://app.circleci.com/pipelines/github/benoit-pierre/koreader-base/127/workflows/8dc81006-078f-417b-a905-f5b2a0b64bb2) / [macOS](https://github.com/benoit-pierre/koreader-base/actions/runs/9051445156/job/24867972170)
- primary hit: [CircleCI](https://app.circleci.com/pipelines/github/benoit-pierre/koreader-base/129/workflows/cc596e8c-cdc6-41ec-910c-87be0c2e53fe) / [macOS](https://github.com/benoit-pierre/koreader-base/actions/runs/9048169299/job/24861828698)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1783)
<!-- Reviewable:end -->
