### PR TITLE
kopt: color support

### DIFF
--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -228,7 +228,7 @@ function KOPTContext_mt.__index:getPageDim() return self.page_width, self.page_h
 function KOPTContext_mt.__index:getBBox(x0, y0, x1, y1) return self.bbox.x0, self.bbox.y0, self.bbox.x1, self.bbox.y1 end
 
 function KOPTContext_mt.__index:copyDestBMP(src)
-    if src.dst.bpp == 8 or src.dst.bpp == 32 then
+    if src.dst.bpp == 8 or src.dst.bpp == 24 or src.dst.bpp == 32 then
         k2pdfopt.bmp_copy(self.dst, src.dst)
     end
 end


### PR DESCRIPTION
Use with:
```diff
--- i/frontend/document/document.lua
+++ w/frontend/document/document.lua
@@ -387,14 +387,6 @@ function Document:updateColorRendering()
     end
 end
 
-function Document:preRenderPage()
-    return nil
-end
-
-function Document:postRenderPage()
-    return nil
-end
-
 function Document:getTileCacheValidity()
     return self.tile_cache_validity_ts
 end
@@ -435,7 +427,6 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
     if hinting then
         CanvasContext:enableCPUCores(2)
     end
-    self:preRenderPage()
 
     local page_size = self:getPageDimensions(pageno, zoom, rotation)
     -- this will be the size we actually render
@@ -493,7 +484,6 @@ function Document:renderPage(pageno, rect, zoom, rotation, gamma, render_mode, h
     page:close()
     DocCache:insert(hash, tile)
 
-    self:postRenderPage()
     if hinting then
         CanvasContext:enableCPUCores(1)
     end
--- i/frontend/document/pdfdocument.lua
+++ w/frontend/document/pdfdocument.lua
@@ -21,12 +21,8 @@ local PdfDocument = Document:extend{
 
 function PdfDocument:init()
     if not pdf then pdf = require("ffi/mupdf") end
-    -- mupdf.color has to stay false for kopt to work correctly
-    -- and be accurate (including its job about showing highlight
-    -- boxes). We will turn it on and off in PdfDocument:preRenderPage()
-    -- and :postRenderPage() when mupdf is called without kopt involved.
-    pdf.color = false
     self:updateColorRendering()
+    pdf.color = self.render_color
     self.koptinterface = require("document/koptinterface")
     self.koptinterface:setDefaultConfigurable(self.configurable)
     local ok
@@ -81,14 +77,6 @@ function PdfDocument:convertKoptToReflowableFontSize(font_size)
     end
 end
 
-function PdfDocument:preRenderPage()
-    pdf.color = self.render_color
-end
-
-function PdfDocument:postRenderPage()
-    pdf.color = false
-end
-
 function PdfDocument:unlock(password)
     if not self._document:authenticatePassword(password) then
         return false
--- i/frontend/ui/widget/htmlboxwidget.lua
+++ w/frontend/ui/widget/htmlboxwidget.lua
@@ -79,17 +79,12 @@ function HtmlBoxWidget:_render()
         return
     end
 
-    -- In pdfdocument.lua, color is activated only at the moment of
-    -- rendering and then immediately disabled, for safety with kopt.
-    -- We do the same here.
     Mupdf.color = Screen:isColorEnabled()
 
     local page = self.document:openPage(self.page_number)
     local dc = DrawContext.new()
     self.bb = page:draw_new(dc, self.dimen.w, self.dimen.h, 0, 0)
     page:close()
-
-    Mupdf.color = false
 end
 
 function HtmlBoxWidget:getSize()
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1836)
<!-- Reviewable:end -->
