### PR TITLE
tesseract: fix pkg-config entry on Android

### DIFF
--- a/thirdparty/tesseract/cmake_tweaks.patch
+++ b/thirdparty/tesseract/cmake_tweaks.patch
@@ -51,7 +51,7 @@
  
  set_target_properties(
    libtesseract
-@@ -885,6 +885,6 @@
+@@ -885,10 +885,11 @@
  
  if(ANDROID)
 -  add_definitions(-DANDROID)
@@ -59,3 +59,20 @@
    find_package(CpuFeaturesNdkCompat REQUIRED)
    target_include_directories(
      libtesseract
+     PRIVATE "${CpuFeaturesNdkCompat_DIR}/../../../include/ndk_compat")
+   target_link_libraries(libtesseract PRIVATE CpuFeatures::ndk_compat)
++  set(cpu_features_LIBS "-lcpu_features -lndk_compat")
+ endif()
+ 
+ # ##############################################################################
+--- i/tesseract.pc.cmake
++++ w/tesseract.pc.cmake
+@@ -8,6 +8,6 @@
+ URL: https://github.com/tesseract-ocr/tesseract
+ Version: @tesseract_VERSION@
+ Requires.private: lept
+-Libs: -L${libdir} -l@tesseract_OUTPUT_NAME@ @libarchive_LIBS@ @libcurl_LIBS@ @TENSORFLOW_LIBS@
++Libs: -L${libdir} -l@tesseract_OUTPUT_NAME@ @cpu_features_LIBS@ @libarchive_LIBS@ @libcurl_LIBS@ @TENSORFLOW_LIBS@
+ Libs.private:
+ Cflags: -I${includedir}
+


### PR DESCRIPTION
Since we're building a static library, we need to make sure all libraries the shared library would normally link with are forwarded to the pkg-config file, including `cpu_features` & `ndk_compat` on Android.

Close koreader/koreader#12098.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1841)
<!-- Reviewable:end -->
