### PR TITLE
feat: Add support for kindles after fw 5.16.3

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -146,6 +146,14 @@ else ifeq ($(TARGET), kindlepw2)
 	else
 		CHOST?=arm-linux-gnueabi
 	endif
+else ifeq ($(TARGET), kindlehf)
+	KINDLE=1
+	HAS_KINDLEHF_TC:=$(shell command -v arm-kindlepw2-linux-gnueabihf-gcc 2> /dev/null)
+	ifdef HAS_KINDLEHF_TC
+		CHOST?=arm-kindlepw2-linux-gnueabihf
+	else
+		CHOST?=arm-linux-gnueabihf
+	endif
 else ifeq ($(TARGET), kindle-legacy)
 	KINDLE=1
 	CHOST?=arm-kindle-linux-gnueabi
@@ -491,6 +499,13 @@ else ifeq ($(TARGET), kindlepw2)
 	ARM_ARCH:=$(ARMV7_A9_ARCH)
 	ARM_ARCH+=-mfloat-abi=softfp
 	ifeq ($(TARGET_MACHINE), arm-linux-gnueabi)
+		COMPAT_CFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
+		COMPAT_CXXFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
+	endif
+else ifeq ($(TARGET), kindlehf)
+	ARM_ARCH:=$(ARMV7_A9_ARCH)
+	ARM_ARCH+=-mfloat-abi=hard
+	ifeq ($(TARGET_MACHINE), arm-linux-gnueabihf)
 		COMPAT_CFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
 		COMPAT_CXXFLAGS:=$(UBUNTU_COMPAT_CFLAGS)
 	endif

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -148,9 +148,9 @@ else ifeq ($(TARGET), kindlepw2)
 	endif
 else ifeq ($(TARGET), kindlehf)
 	KINDLE=1
-	HAS_KINDLEHF_TC:=$(shell command -v arm-kindlepw2-linux-gnueabihf-gcc 2> /dev/null)
+	HAS_KINDLEHF_TC:=$(shell command -v arm-kindlehf-linux-gnueabihf-gcc 2> /dev/null)
 	ifdef HAS_KINDLEHF_TC
-		CHOST?=arm-kindlepw2-linux-gnueabihf
+		CHOST?=arm-kindlehf-linux-gnueabihf
 	else
 		CHOST?=arm-linux-gnueabihf
 	endif

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Follow these steps:
 * automatically fetch thirdparty sources with Makefile:
   * make sure you have `patch`, `wget`, `unzip`, `git` and `svn` installed
   * run `make fetchthirdparty`.
+* run `make TARGET=kindlehf` For kindle models running fw >= 5.16.3 (Paperwhite 4 and later)
 
 * run `make TARGET=kindlepw2` For Kindle models >= Paperwhite 2.
 


### PR DESCRIPTION
Adds support for building koreader for kindles after the switch to hardfloats using https://github.com/notmarek/koxtoolchain. This is more of an example for people adventuring into jailbreak on newer firmwares rather than a ready for production toolchain since @NiLuJe mentioned wanting to do multiple modifications to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1814)
<!-- Reviewable:end -->
