### PR TITLE
mupdf: pre update cleanups

### DIFF
--- a/ffi-cdecl/mupdf_decl.c
+++ b/ffi-cdecl/mupdf_decl.c
@@ -1,5 +1,6 @@
 // We need to make generate first...
 // CPPFLAGS="-I../koreader-base -I/var/tmp/niluje/mupdf/include"
+
 #include "wrap-mupdf.h"
 
 #include "ffi-cdecl.h"
@@ -9,55 +10,29 @@ cdecl_const(FZ_STEXT_BLOCK_TEXT)
 /* math */
 cdecl_type(fz_point)
 cdecl_struct(fz_point_s)
-
 cdecl_type(fz_rect)
 cdecl_struct(fz_rect_s)
-cdecl_var(fz_unit_rect)
-cdecl_var(fz_empty_rect)
-cdecl_var(fz_infinite_rect)
-cdecl_func(fz_intersect_rect)
-cdecl_func(fz_union_rect)
-
 cdecl_type(fz_irect)
 cdecl_struct(fz_irect_s)
-cdecl_var(fz_empty_irect)
-cdecl_var(fz_infinite_irect)
-cdecl_func(fz_intersect_irect)
-
-cdecl_func(fz_irect_from_rect)
-cdecl_func(fz_round_rect)
-
 cdecl_type(fz_matrix)
 cdecl_struct(fz_matrix_s)
 cdecl_var(fz_identity)
-cdecl_func(fz_concat)
-cdecl_func(fz_scale)
-cdecl_func(fz_pre_scale)
-cdecl_func(fz_rotate)
-cdecl_func(fz_pre_rotate)
-cdecl_func(fz_translate)
-cdecl_func(fz_pre_translate)
-
-cdecl_func(fz_transform_rect)
+cdecl_var(fz_empty_rect)
 
 /* misc/assorted */
 cdecl_type(fz_context)
 cdecl_type(fz_font)
-cdecl_type(fz_hash_table)
-cdecl_type(fz_storable)
-cdecl_type(fz_key_storable)
-cdecl_type(fz_store_drop_fn)
-cdecl_struct(fz_storable_s)
-cdecl_struct(fz_key_storable_s)
 cdecl_func(fz_install_external_font_funcs)
 
 /* buffer */
+cdecl_type(fz_buffer)
 cdecl_func(mupdf_new_buffer_from_shared_data)
 cdecl_func(mupdf_drop_buffer)
 
 /* context */
 cdecl_type(fz_alloc_context)
 cdecl_type(fz_colorspace)
+cdecl_type(fz_locks_context)
 cdecl_func(fz_new_context_imp)
 cdecl_func(fz_drop_context)
 cdecl_func(fz_register_document_handlers)
@@ -65,27 +40,19 @@ cdecl_func(fz_register_document_handlers)
 /* images */
 cdecl_type(fz_image)
 cdecl_type(fz_pixmap)
-cdecl_struct(fz_image_s)
-cdecl_struct(fz_pixmap_s)
 cdecl_func(mupdf_new_image_from_buffer)
 cdecl_func(mupdf_get_pixmap_from_image)
-cdecl_func(mupdf_save_pixmap_as_png)
-cdecl_func(fz_keep_image)
 cdecl_func(fz_drop_image)
 
-cdecl_func(fz_load_png)
 cdecl_func(fz_runetochar)
 
 /* document */
-cdecl_type(fz_annot)
-cdecl_struct(fz_annot_s)
+cdecl_type(fz_stream)
 cdecl_type(fz_outline)
 cdecl_struct(fz_outline_s)
-cdecl_type(fz_document)
 cdecl_type(fz_page)
-cdecl_type(fz_link)
-cdecl_struct(fz_document_s) // NOTE: And now it's intptr_t that's being converted... >_<"
-cdecl_struct(fz_page_s)
+cdecl_type(fz_document)
+cdecl_type(fz_device)
 
 cdecl_func(mupdf_open_document)
 cdecl_func(mupdf_open_document_with_stream)
@@ -96,7 +63,6 @@ cdecl_func(fz_drop_document)
 cdecl_func(mupdf_count_pages)
 cdecl_func(mupdf_layout_document)
 cdecl_func(fz_lookup_metadata)
-cdecl_func(fz_resolve_link)
 
 /* page */
 cdecl_func(mupdf_load_page)
@@ -104,8 +70,10 @@ cdecl_func(fz_bound_page)
 cdecl_func(fz_drop_page)
 
 /* links */
+cdecl_type(fz_link)
 cdecl_struct(fz_link_s)
 cdecl_func(mupdf_load_links)
+cdecl_func(fz_resolve_link)
 cdecl_func(fz_drop_link)
 
 /* outline */
@@ -132,14 +100,14 @@ cdecl_struct(fz_stext_page_s)
 cdecl_func(mupdf_new_stext_page_from_page)
 cdecl_func(fz_drop_stext_page)
 
+cdecl_func(fz_default_color_params)
+
 /* pixmaps */
-cdecl_func(mupdf_new_pixmap)
 cdecl_func(fz_new_pixmap) // compat
 cdecl_func(mupdf_new_pixmap_with_bbox)
 cdecl_func(mupdf_new_pixmap_with_data)
 cdecl_func(mupdf_new_pixmap_with_bbox_and_data)
 cdecl_func(fz_convert_pixmap)
-cdecl_func(fz_keep_pixmap)
 cdecl_func(fz_drop_pixmap)
 cdecl_func(fz_clear_pixmap_with_value)
 cdecl_func(fz_gamma_pixmap)
@@ -153,12 +121,8 @@ cdecl_func(fz_device_gray)
 cdecl_func(fz_device_rgb)
 cdecl_func(fz_device_bgr)
 
-cdecl_struct(fz_color_params_s)
-cdecl_func(fz_default_color_params)
-
 /* device, rendering */
 cdecl_func(mupdf_new_draw_device)
-cdecl_func(mupdf_new_text_device)
 cdecl_func(mupdf_new_bbox_device)
 cdecl_func(mupdf_run_page)
 cdecl_func(fz_close_device)
@@ -166,29 +130,21 @@ cdecl_func(fz_drop_device)
 
 /* pdf specifics */
 cdecl_enum(pdf_annot_type)
-cdecl_type(pdf_hotspot)
-cdecl_struct(pdf_hotspot_s)
-cdecl_type(pdf_lexbuf)
-cdecl_struct(pdf_lexbuf_s)
-cdecl_type(pdf_lexbuf_large)
-cdecl_struct(pdf_lexbuf_large_s)
-cdecl_type(pdf_obj)
 cdecl_type(pdf_annot)
 cdecl_type(pdf_page)
-cdecl_struct(pdf_annot_s)
 cdecl_type(pdf_document)
-cdecl_struct(pdf_document_s)
+
+/* annotations */
 cdecl_func(pdf_specifics)
 cdecl_func(mupdf_pdf_create_annot)
 cdecl_func(mupdf_pdf_delete_annot)
 cdecl_func(mupdf_pdf_set_annot_quad_points)
 cdecl_func(mupdf_pdf_set_annot_contents)
+cdecl_func(mupdf_pdf_set_markup_appearance)
 cdecl_func(mupdf_pdf_first_annot)
 cdecl_func(mupdf_pdf_next_annot)
 cdecl_func(mupdf_pdf_annot_quad_point_count)
 cdecl_func(mupdf_pdf_annot_quad_point)
