### PR TITLE
ffi/sdl: tweak support for `EMULATE_BW_SCREEN`

### DIFF
--- a/ffi/framebuffer_SDL2_0.lua
+++ b/ffi/framebuffer_SDL2_0.lua
@@ -18,7 +18,7 @@ function framebuffer:init()
     else
         self.bb = BB.new(600, 800)
     end
-    if os.getenv("EMULATE_BW_SCREEN") then
+    if (os.getenv("EMULATE_BW_SCREEN") or "") ~= "" then
         self.device.hasColorScreen = function() return false end
         self.isColorEnabled = function() return false end
     end


### PR DESCRIPTION
Check for a non-empty value.

Will make it easier to update kodev's run support for `--simulate`:

```diff
--- i/kodev
+++ w/kodev
@@ -582,6 +582,7 @@ TARGET:
     #       Just append --suppressions=${PWD/tools/valgrind_amd.supp to your valgrind command.
 
     # Defaults
+    screen_bw=
     screen_width=540
     screen_height=720
     export KODEBUG=1
@@ -685,6 +686,7 @@ TARGET:
                 device_model="${VALUE}"
                 case "${device_model}" in
                     kindle)
+                        screen_bw=1
                         screen_width=600
                         screen_height=800
                         screen_dpi=167
@@ -827,7 +829,7 @@ TARGET:
                 RETURN_VALUE=85
                 while [ "${RETURN_VALUE}" -eq 85 ]; do
                     # shellcheck disable=SC2086
-                    env EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
+                    env EMULATE_BW_SCREEN="${screen_bw}" EMULATE_READER_W="${screen_width}" EMULATE_READER_H="${screen_height}" EMULATE_READER_DPI="${screen_dpi}" \
                         ${KOREADER_COMMAND}
                     RETURN_VALUE=$?
                 done
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1835)
<!-- Reviewable:end -->
