### PR TITLE
trim down koreader-djvu library

### DIFF
--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -50,7 +50,7 @@ target_compile_options(_crengine__crengine INTERFACE -include ${OUTPUT_DIR}/thir
 target_include_directories(_crengine__crengine INTERFACE ${THIRDPARTY_DIR}/kpvcrlib/crengine/crengine/include)
 
 # djvulibre
-declare_dependency(djvulibre::djvulibre SHARED djvulibre)
+declare_dependency(djvulibre::djvulibre SHARED jpeg STATIC djvulibre LIBRARIES m)
 
 # freetype
 declare_dependency(freetype2::freetype INCLUDES freetype2 SHARED freetype)

--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -16,6 +16,9 @@ string(APPEND CFLAGS " -Wno-error")
 # Fix build error when compiling with -std=gnu++17: ISO
 # C++17 does not allow 'register' storage class specifier.
 string(APPEND CXXFLAGS " -Wno-register -Wno-error=register")
+# Fix symbols visibility.
+string(APPEND CFLAGS " -fvisibility=hidden")
+string(APPEND CXXFLAGS " -fvisibility=hidden -fvisibility-inlines-hidden")
 
 list(APPEND CFG_CMD COMMAND env)
 append_autotools_vars(CFG_CMD)

--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND CFG_CMD COMMAND env)
 append_autotools_vars(CFG_CMD)
 list(APPEND CFG_CMD
     ${SOURCE_DIR}/configure --host=${CHOST} --prefix=/
-    --disable-static --enable-shared
+    --disable-shared --enable-static
     --disable-desktopfiles
     --disable-largefile
     --disable-xmltools
@@ -36,12 +36,6 @@ endif()
 list(APPEND BUILD_CMD COMMAND ${KO_MAKE_RECURSIVE} -C libdjvu)
 
 list(APPEND INSTALL_CMD COMMAND ${KO_MAKE_RECURSIVE} -C libdjvu DESTDIR=${STAGING_DIR} install)
-
-set(LIB_SPEC djvulibre VERSION 21)
-if(DARWIN)
-    append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
-endif()
-append_shared_lib_install_commands(INSTALL_CMD ${LIB_SPEC})
 
 ko_write_gitclone_script(
     GIT_CLONE_SCRIPT_FILENAME


### PR DESCRIPTION
Compile a static djvulibre library.

Impact on release builds code (bss+data+text) and file sizes:

|      | android-arm64|  emulator | kindlepw2 |
|  --- |         ---: |      ---: |      ---: |
| code |    -426.8 KB | -300.2 KB | -230.9 KB |
| file |    -429.1 KB | -331.3 KB | -234.5 KB |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1839)
<!-- Reviewable:end -->
