### PR TITLE
tesseract: disable debug fonts

### DIFF
--- a/thirdparty/tesseract/CMakeLists.txt
+++ b/thirdparty/tesseract/CMakeLists.txt
@@ -2,6 +2,7 @@ list(APPEND PATCH_CMD COMMAND ${KO_PATCH}
     ${CMAKE_CURRENT_SOURCE_DIR}/k2pdfopt.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake_tweaks.patch
     ${CMAKE_CURRENT_SOURCE_DIR}/fix-old-tc-build.patch
+    ${CMAKE_CURRENT_SOURCE_DIR}/no_debug_fonts.patch
 )
 
 list(APPEND CMAKE_ARGS

--- a/thirdparty/tesseract/no_debug_fonts.patch
+++ b/thirdparty/tesseract/no_debug_fonts.patch
@@ -1,0 +1,11 @@
+--- i/src/ccstruct/debugpixa.h
++++ w/src/ccstruct/debugpixa.h
+@@ -14,7 +14,7 @@
+   // TODO(rays) add another constructor with size control.
+   DebugPixa() {
+     pixa_ = pixaCreate(0);
+-#ifdef TESSERACT_DISABLE_DEBUG_FONTS
++#if 1//def TESSERACT_DISABLE_DEBUG_FONTS
+     fonts_ = NULL;
+ #else
+     fonts_ = bmfCreate(nullptr, 14);


### PR DESCRIPTION
Avoid spurious error traces:
```
Error in pixReadMemTiff: function not present
Error in pixReadMem: tiff: no pix returned
Error in pixaGenerateFontFromString: pix not made
Error in bmfCreate: font pixa not made
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1834)
<!-- Reviewable:end -->
