### PR TITLE
mupdf: fix shared library permissions

### DIFF
--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -136,6 +136,7 @@ set(MAKE_CMD
 list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
+list(APPEND INSTALL_CMD COMMAND chmod 755 ${STAGING_DIR}/lib/${LIB})
 
 append_shared_lib_install_commands(INSTALL_CMD ${LIB_SPEC})
 


### PR DESCRIPTION
Ensure it's executable, so `bindeps` & `libcheck` targets don't ignore it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1818)
<!-- Reviewable:end -->
