### PR TITLE
make: improve compiler diagnostics output

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -258,7 +258,10 @@ ifdef DARWINHOST
 endif
 
 ifneq ($(CCACHE),)
-	export CCACHE
+  export CCACHE
+  # Rewrite relative paths in the compiler’s
+  # standard error output to absolute paths.
+  export CCACHE_ABSSTDERR = 1
 endif
 
 # NOTE: This is necessary (at least on Android), because some early API levels will not put DT_NEEDED libraries in the global namespace.


### PR DESCRIPTION
Take advantage of ccache when using it to rewrite relative paths in the compiler’s standard error output to absolute paths.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1802)
<!-- Reviewable:end -->