-cdecl_func(mupdf_pdf_set_text_annot_position)
-cdecl_func(mupdf_pdf_set_markup_appearance)
 
 /* saving documents */
 cdecl_type(pdf_write_options)
@@ -200,3 +156,12 @@ cdecl_func(mupdf_get_my_alloc_context)
 cdecl_func(mupdf_get_cache_size)
 cdecl_func(mupdf_error_code)
 cdecl_func(mupdf_error_message)
+
+/* geometry */
+cdecl_func(fz_scale)
+cdecl_func(fz_translate)
+cdecl_func(fz_pre_rotate)
+cdecl_func(fz_pre_translate)
+cdecl_func(fz_transform_rect)
+cdecl_func(fz_round_rect)
+cdecl_func(fz_union_rect)

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -14,11 +14,6 @@ struct fz_rect_s {
   float x1;
   float y1;
 };
-extern const fz_rect fz_unit_rect;
-extern const fz_rect fz_empty_rect;
-extern const fz_rect fz_infinite_rect;
-fz_rect *fz_intersect_rect(fz_rect *restrict, const fz_rect *restrict);
-fz_rect *fz_union_rect(fz_rect *restrict, const fz_rect *restrict);
 typedef struct fz_irect_s fz_irect;
 struct fz_irect_s {
   int x0;
@@ -26,11 +21,6 @@ struct fz_irect_s {
   int x1;
   int y1;
 };
-extern const fz_irect fz_empty_irect;
-extern const fz_irect fz_infinite_irect;
-fz_irect *fz_intersect_irect(fz_irect *restrict, const fz_irect *restrict);
-fz_irect *fz_irect_from_rect(fz_irect *restrict, const fz_rect *restrict);
-fz_irect *fz_round_rect(fz_irect *restrict, const fz_rect *restrict);
 typedef struct fz_matrix_s fz_matrix;
 struct fz_matrix_s {
   float a;
@@ -41,94 +31,26 @@ struct fz_matrix_s {
   float f;
 };
 extern const fz_matrix fz_identity;
-fz_matrix *fz_concat(fz_matrix *, const fz_matrix *, const fz_matrix *);
-fz_matrix *fz_scale(fz_matrix *, float, float);
-fz_matrix *fz_pre_scale(fz_matrix *, float, float);
-fz_matrix *fz_rotate(fz_matrix *, float);
-fz_matrix *fz_pre_rotate(fz_matrix *, float);
-fz_matrix *fz_translate(fz_matrix *, float, float);
-fz_matrix *fz_pre_translate(fz_matrix *, float, float);
-fz_rect *fz_transform_rect(fz_rect *restrict, const fz_matrix *restrict);
+extern const fz_rect fz_empty_rect;
 typedef struct fz_context_s fz_context;
 typedef struct fz_font_s fz_font;
-typedef struct fz_hash_table_s fz_hash_table;
-typedef struct fz_storable_s fz_storable;
-typedef struct fz_key_storable_s fz_key_storable;
-typedef void fz_store_drop_fn(fz_context *, fz_storable *);
-struct fz_storable_s {
-  int refs;
-  fz_store_drop_fn *drop;
-};
-struct fz_key_storable_s {
-  fz_storable storable;
-  short int store_key_refs;
-};
 void fz_install_external_font_funcs(fz_context *);
-struct fz_buffer_s *mupdf_new_buffer_from_shared_data(fz_context *, const unsigned char *, size_t);
-void *mupdf_drop_buffer(fz_context *, struct fz_buffer_s *);
+typedef struct fz_buffer_s fz_buffer;
+fz_buffer *mupdf_new_buffer_from_shared_data(fz_context *, const unsigned char *, size_t);
+void *mupdf_drop_buffer(fz_context *, fz_buffer *);
 typedef struct fz_alloc_context_s fz_alloc_context;
 typedef struct fz_colorspace_s fz_colorspace;
-fz_context *fz_new_context_imp(const fz_alloc_context *, const struct fz_locks_context_s *, size_t, const char *);
+typedef struct fz_locks_context_s fz_locks_context;
+fz_context *fz_new_context_imp(const fz_alloc_context *, const fz_locks_context *, size_t, const char *);
 void fz_drop_context(fz_context *);
 void fz_register_document_handlers(fz_context *);
 typedef struct fz_image_s fz_image;
 typedef struct fz_pixmap_s fz_pixmap;
-struct fz_image_s {
-  fz_key_storable key_storable;
-  int w;
-  int h;
-  uint8_t n;
-  uint8_t bpc;
-  unsigned int imagemask : 1;
-  unsigned int interpolate : 1;
-  unsigned int use_colorkey : 1;
-  unsigned int use_decode : 1;
-  unsigned int invert_cmyk_jpeg : 1;
-  unsigned int decoded : 1;
-  unsigned int scalable : 1;
-  fz_image *mask;
-  int xres;
-  int yres;
-  fz_colorspace *colorspace;
-  void (*drop_image)(fz_context *, fz_image *);
-  fz_pixmap *(*get_pixmap)(fz_context *, fz_image *, fz_irect *, int, int, int *);
-  size_t (*get_size)(fz_context *, fz_image *);
-  int colorkey[64];
-  float decode[64];
-};
-struct fz_pixmap_s {
-  fz_storable storable;
-  int x;
-  int y;
-  int w;
-  int h;
-  unsigned char n;
-  unsigned char s;
-  unsigned char alpha;
-  unsigned char flags;
-  ptrdiff_t stride;
-  struct fz_separations_s *seps;
-  int xres;
-  int yres;
-  fz_colorspace *colorspace;
-  unsigned char *samples;
-  fz_pixmap *underlying;
-};
-fz_image *mupdf_new_image_from_buffer(fz_context *, struct fz_buffer_s *);
+fz_image *mupdf_new_image_from_buffer(fz_context *, fz_buffer *);
 fz_pixmap *mupdf_get_pixmap_from_image(fz_context *, fz_image *, const fz_irect *, fz_matrix *, int *, int *);
-void *mupdf_save_pixmap_as_png(fz_context *, fz_pixmap *, const char *);
-fz_image *fz_keep_image(fz_context *, fz_image *);
 void fz_drop_image(fz_context *, fz_image *);
-fz_pixmap *fz_load_png(fz_context *, const unsigned char *, size_t);
 int fz_runetochar(char *, int);
-typedef struct fz_annot_s fz_annot;
-struct fz_annot_s {
-  int refs;
-  void (*drop_annot)(fz_context *, fz_annot *);
-  fz_rect *(*bound_annot)(fz_context *, fz_annot *, fz_rect *);
-  void (*run_annot)(fz_context *, fz_annot *, struct fz_device_s *, const fz_matrix *, struct fz_cookie_s *);
-  fz_annot *(*next_annot)(fz_context *, fz_annot *);
-};
+typedef struct fz_stream_s fz_stream;
 typedef struct fz_outline_s fz_outline;
 struct fz_outline_s {
   int refs;
@@ -141,47 +63,11 @@ struct fz_outline_s {
   fz_outline *down;
   int is_open;
 };
-typedef struct fz_document_s fz_document;
 typedef struct fz_page_s fz_page;
-typedef struct fz_link_s fz_link;
-struct fz_document_s {
-  int refs;
-  void (*drop_document)(fz_context *, fz_document *);
-  int (*needs_password)(fz_context *, fz_document *);
-  int (*authenticate_password)(fz_context *, fz_document *, const char *);
-  int (*has_permission)(fz_context *, fz_document *, enum {
-    FZ_PERMISSION_PRINT = 112,
-    FZ_PERMISSION_COPY = 99,
-    FZ_PERMISSION_EDIT = 101,
-    FZ_PERMISSION_ANNOTATE = 110,
-  });
-  fz_outline *(*load_outline)(fz_context *, fz_document *);
-  void (*layout)(fz_context *, fz_document *, float, float, float);
-  intptr_t (*make_bookmark)(fz_context *, fz_document *, int);
-  int (*lookup_bookmark)(fz_context *, fz_document *, intptr_t);
-  int (*resolve_link)(fz_context *, fz_document *, const char *, float *, float *);
-  int (*count_pages)(fz_context *, fz_document *);
-  fz_page *(*load_page)(fz_context *, fz_document *, int);
-  int (*lookup_metadata)(fz_context *, fz_document *, const char *, char *, int);
-  fz_colorspace *(*get_output_intent)(fz_context *, fz_document *);
-  int did_layout;
-  int is_reflowable;
-};
-struct fz_page_s {
-  int refs;
-  void (*drop_page)(fz_context *, fz_page *);
-  fz_rect *(*bound_page)(fz_context *, fz_page *, fz_rect *);
-  void (*run_page_contents)(fz_context *, fz_page *, struct fz_device_s *, const fz_matrix *, struct fz_cookie_s *);
-  fz_link *(*load_links)(fz_context *, fz_page *);
-  fz_annot *(*first_annot)(fz_context *, fz_page *);
-  struct fz_transition_s *(*page_presentation)(fz_context *, fz_page *, struct fz_transition_s *, float *);
-  void (*control_separation)(fz_context *, fz_page *, int, int);
-  int (*separation_disabled)(fz_context *, fz_page *, int);
-  struct fz_separations_s *(*separations)(fz_context *, fz_page *);
-  int (*overprint)(fz_context *, fz_page *);
-};
+typedef struct fz_document_s fz_document;
+typedef struct fz_device_s fz_device;
 fz_document *mupdf_open_document(fz_context *, const char *);
-fz_document *mupdf_open_document_with_stream(fz_context *, const char *, struct fz_stream_s *);
+fz_document *mupdf_open_document_with_stream(fz_context *, const char *, fz_stream *);
 int fz_is_document_reflowable(fz_context *, fz_document *);
 int fz_needs_password(fz_context *, fz_document *);
 int fz_authenticate_password(fz_context *, fz_document *, const char *);
@@ -189,10 +75,10 @@ void fz_drop_document(fz_context *, fz_document *);
 int mupdf_count_pages(fz_context *, fz_document *);
 void *mupdf_layout_document(fz_context *, fz_document *, float, float, float);
 int fz_lookup_metadata(fz_context *, fz_document *, const char *, char *, int);
-int fz_resolve_link(fz_context *, fz_document *, const char *, float *, float *);
 fz_page *mupdf_load_page(fz_context *, fz_document *, int);
 fz_rect *fz_bound_page(fz_context *, fz_page *, fz_rect *);
 void fz_drop_page(fz_context *, fz_page *);
+typedef struct fz_link_s fz_link;
 struct fz_link_s {
   int refs;
   fz_link *next;
@@ -201,11 +87,12 @@ struct fz_link_s {
   char *uri;
 };
 fz_link *mupdf_load_links(fz_context *, fz_page *);
+int fz_resolve_link(fz_context *, fz_document *, const char *, float *, float *);
 void fz_drop_link(fz_context *, fz_link *);
 fz_outline *mupdf_load_outline(fz_context *, fz_document *);
 void fz_drop_outline(fz_context *, fz_outline *);
-void *mupdf_drop_stream(fz_context *, struct fz_stream_s *);
-struct fz_stream_s *mupdf_open_memory(fz_context *, const unsigned char *, size_t);
+void *mupdf_drop_stream(fz_context *, fz_stream *);
+fz_stream *mupdf_open_memory(fz_context *, const unsigned char *, size_t);
 typedef struct fz_stext_char_s fz_stext_char;
 struct fz_stext_char_s {
   int c;
@@ -255,13 +142,12 @@ struct fz_stext_page_s {
 };
 fz_stext_page *mupdf_new_stext_page_from_page(fz_context *, fz_page *, const fz_stext_options *);
 void fz_drop_stext_page(fz_context *, fz_stext_page *);
-fz_pixmap *mupdf_new_pixmap(fz_context *, fz_colorspace *, int, int, struct fz_separations_s *, int);
+const struct fz_color_params_s *fz_default_color_params(fz_context *);
 fz_pixmap *fz_new_pixmap(fz_context *, fz_colorspace *, int, int, struct fz_separations_s *, int);
 fz_pixmap *mupdf_new_pixmap_with_bbox(fz_context *, fz_colorspace *, const fz_irect *, struct fz_separations_s *, int);
 fz_pixmap *mupdf_new_pixmap_with_data(fz_context *, fz_colorspace *, int, int, struct fz_separations_s *, int, int, unsigned char *);
 fz_pixmap *mupdf_new_pixmap_with_bbox_and_data(fz_context *, fz_colorspace *, const fz_irect *, struct fz_separations_s *, int, unsigned char *);
 fz_pixmap *fz_convert_pixmap(fz_context *, fz_pixmap *, fz_colorspace *, fz_colorspace *, struct fz_default_colorspaces_s *, const struct fz_color_params_s *, int);
-fz_pixmap *fz_keep_pixmap(fz_context *, fz_pixmap *);
 void fz_drop_pixmap(fz_context *, fz_pixmap *);
 void fz_clear_pixmap_with_value(fz_context *, fz_pixmap *, int);
 void fz_gamma_pixmap(fz_context *, fz_pixmap *, float);
@@ -273,19 +159,11 @@ unsigned char *fz_pixmap_samples(fz_context *, fz_pixmap *);
 fz_colorspace *fz_device_gray(fz_context *);
 fz_colorspace *fz_device_rgb(fz_context *);
 fz_colorspace *fz_device_bgr(fz_context *);
-struct fz_color_params_s {
-  uint8_t ri;
-  uint8_t bp;
-  uint8_t op;
-  uint8_t opm;
-};
-const struct fz_color_params_s *fz_default_color_params(fz_context *);
-struct fz_device_s *mupdf_new_draw_device(fz_context *, const fz_matrix *, fz_pixmap *);
-struct fz_device_s *mupdf_new_text_device(fz_context *, fz_stext_page *, const fz_stext_options *);
-struct fz_device_s *mupdf_new_bbox_device(fz_context *, fz_rect *);
-void *mupdf_run_page(fz_context *, fz_page *, struct fz_device_s *, const fz_matrix *, struct fz_cookie_s *);
-void fz_close_device(fz_context *, struct fz_device_s *);
-void fz_drop_device(fz_context *, struct fz_device_s *);
+fz_device *mupdf_new_draw_device(fz_context *, const fz_matrix *, fz_pixmap *);
+fz_device *mupdf_new_bbox_device(fz_context *, fz_rect *);
+void *mupdf_run_page(fz_context *, fz_page *, fz_device *, const fz_matrix *, struct fz_cookie_s *);
+void fz_close_device(fz_context *, fz_device *);
+void fz_drop_device(fz_context *, fz_device *);
 enum pdf_annot_type {
   PDF_ANNOT_TEXT = 0,
   PDF_ANNOT_LINK = 1,
@@ -314,118 +192,19 @@ enum pdf_annot_type {
   PDF_ANNOT_3D = 24,
   PDF_ANNOT_UNKNOWN = -1,
 };
-typedef struct pdf_hotspot_s pdf_hotspot;
-struct pdf_hotspot_s {
-  int num;
-  int state;
-};
-typedef struct pdf_lexbuf_s pdf_lexbuf;
-struct pdf_lexbuf_s {
-  int size;
-  int base_size;
-  int len;
-  int64_t i;
-  float f;
-  char *scratch;
-  char buffer[256];
-};
-typedef struct pdf_lexbuf_large_s pdf_lexbuf_large;
-struct pdf_lexbuf_large_s {
-  pdf_lexbuf base;
-  char buffer[65280];
-};
-typedef struct pdf_obj_s pdf_obj;
 typedef struct pdf_annot_s pdf_annot;
 typedef struct pdf_page_s pdf_page;
-struct pdf_annot_s {
-  fz_annot super;
-  pdf_page *page;
-  pdf_obj *obj;
-  pdf_obj *ap;
-  int needs_new_ap;
-  int has_new_ap;
-  pdf_annot *next;
-};
 typedef struct pdf_document_s pdf_document;
-struct pdf_document_s {
-  fz_document super;
-  struct fz_stream_s *file;
-  int version;
-  int64_t startxref;
-  int64_t file_size;
-  struct pdf_crypt_s *crypt;
-  struct pdf_ocg_descriptor_s *ocg;
-  struct pdf_portfolio_s *portfolio;
-  pdf_hotspot hotspot;
-  fz_colorspace *oi;
-  int max_xref_len;
-  int num_xref_sections;
-  int saved_num_xref_sections;
-  int num_incremental_sections;
-  int xref_base;
-  int disallow_new_increments;
-  struct pdf_xref_s *xref_sections;
-  struct pdf_xref_s *saved_xref_sections;
-  int *xref_index;
-  int freeze_updates;
-  int has_xref_streams;
-  int rev_page_count;
-  struct pdf_rev_page_map_s *rev_page_map;
-  int repair_attempted;
-  int file_reading_linearly;
-  int64_t file_length;
-  int linear_page_count;
-  pdf_obj *linear_obj;
-  pdf_obj **linear_page_refs;
-  int linear_page1_obj_num;
-  int64_t linear_pos;
-  int linear_page_num;
-  int hint_object_offset;
-  int hint_object_length;
-  int hints_loaded;
-  struct {
-    int number;
-    int64_t offset;
-    int64_t index;
-  } *hint_page;
-  int *hint_shared_ref;
-  struct {
-    int number;
-    int64_t offset;
-  } *hint_shared;
-  int hint_obj_offsets_max;
-  int64_t *hint_obj_offsets;
-  int resources_localised;
-  pdf_lexbuf_large lexbuf;
-  pdf_annot *focus;
-  pdf_obj *focus_obj;
-  struct pdf_js_s *js;
-  int recalculating;
-  int dirty;
-  void (*event_cb)(fz_context *, pdf_document *, struct pdf_doc_event_s *, void *);
-  void *event_cb_data;
-  int num_type3_fonts;
-  int max_type3_fonts;
-  fz_font **type3_fonts;
-  struct {
-    fz_hash_table *images;
-    fz_hash_table *fonts;
-  } resources;
-  int orphans_max;
-  int orphans_count;
-  pdf_obj **orphans;
-};
 pdf_document *pdf_specifics(fz_context *, fz_document *);
 pdf_annot *mupdf_pdf_create_annot(fz_context *, pdf_page *, enum pdf_annot_type);
 void *mupdf_pdf_delete_annot(fz_context *, pdf_page *, pdf_annot *);
 void *mupdf_pdf_set_annot_quad_points(fz_context *, pdf_annot *, int, const float *);
 void *mupdf_pdf_set_annot_contents(fz_context *, pdf_annot *, const char *);
+void *mupdf_pdf_set_markup_appearance(fz_context *, pdf_document *, pdf_annot *, float *, float, float, float);
 pdf_annot *mupdf_pdf_first_annot(fz_context *, pdf_page *);
 pdf_annot *mupdf_pdf_next_annot(fz_context *, pdf_annot *);
 int mupdf_pdf_annot_quad_point_count(fz_context *, pdf_annot *);
 void *mupdf_pdf_annot_quad_point(fz_context *, pdf_annot *, int, float *);
-void *mupdf_pdf_set_text_annot_position(fz_context *, pdf_annot *, fz_point);
-void *mupdf_pdf_set_markup_appearance(fz_context *, pdf_document *, pdf_annot *, float *, float, float, float);
 typedef struct pdf_write_options_s pdf_write_options;
 struct pdf_write_options_s {
   int do_incremental;
@@ -447,4 +226,11 @@ fz_alloc_context *mupdf_get_my_alloc_context();
 int mupdf_get_cache_size();
 int mupdf_error_code(fz_context *);
 char *mupdf_error_message(fz_context *);
+fz_matrix *fz_scale(fz_matrix *, float, float);
+fz_matrix *fz_translate(fz_matrix *, float, float);
+fz_matrix *fz_pre_rotate(fz_matrix *, float);
+fz_matrix *fz_pre_translate(fz_matrix *, float, float);
+fz_rect *fz_transform_rect(fz_rect *restrict, const fz_matrix *restrict);
+fz_irect *fz_round_rect(fz_irect *restrict, const fz_rect *restrict);
+fz_rect *fz_union_rect(fz_rect *restrict, const fz_rect *restrict);
 ]]

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -110,6 +110,7 @@ string(APPEND XCFLAGS
     " -DNO_ICC"
     " -DFZ_PLOTTERS_CMYK=0"
     " -DFZ_ENABLE_JS=0"
+    " -DHAVE_WEBP=1"
 )
 if(ANDROID AND CHOST MATCHES "^armv7a-.*")
     # NOTE: to be removed when upgrading the minimal supported API level to 24.

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -110,6 +110,7 @@ string(APPEND XCFLAGS
     " -DNO_ICC"
     " -DFZ_PLOTTERS_CMYK=0"
     " -DFZ_ENABLE_JS=0"
+    " -DHAVE_LIBAES=1"
     " -DHAVE_WEBP=1"
 )
 if(ANDROID AND CHOST MATCHES "^armv7a-.*")

--- a/thirdparty/mupdf/encrypted_zip.patch
+++ b/thirdparty/mupdf/encrypted_zip.patch
@@ -2,7 +2,7 @@ diff --git a/include/mupdf/fitz/archive.h b/include/mupdf/fitz/archive.h
 index c204b34f..4854c1ac 100644
 --- a/include/mupdf/fitz/archive.h
 +++ b/include/mupdf/fitz/archive.h
-@@ -178,6 +178,9 @@ fz_archive *fz_open_zip_archive(fz_context *ctx, const char *path);
+@@ -180,6 +180,9 @@ fz_archive *fz_open_zip_archive(fz_context *ctx, const char *path);
  */
  fz_archive *fz_open_zip_archive_with_stream(fz_context *ctx, fz_stream *file);
  
@@ -50,47 +50,49 @@ diff --git a/source/fitz/unzip.c b/source/fitz/unzip.c
 index 4eb90dda..a9dee1c2 100644
 --- a/source/fitz/unzip.c
 +++ b/source/fitz/unzip.c
-@@ -20,6 +20,27 @@
+@@ -20,6 +20,26 @@
  
  #define ZIP_ENCRYPTED_FLAG 0x1
  
++#ifdef HAVE_LIBAES
 +/*
-+ * Note that the crypt.h in minizip uses unsigned long pointer to pcrc_32_tab
-+ * it will cause problem on x86_64 machine. While the crypt.h in zlib-1.2.8
-+ * contrib minizip uses z_crc_t pointer which is determined to unsigned int
-+ * pointer on 64 bit machine.
++ * Note that the original crypt.h in minizip uses unsigned long pointer to
++ * pcrc_32_tab it will cause problem on x86_64 machine. While the crypt.h
++ * in zlib-1.2.8 contrib minizip uses z_crc_t pointer which is determined
++ * to unsigned int pointer on 64 bit machine.
 + */
 +#include "contrib/minizip/crypt.h"  // from zlib-1.2.8
-+
 +#include "aes/fileenc.h"            // from minizip-g0b46a2b
-+
 +#define AES_METHOD          (99)
 +#define AES_PWVERIFYSIZE    (2)
 +#define AES_MAXSALTLENGTH   (16)
 +#define AES_AUTHCODESIZE    (10)
 +#define AES_HEADERSIZE      (11)
 +#define AES_KEYSIZE(mode)   (64 + (mode * 64))
-+
-+#define KEY_LENGTH(mode)        (8 * (mode & 3) + 8)
-+#define SALT_LENGTH(mode)       (4 * (mode & 3) + 4)
-+#define MAC_LENGTH(mode)        (10)
++#define KEY_LENGTH(mode)    (8 * (mode & 3) + 8)
++#define SALT_LENGTH(mode)   (4 * (mode & 3) + 4)
++#define MAC_LENGTH(mode)    (10)
++#endif
 +
  typedef struct zip_entry_s zip_entry;
  typedef struct fz_zip_archive_s fz_zip_archive;
  
-@@ -27,6 +48,7 @@ struct zip_entry_s
+@@ -27,6 +47,9 @@ struct zip_entry_s
  {
  	char *name;
  	int offset, csize, usize;
++#ifdef HAVE_LIBAES
 +	int crypted;
++#endif
  };
  
  struct fz_zip_archive_s
-@@ -35,6 +57,15 @@ struct fz_zip_archive_s
+@@ -35,6 +58,17 @@ struct fz_zip_archive_s
  
  	int count;
  	zip_entry *entries;
 +
++#ifdef HAVE_LIBAES
 +	int crypted;
 +	char password[128];
 +	unsigned long keys[3];     /* keys defining the pseudo-random sequence */
@@ -99,10 +101,11 @@ index 4eb90dda..a9dee1c2 100644
 +	unsigned long aes_compression_method;
 +	unsigned long aes_version;
 +	fcrypt_ctx aes_ctx;
++#endif
  };
  
  static void *zalloc_zip(void *opaque, unsigned int items, unsigned int size)
-@@ -64,6 +95,7 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -64,6 +98,7 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  	int namesize, metasize, commentsize;
  	char *name;
  	size_t n;
@@ -110,7 +113,7 @@ index 4eb90dda..a9dee1c2 100644
  
  	zip->count = 0;
  
-@@ -136,7 +168,7 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -136,7 +171,7 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  
  		(void) fz_read_int16_le(ctx, file); /* version made by */
  		(void) fz_read_int16_le(ctx, file); /* version to extract */
@@ -119,43 +122,49 @@ index 4eb90dda..a9dee1c2 100644
  		(void) fz_read_int16_le(ctx, file); /* method */
  		(void) fz_read_int16_le(ctx, file); /* last mod file time */
  		(void) fz_read_int16_le(ctx, file); /* last mod file date */
-@@ -199,6 +231,13 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -199,6 +234,15 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  		zip->entries[zip->count].csize = csize;
  		zip->entries[zip->count].usize = usize;
  
++#ifdef HAVE_LIBAES
 +		if (general & ZIP_ENCRYPTED_FLAG) {
 +			zip->crypted = 1;
 +			zip->entries[zip->count].crypted = 1;
 +		} else {
 +			zip->entries[zip->count].crypted = 0;
 +		}
++#endif
 +
  		zip->count++;
  	}
  }
-@@ -207,6 +246,10 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+@@ -207,6 +251,12 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
  {
  	fz_stream *file = zip->super.file;
  	int sig, general, method, namelength, extralength;
-+	int i, headerid, datasize, crc32, modtime, chk;
-+
++	int crc32, modtime;
++#ifdef HAVE_LIBAES
++	int i, headerid, datasize, chk;
 +	unsigned char source[12];
 +	unsigned char crcbyte;
++#endif
  
  	fz_seek(ctx, file, ent->offset, 0);
  
-@@ -215,20 +258,67 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+@@ -215,20 +265,75 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
  		fz_throw(ctx, FZ_ERROR_GENERIC, "wrong zip local file signature (0x%x)", sig);
  
  	(void) fz_read_int16_le(ctx, file); /* version */
 -	general = fz_read_int16_le(ctx, file); /* general */
--	if (general & ZIP_ENCRYPTED_FLAG)
--		fz_throw(ctx, FZ_ERROR_GENERIC, "zip content is encrypted");
++	general = fz_read_uint16_le(ctx, file); /* general */
++	method = fz_read_uint16_le(ctx, file);
++#if !defined(HAVE_LIBAES)
+ 	if (general & ZIP_ENCRYPTED_FLAG)
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "zip content is encrypted");
 -
 -	method = fz_read_int16_le(ctx, file);
 -	(void) fz_read_int16_le(ctx, file); /* file time */
-+	general = fz_read_uint16_le(ctx, file); /* general */
-+	method = fz_read_uint16_le(ctx, file);
++#endif
 +	modtime = fz_read_uint16_le(ctx, file); /* file time */
  	(void) fz_read_int16_le(ctx, file); /* file date */
 -	(void) fz_read_int32_le(ctx, file); /* crc-32 */
@@ -165,7 +174,9 @@ index 4eb90dda..a9dee1c2 100644
  	namelength = fz_read_int16_le(ctx, file);
  	extralength = fz_read_int16_le(ctx, file);
  
--	fz_seek(ctx, file, namelength + extralength, 1);
++#if !defined(HAVE_LIBAES)
+ 	fz_seek(ctx, file, namelength + extralength, 1);
++#else
 +	fz_seek(ctx, file, namelength, 1);
 +
 +	if (general & ZIP_ENCRYPTED_FLAG) {
@@ -217,77 +228,81 @@ index 4eb90dda..a9dee1c2 100644
 +	} else {
 +		fz_seek(ctx, file, extralength, 1);
 +	}
++#endif
  
  	return method;
  }
-@@ -285,6 +375,9 @@ static fz_stream *open_zip_entry(fz_context *ctx, fz_archive *arch, const char *
+@@ -285,6 +390,11 @@ static fz_stream *open_zip_entry(fz_context *ctx, fz_archive *arch, const char *
  		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry");
  
  	method = read_zip_entry_header(ctx, zip, ent);
++#ifdef HAVE_LIBAES
 +	if (method == AES_METHOD) {
 +		method = zip->aes_compression_method;
 +	}
++#endif
  	if (method == 0)
  		return fz_open_null(ctx, file, ent->usize, fz_tell(ctx, file));
  	if (method == 8)
-@@ -299,6 +392,7 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
- 	fz_buffer *ubuf;
- 	unsigned char *cbuf;
- 	int method;
-+	int i;
- 	z_stream z;
- 	int code;
- 	int len;
-@@ -309,6 +403,10 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
+@@ -309,6 +419,12 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
  		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot find named zip archive entry");
  
  	method = read_zip_entry_header(ctx, zip, ent);
++#ifdef HAVE_LIBAES
 +	if (method == AES_METHOD) {
 +		method = zip->aes_compression_method;
 +	}
++#endif
 +
  	ubuf = fz_new_buffer(ctx, ent->usize + 1); /* +1 because many callers will add a terminating zero */
  
  	if (method == 0)
-@@ -318,6 +416,15 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
+@@ -318,6 +434,18 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
  			ubuf->len = fz_read(ctx, file, ubuf->data, ent->usize);
  			if (ubuf->len < (size_t)ent->usize)
  				fz_warn(ctx, "premature end of data in stored zip archive entry");
 +
++#ifdef HAVE_LIBAES
 +			if (ent->crypted) {
 +				if (zip->aes_encryption_mode) {
 +					fcrypt_decrypt(ubuf->data, ent->usize, &zip->aes_ctx);
 +				} else {
++					int i;
 +					for(i = 0; i < ent->usize; ++i)
 +						ubuf->data[i] = zdecode(zip->keys, zip->pcrc_32_tab, ubuf->data[i]);
 +				}
 +			}
++#endif
  		}
  		fz_catch(ctx)
  		{
-@@ -333,6 +440,16 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
+@@ -333,6 +461,19 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
  		{
  			fz_read(ctx, file, cbuf, ent->csize);
  
++#ifdef HAVE_LIBAES
 +			if (ent->crypted) {
 +				if (zip->aes_encryption_mode) {
 +					fcrypt_decrypt(cbuf, ent->csize, &zip->aes_ctx);
 +				} else {
++					int i;
 +					for(i = 0; i < ent->csize; ++i) {
 +						cbuf[i] = zdecode(zip->keys, zip->pcrc_32_tab, cbuf[i]);
 +					}
 +				}
 +			}
++#endif
 +
  			z.zalloc = zalloc_zip;
  			z.zfree = zfree_zip;
  			z.opaque = ctx;
-@@ -379,6 +496,31 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
+@@ -379,6 +520,39 @@ static fz_buffer *read_zip_entry(fz_context *ctx, fz_archive *arch, const char *
  	fz_throw(ctx, FZ_ERROR_GENERIC, "unknown zip method: %d", method);
  }
  
 +int fz_archive_needs_password(fz_context *ctx, fz_archive *arch)
 +{
++#ifdef HAVE_LIBAES
 +	fz_zip_archive *zip;
 +
 +	if (strcmp(arch->format, "zip") != 0)
@@ -295,10 +310,14 @@ index 4eb90dda..a9dee1c2 100644
 +
 +	zip = (fz_zip_archive *) arch;
 +	return zip->crypted;
++#else
++	return 0;
++#endif
 +}
 +
 +int fz_archive_authenticate_password(fz_context *ctx, fz_archive *arch, const char *password)
 +{
++#ifdef HAVE_LIBAES
 +	fz_zip_archive *zip = (fz_zip_archive *) arch;
 +	int i;
 +
@@ -309,19 +328,24 @@ index 4eb90dda..a9dee1c2 100644
 +		}
 +	}
 +	return 1;
++#else
++	return 0;
++#endif
 +}
 +
  static int has_zip_entry(fz_context *ctx, fz_archive *arch, const char *name)
  {
  	fz_zip_archive *zip = (fz_zip_archive *) arch;
-@@ -426,6 +568,10 @@ fz_open_zip_archive_with_stream(fz_context *ctx, fz_stream *file)
+@@ -426,6 +600,12 @@ fz_open_zip_archive_with_stream(fz_context *ctx, fz_stream *file)
  		fz_throw(ctx, FZ_ERROR_GENERIC, "cannot recognize zip archive");
  
  	zip = fz_new_derived_archive(ctx, file, fz_zip_archive);
++#ifdef HAVE_LIBAES
 +	zip->crypted = 0;
 +	zip->aes_compression_method = 0;
 +	zip->aes_encryption_mode = 0;
 +	zip->aes_version = 0;
++#endif
  	zip->super.format = "zip";
  	zip->super.count_entries = count_zip_entries;
  	zip->super.list_entry = list_zip_entry;

--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -14,7 +14,7 @@ diff --git a/include/mupdf/fitz/font.h b/include/mupdf/fitz/font.h
 index ef4cd74d..6e6ea124 100644
 --- a/include/mupdf/fitz/font.h
 +++ b/include/mupdf/fitz/font.h
-@@ -624,4 +624,9 @@ void fz_hb_lock(fz_context *ctx);
+@@ -628,4 +628,9 @@ void fz_hb_lock(fz_context *ctx);
  */
  void fz_hb_unlock(fz_context *ctx);
  
@@ -28,7 +28,7 @@ diff --git a/source/fitz/font.c b/source/fitz/font.c
 index e197fa1b..03bfbb34 100644
 --- a/source/fitz/font.c
 +++ b/source/fitz/font.c
-@@ -420,13 +420,19 @@ fz_font *fz_load_fallback_font(fz_context *ctx, int script, int language, int se
+@@ -419,13 +419,19 @@ fz_font *fz_load_fallback_font(fz_context *ctx, int script, int language, int se
  
  fz_font *fz_load_fallback_symbol_font(fz_context *ctx)
  {
@@ -224,7 +224,7 @@ diff --git a/source/html/html-font.c b/source/html/html-font.c
 index d319a462..df823fa0 100644
 --- a/source/html/html-font.c
 +++ b/source/html/html-font.c
-@@ -1,8 +1,50 @@
+@@ -1,18 +1,63 @@
  #include "mupdf/fitz.h"
  #include "html-imp.h"
  
@@ -275,7 +275,12 @@ index d319a462..df823fa0 100644
  static fz_font *
  fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *family, int is_bold, int is_italic)
  {
-@@ -13,6 +55,7 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
+ 	int is_mono = !strcmp(family, "monospace");
+ 	int is_sans = !strcmp(family, "sans-serif");
++#ifndef NOBUILTINFONT
+ 	const char *real_family = is_mono ? "Courier" : is_sans ? "Helvetica" : "Charis SIL";
+ 	const char *backup_family = is_mono ? "Courier" : is_sans ? "Helvetica" : "Times";
++#endif
  	int idx = (is_mono ? 8 : is_sans ? 4 : 0) + is_bold * 2 + is_italic;
  	if (!set->fonts[idx])
  	{
@@ -283,7 +288,7 @@ index d319a462..df823fa0 100644
  		const unsigned char *data;
  		int size;
  
-@@ -23,6 +66,18 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
+@@ -23,6 +68,18 @@ fz_load_html_default_font(fz_context *ctx, fz_html_font_set *set, const char *fa
  			fz_throw(ctx, FZ_ERROR_GENERIC, "cannot load html font: %s", real_family);
  		set->fonts[idx] = fz_new_font_from_memory(ctx, NULL, data, size, 0, 1);
  		fz_font_flags(set->fonts[idx])->is_serif = !is_sans;
@@ -302,7 +307,7 @@ index d319a462..df823fa0 100644
  	}
  	return set->fonts[idx];
  }
-@@ -73,7 +128,7 @@ fz_load_html_font(fz_context *ctx, fz_html_font_set *set, const char *family, in
+@@ -73,7 +130,7 @@ fz_load_html_font(fz_context *ctx, fz_html_font_set *set, const char *family, in
  		return font;
  	}
  

--- a/thirdparty/mupdf/read_large_zip.patch
+++ b/thirdparty/mupdf/read_large_zip.patch
@@ -2,16 +2,16 @@ diff --git a/source/fitz/unzip.c b/source/fitz/unzip.c
 index 720b5505b..6fc80218f 100644
 --- a/source/fitz/unzip.c
 +++ b/source/fitz/unzip.c
-@@ -47,7 +47,7 @@ typedef struct fz_zip_archive_s fz_zip_archive;
+@@ -46,7 +46,7 @@ typedef struct fz_zip_archive_s fz_zip_archive;
  struct zip_entry_s
  {
  	char *name;
 -	int offset, csize, usize;
 +	uint64_t offset, csize, usize;
+ #ifdef HAVE_LIBAES
  	int crypted;
- };
- 
-@@ -55,7 +55,7 @@ struct fz_zip_archive_s
+ #endif
+@@ -56,7 +56,7 @@ struct fz_zip_archive_s
  {
  	fz_archive super;
  
@@ -19,8 +19,8 @@ index 720b5505b..6fc80218f 100644
 +	uint64_t count;
  	zip_entry *entries;
  
- 	int crypted;
-@@ -87,12 +87,14 @@ static void drop_zip_archive(fz_context *ctx, fz_archive *arch)
+ #ifdef HAVE_LIBAES
+@@ -90,12 +90,14 @@ static void drop_zip_archive(fz_context *ctx, fz_archive *arch)
  	fz_free(ctx, zip->entries);
  }
  
@@ -38,7 +38,7 @@ index 720b5505b..6fc80218f 100644
  	char *name;
  	size_t n;
  	int general;
-@@ -101,16 +103,16 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -104,16 +106,16 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  
  	fz_seek(ctx, file, start_offset, 0);
  
@@ -62,7 +62,7 @@ index 720b5505b..6fc80218f 100644
  
  	/* ZIP64 */
  	if (count == 0xFFFF || offset == 0xFFFFFFFF)
-@@ -119,30 +121,28 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -122,30 +124,28 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  
  		fz_seek(ctx, file, start_offset - 20, 0);
  
@@ -106,7 +106,7 @@ index 720b5505b..6fc80218f 100644
  
  		if (count == 0xFFFF)
  		{
-@@ -152,8 +152,6 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -155,8 +155,6 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  		}
  		if (offset == 0xFFFFFFFF)
  		{
@@ -115,7 +115,7 @@ index 720b5505b..6fc80218f 100644
  			offset = offset64;
  		}
  	}
-@@ -162,26 +160,26 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -165,26 +163,26 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  
  	for (i = 0; i < count; i++)
  	{
@@ -159,7 +159,7 @@ index 720b5505b..6fc80218f 100644
  
  		if (namesize < 0 || metasize < 0 || commentsize < 0)
  			fz_throw(ctx, FZ_ERROR_GENERIC, "invalid size in zip entry");
-@@ -194,24 +192,25 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -197,24 +195,25 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  
  		while (metasize > 0)
  		{
@@ -193,17 +193,17 @@ index 720b5505b..6fc80218f 100644
  					sizeleft -= 8;
  				}
  				fz_seek(ctx, file, sizeleft - size, 1);
-@@ -245,7 +244,8 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
+@@ -250,7 +249,8 @@ static void read_zip_dir_imp(fz_context *ctx, fz_zip_archive *zip, int start_off
  static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry *ent)
  {
  	fz_stream *file = zip->super.file;
 -	int sig, general, method, namelength, extralength;
 +	uint32_t sig;
 +	int general, method, namelength, extralength;
- 	int i, headerid, datasize, crc32, modtime, chk;
- 
- 	unsigned char source[12];
-@@ -253,20 +253,20 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+ 	int crc32, modtime;
+ #ifdef HAVE_LIBAES
+ 	int i, headerid, datasize, chk;
+@@ -260,11 +260,11 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
  
  	fz_seek(ctx, file, ent->offset, 0);
  
@@ -216,6 +216,10 @@ index 720b5505b..6fc80218f 100644
 +	(void) fz_read_uint16_le(ctx, file); /* version */
  	general = fz_read_uint16_le(ctx, file); /* general */
  	method = fz_read_uint16_le(ctx, file);
+ #if !defined(HAVE_LIBAES)
+@@ -272,12 +272,12 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "zip content is encrypted");
+ #endif
  	modtime = fz_read_uint16_le(ctx, file); /* file time */
 -	(void) fz_read_int16_le(ctx, file); /* file date */
 +	(void) fz_read_uint16_le(ctx, file); /* file date */
@@ -229,9 +233,9 @@ index 720b5505b..6fc80218f 100644
 +	namelength = fz_read_uint16_le(ctx, file);
 +	extralength = fz_read_uint16_le(ctx, file);
  
- 	fz_seek(ctx, file, namelength, 1);
- 
-@@ -276,10 +276,10 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+ #if !defined(HAVE_LIBAES)
+ 	fz_seek(ctx, file, namelength + extralength, 1);
+@@ -290,10 +290,10 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
  				headerid = fz_read_uint16_le(ctx, file);
  				datasize = fz_read_uint16_le(ctx, file);
  				if (headerid == 0x9901) {
@@ -245,7 +249,7 @@ index 720b5505b..6fc80218f 100644
  				}
  				extralength -= 2 + 2 + datasize;
  			}
-@@ -345,7 +345,7 @@ static void ensure_zip_entries(fz_context *ctx, fz_zip_archive *zip)
+@@ -360,7 +360,7 @@ static void ensure_zip_entries(fz_context *ctx, fz_zip_archive *zip)
  		for (i = n - 4; i > 0; i--)
  			if (!memcmp(buf + i, "PK\5\6", 4))
  			{

--- a/thirdparty/mupdf/webp-upstream-697749.patch
+++ b/thirdparty/mupdf/webp-upstream-697749.patch
@@ -2,6 +2,15 @@ diff --git a/include/mupdf/fitz/compressed-buffer.h b/include/mupdf/fitz/compres
 index 995f56069..b1f79fe06 100644
 --- a/include/mupdf/fitz/compressed-buffer.h
 +++ b/include/mupdf/fitz/compressed-buffer.h
+@@ -15,7 +15,7 @@ fz_stream *fz_open_compressed_buffer(fz_context *ctx, fz_compressed_buffer *);
+ fz_stream *fz_open_image_decomp_stream_from_buffer(fz_context *ctx, fz_compressed_buffer *, int *l2factor);
+ fz_stream *fz_open_image_decomp_stream(fz_context *ctx, fz_stream *, fz_compression_params *, int *l2factor);
+ 
+-int fz_recognize_image_format(fz_context *ctx, unsigned char p[8]);
++int fz_recognize_image_format(fz_context *ctx, unsigned char p[12]);
+ 
+ enum
+ {
 @@ -39,6 +39,7 @@ enum
  	FZ_IMAGE_PNG,
  	FZ_IMAGE_PNM,
@@ -46,7 +55,7 @@ diff --git a/source/fitz/image.c b/source/fitz/image.c
 index 516997727..4f3a2ff67 100644
 --- a/source/fitz/image.c
 +++ b/source/fitz/image.c
-@@ -494,6 +494,9 @@ compressed_image_get_pixmap(fz_context *ctx, fz_image *image_, fz_irect *subarea
+@@ -493,6 +493,9 @@ compressed_image_get_pixmap(fz_context *ctx, fz_image *image_, fz_irect *subarea
  	case FZ_IMAGE_BMP:
  		tile = fz_load_bmp(ctx, image->buffer->buffer->data, image->buffer->buffer->len);
  		break;
@@ -56,7 +65,16 @@ index 516997727..4f3a2ff67 100644
  	case FZ_IMAGE_TIFF:
  		tile = fz_load_tiff(ctx, image->buffer->buffer->data, image->buffer->buffer->len);
  		break;
-@@ -982,6 +985,9 @@ fz_recognize_image_format(fz_context *ctx, unsigned char p[8])
+@@ -957,7 +960,7 @@ void fz_set_pixmap_image_tile(fz_context *ctx, fz_pixmap_image *image, fz_pixmap
+ }
+ 
+ int
+-fz_recognize_image_format(fz_context *ctx, unsigned char p[8])
++fz_recognize_image_format(fz_context *ctx, unsigned char p[12])
+ {
+ 	if (p[0] == 'P' && p[1] >= '1' && p[1] <= '7')
+ 		return FZ_IMAGE_PNM;
+@@ -981,6 +984,9 @@ fz_recognize_image_format(fz_context *ctx, unsigned char p[8])
  		return FZ_IMAGE_GIF;
  	if (p[0] == 'B' && p[1] == 'M')
  		return FZ_IMAGE_BMP;
@@ -66,7 +84,16 @@ index 516997727..4f3a2ff67 100644
  	return FZ_IMAGE_UNKNOWN;
  }
  
-@@ -1026,6 +1032,9 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
+@@ -995,7 +1001,7 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
+ 	fz_image *image = NULL;
+ 	int type;
+ 
+-	if (len < 8)
++	if (len < 12)
+ 		fz_throw(ctx, FZ_ERROR_GENERIC, "unknown image file format");
+ 
+ 	type = fz_recognize_image_format(ctx, buf);
+@@ -1025,6 +1031,9 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
  	case FZ_IMAGE_BMP:
  		fz_load_bmp_info(ctx, buf, len, &w, &h, &xres, &yres, &cspace);
  		break;
@@ -81,8 +108,10 @@ new file mode 100644
 index 000000000..ad625d0f7
 --- /dev/null
 +++ b/source/fitz/load-webp.c
-@@ -0,0 +1,260 @@
+@@ -0,0 +1,278 @@
 +#include "mupdf/fitz.h"
++
++#ifdef HAVE_WEBP
 +
 +#include <math.h>
 +#include <string.h>
@@ -205,7 +234,7 @@ index 000000000..ad625d0f7
 +
 +static fz_colorspace *extract_icc_profile(fz_context *ctx, WebPData* chunk, fz_colorspace *colorspace)
 +{
-+#if FZ_ENABLE_ICC
++#ifndef NO_ICC
 +	fz_buffer *buf = NULL;
 +
 +	fz_var(buf);
@@ -342,3 +371,19 @@ index 000000000..ad625d0f7
 +	*xresp = info.xres;
 +	*yresp = info.xres;
 +}
++
++#else /* HAVE_WEBP */
++
++fz_pixmap *
++fz_load_webp(fz_context *ctx, const unsigned char *p, size_t total)
++{
++	fz_throw(ctx, FZ_ERROR_GENERIC, "WebP codec is not available");
++}
++
++void
++fz_load_webp_info(fz_context *ctx, const unsigned char *p, size_t total, int *wp, int *hp, int *xresp, int *yresp, fz_colorspace **cspacep)
++{
++	fz_throw(ctx, FZ_ERROR_GENERIC, "WebP codec is not available");
++}
++
++#endif /* HAVE_WEBP */

--- a/wrap-mupdf.h
+++ b/wrap-mupdf.h
@@ -88,9 +88,6 @@ MUPDF_WRAP(mupdf_load_page, fz_page*, NULL,
 MUPDF_WRAP(mupdf_new_stext_page_from_page, fz_stext_page*, NULL,
     ret = fz_new_stext_page_from_page(ctx, page, options),
     fz_page *page, const fz_stext_options *options)
-MUPDF_WRAP(mupdf_new_text_device, fz_device*, NULL,
-    ret = fz_new_stext_device(ctx, page, options),
-    fz_stext_page *page, const fz_stext_options *options)
 MUPDF_WRAP(mupdf_new_bbox_device, fz_device*, NULL,
     ret = fz_new_bbox_device(ctx, rectp),
     fz_rect *rectp)
@@ -103,9 +100,6 @@ MUPDF_WRAP(mupdf_run_page, void*, NULL,
 MUPDF_WRAP(mupdf_pdf_save_document, void*, NULL,
     { pdf_save_document(ctx, doc, filename, opts); ret = (void*) -1; },
     pdf_document *doc, const char *filename, pdf_write_options *opts)
-MUPDF_WRAP(mupdf_new_pixmap, fz_pixmap*, NULL,
-    ret = fz_new_pixmap(ctx, cs, w, h, seps, alpha),
-    fz_colorspace *cs, int w, int h, fz_separations *seps, int alpha)
 MUPDF_WRAP(mupdf_new_pixmap_with_bbox, fz_pixmap*, NULL,
     ret = fz_new_pixmap_with_bbox(ctx, cs, bbox, seps, alpha),
     fz_colorspace *cs, const fz_irect *bbox, fz_separations *seps, int alpha)
@@ -142,18 +136,12 @@ MUPDF_WRAP(mupdf_pdf_annot_quad_point_count, int, -1,
 MUPDF_WRAP(mupdf_pdf_annot_quad_point, void*, NULL,
     { pdf_annot_quad_point(ctx, annot, i, qp); ret = (void*) -1; },
      pdf_annot *annot, int i, float qp[8])
-MUPDF_WRAP(mupdf_pdf_set_text_annot_position, void*, NULL,
-    { pdf_set_text_annot_position(ctx, annot, pt); ret = (void*) -1; },
-    pdf_annot *annot, fz_point pt)
 MUPDF_WRAP(mupdf_pdf_set_markup_appearance, void*, NULL,
     { pdf_set_markup_appearance(ctx, doc, annot, color, alpha, line_thickness, line_height); ret = (void*) -1; },
     pdf_document *doc, pdf_annot *annot, float color[3], float alpha, float line_thickness, float line_height)
 MUPDF_WRAP(mupdf_get_pixmap_from_image, fz_pixmap*, NULL,
     ret = fz_get_pixmap_from_image(ctx, image, subarea, trans, w, h),
     fz_image *image, const fz_irect *subarea, fz_matrix *trans, int *w, int *h)
-MUPDF_WRAP(mupdf_save_pixmap_as_png, void*, NULL,
-    { fz_save_pixmap_as_png(ctx, pixmap, filename); ret = (void*) -1; },
-    fz_pixmap *pixmap, const char *filename)
 MUPDF_WRAP(mupdf_new_image_from_buffer, fz_image*, NULL,
     ret = fz_new_image_from_buffer(ctx, buffer),
     fz_buffer *buffer)


### PR DESCRIPTION
There's one minor fix (correct `fz_recognize_image_format`'s prototype), but mostly tweak some patches to make updating easier (e.g. reduce conflicts), and trim FFI cdecls to keep only the declarations we need.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1791)
<!-- Reviewable:end -->
