### PR TITLE
ci/circle: drop `emu_gcc_make` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,12 +33,6 @@ executors:
       <<: *EMU_ENV_LST
       KODEBUG: "1"
 
-  emu_gcc_make:
-    <<: *BASE_EXE
-    environment:
-      <<: *EMU_ENV_LST
-      USE_MAKE: "1"
-
   emu_clang_ninja:
     docker:
       - image: koreader/kobase-clang:0.3.4-20.04
@@ -245,16 +239,6 @@ workflows:
           requires:
             - lint
           ccache_maxsize: "512M"
-          always_test: true
-
-      - build_and_test:
-          name: emu_gcc_make
-          executor: emu_gcc_make
-          filters:
-            branches:
-              only: master
-          requires:
-            - lint
           always_test: true
 
       - build_and_test:


### PR DESCRIPTION
Support for the make generator was dropped.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1856)
<!-- Reviewable:end -->
