### PR TITLE
kopt: add CI cache key exception

### DIFF
--- a/cache-key.base
+++ b/cache-key.base
@@ -16,6 +16,7 @@
 !/ffi-cdecl/**
 
 # Exceptions.
+/ffi-cdecl/koptcontext_cdecl.c
 /ffi-cdecl/mupdf_decl.c
 
 # vim: ft=gitignore


### PR DESCRIPTION
Ensure changes to `ffi-cdecl/koptcontext_cdecl.c` trigger a full build.

Forgot to do it as part of #1837.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1838)
<!-- Reviewable:end -->
