### PR TITLE
make: fix shell

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,6 +1,6 @@
 # Note: ensure our possibly updated `PATH` variable is picked up by
 # `$(shell …)` invocations when using older (<4.4) make versions.
-SHELL = env PATH='$(PATH)' bash
+SHELL = env PATH='$(PATH)' bash -eo pipefail
 
 ifeq (,$(PARALLEL_JOBS))
   PARALLEL_JOBS := $(or $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS))))


### PR DESCRIPTION
Use `-eo pipefail` so errors in pipe commands are not ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1831)
<!-- Reviewable:end -->
