### PR TITLE
ci: fix shellchecks helper

### DIFF
--- a/.ci/helper_shellchecks.sh
+++ b/.ci/helper_shellchecks.sh
@@ -5,6 +5,6 @@ CI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CI_DIR}/common.sh"
 
 # shellcheck disable=2016
-mapfile -t shellscript_locations < <({ git grep -lE '^#!(/usr)?/bin/(env )?(bash|sh)' && git submodule --quiet foreach '[ "$path" = "thirdparty/kpvcrlib/crengine" ] && git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | grep .ci | sed "s|^|$path/|" || git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | sed "s|^|$path/|"' && git ls-files ./*.sh; } | sort | uniq)
+mapfile -t shellscript_locations < <({ git grep -lE '^#!(/usr)?/bin/(env )?(bash|sh)' && git submodule --quiet foreach '[ "$path" = "thirdparty/kpvcrlib/crengine" ] && git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | grep .ci | sed "s|^|$path/|" || git grep -lE "^#!(/usr)?/bin/(env )?(bash|sh)" | sed "s|^|$path/|"' && git ls-files './*.sh'; } | sort | uniq)
 
 ./utils/shellcheck.sh "${shellscript_locations[@]}"


### PR DESCRIPTION
Quote argument to `git ls-files`: ensure the glob is evaluated by git, not bash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1822)
<!-- Reviewable:end -->
