### PR TITLE
make: tweak wget parameters

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -267,7 +267,7 @@ USE_LUAJIT_LIB = $(or $(DARWIN),$(ANDROID),$(WIN32))
 SKIP_LUAJIT_BIN = $(or $(ANDROID),$(MACOS))
 
 RCP := cp -R
-WGET ?= wget --progress=dot:giga
+WGET ?= wget
 
 define wget_and_validate
 	$(WGET) -O '$1' '$2' \


### PR DESCRIPTION
So it works on Fedora: wget2 is provided, instead of the standard version, which does not support any of the progress options yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1811)
<!-- Reviewable:end -->
