### PR TITLE
MuPDF: Unbreak RGB->BGR swap

### DIFF
--- a/ffi-cdecl/mupdf_decl.c
+++ b/ffi-cdecl/mupdf_decl.c
@@ -104,7 +104,7 @@ cdecl_func(fz_drop_stext_page)
 
 cdecl_type(fz_color_params)
 cdecl_type(fz_default_colorspaces)
-cdecl_func(fz_default_color_params)
+cdecl_const(fz_default_color_params)
 
 /* pixmaps */
 cdecl_func(fz_new_pixmap) // compat

--- a/ffi-cdecl/mupdf_decl.c
+++ b/ffi-cdecl/mupdf_decl.c
@@ -111,7 +111,7 @@ cdecl_func(fz_new_pixmap) // compat
 cdecl_func(mupdf_new_pixmap_with_bbox)
 cdecl_func(mupdf_new_pixmap_with_data)
 cdecl_func(mupdf_new_pixmap_with_bbox_and_data)
-cdecl_func(fz_convert_pixmap)
+cdecl_func(mupdf_convert_pixmap)
 cdecl_func(fz_drop_pixmap)
 cdecl_func(fz_clear_pixmap_with_value)
 cdecl_func(fz_gamma_pixmap)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -807,7 +807,7 @@ function mupdf.renderImage(data, size, width, height)
     -- Handle RGB->BGR conversion for Kobos when needed
     local bb
     if mupdf.bgr and ncomp >= 3 then
-        local bgr_pixmap = M.fz_convert_pixmap(context(), pixmap, M.fz_device_bgr(context()), nil, nil, M.fz_default_color_params(context()), (ncomp == 4 and 1 or 0))
+        local bgr_pixmap = M.fz_convert_pixmap(context(), pixmap, M.fz_device_bgr(context()), nil, nil, M.fz_default_color_params, (ncomp == 4 and 1 or 0))
         M.fz_drop_pixmap(context(), pixmap)
 
         local p = M.fz_pixmap_samples(context(), bgr_pixmap)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -807,7 +807,10 @@ function mupdf.renderImage(data, size, width, height)
     -- Handle RGB->BGR conversion for Kobos when needed
     local bb
     if mupdf.bgr and ncomp >= 3 then
-        local bgr_pixmap = M.fz_convert_pixmap(context(), pixmap, M.fz_device_bgr(context()), nil, nil, M.fz_default_color_params, (ncomp == 4 and 1 or 0))
+        local bgr_pixmap = W.mupdf_convert_pixmap(context(), pixmap, M.fz_device_bgr(context()), nil, nil, M.fz_default_color_params, (ncomp == 4 and 1 or 0))
+        if pixmap == nil then
+            merror("could not convert pixmap to BGR")
+        end
         M.fz_drop_pixmap(context(), pixmap)
 
         local p = M.fz_pixmap_samples(context(), bgr_pixmap)

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -195,7 +195,7 @@ fz_pixmap *fz_new_pixmap(fz_context *, fz_colorspace *, int, int, fz_separations
 fz_pixmap *mupdf_new_pixmap_with_bbox(fz_context *, fz_colorspace *, const fz_irect *, fz_separations *, int);
 fz_pixmap *mupdf_new_pixmap_with_data(fz_context *, fz_colorspace *, int, int, fz_separations *, int, int, unsigned char *);
 fz_pixmap *mupdf_new_pixmap_with_bbox_and_data(fz_context *, fz_colorspace *, const fz_irect *, fz_separations *, int, unsigned char *);
-fz_pixmap *fz_convert_pixmap(fz_context *, const fz_pixmap *, fz_colorspace *, fz_colorspace *, fz_default_colorspaces *, fz_color_params, int);
+fz_pixmap *mupdf_convert_pixmap(fz_context *, const fz_pixmap *, fz_colorspace *, fz_colorspace *, fz_default_colorspaces *, fz_color_params, int);
 void fz_drop_pixmap(fz_context *, fz_pixmap *);
 void fz_clear_pixmap_with_value(fz_context *, fz_pixmap *, int);
 void fz_gamma_pixmap(fz_context *, fz_pixmap *, float);

--- a/wrap-mupdf.h
+++ b/wrap-mupdf.h
@@ -164,6 +164,9 @@ MUPDF_WRAP(mupdf_pdf_set_annot_opacity, void*, NULL,
 MUPDF_WRAP(mupdf_get_pixmap_from_image, fz_pixmap*, NULL,
     ret = fz_get_pixmap_from_image(ctx, image, subarea, trans, w, h),
     fz_image *image, const fz_irect *subarea, fz_matrix *trans, int *w, int *h)
+MUPDF_WRAP(mupdf_convert_pixmap, fz_pixmap*, NULL,
+    ret = fz_convert_pixmap(ctx, pix, ds, prf, default_cs, color_params, keep_alpha),
+    const fz_pixmap *pix, fz_colorspace *ds, fz_colorspace *prf, fz_default_colorspaces *default_cs, fz_color_params color_params, int keep_alpha)
 MUPDF_WRAP(mupdf_new_image_from_buffer, fz_image*, NULL,
     ret = fz_new_image_from_buffer(ctx, buffer),
     fz_buffer *buffer)


### PR DESCRIPTION
`fz_default_color_params` is no longer a function, but a plain constant.

Regression since #1805

Re: https://github.com/koreader/koreader/issues/11952

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1808)
<!-- Reviewable:end -->
