### PR TITLE
make: fix `NINJAFLAGS` handling

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -88,7 +88,7 @@ ifneq (,$(or $(VERBOSE),$(V)))
   else
     MAKEFLAGS += --trace
   endif
-  NINJAFLAGS := -v
+  NINJAFLAGS += -v
 endif
 ifneq (,$(PARALLEL_JOBS))
   NINJAFLAGS += -j$(PARALLEL_JOBS)


### PR DESCRIPTION
Don't override existing flags when verbose mode is enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1830)
<!-- Reviewable:end -->
