### PR TITLE
crengine: fix `libcrengine.a` symbols visibility

### DIFF
--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -67,6 +67,9 @@ add_library(crengine STATIC
 )
 # Make sure we get full `constexpr` support.
 target_compile_features(crengine PRIVATE cxx_std_17)
+# Enable `-fvisibility=hidden`.
+set_target_properties(crengine PROPERTIES CXX_VISIBILITY_PRESET hidden)
+# Enable `-fvisibility-inlines-hidden`.
 set_target_properties(crengine PROPERTIES VISIBILITY_INLINES_HIDDEN TRUE)
 target_include_directories(crengine PUBLIC ${CRE_DIR}/include)
 target_include_directories(crengine PRIVATE


### PR DESCRIPTION
We want both `-fvisibility-inlines-hidden` **and** `-fvisibility=hidden`.

This reduce `koreader-cre`'s final code size by ~174-220 KB (and potentially improve performance).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1795)
<!-- Reviewable:end -->
