### PR TITLE
ci/macos: trim build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,17 +95,8 @@ jobs:
         run: |
           packages=(
             nasm binutils coreutils libtool autoconf automake cmake make
-            sdl2 lua@5.1 luarocks gettext pkg-config wget
-            gnu-getopt grep p7zip ninja
+            sdl2 gettext pkg-config wget gnu-getopt grep p7zip ninja
           )
-          # Lua 5.1 is disabled, so we need to work around that:
-          # - fetch all packages
-          brew fetch --formula "${packages[@]}"
-          # - disable auto-updates
-          export HOMEBREW_NO_AUTO_UPDATE=1
-          # - install lua@5.1 from cache
-          brew install --formula --quiet "$(brew --cache lua@5.1)"
-          # - and install the rest
           brew install --formula --quiet "${packages[@]}"
 
       - name: Update PATH


### PR DESCRIPTION
We actually don't need luarocks anymore for building (just testing).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1809)
<!-- Reviewable:end -->
