### PR TITLE
miscellaneous build system changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,13 @@ endif
 skeleton: $(strip $(SKELETON))
 
 $(OUTPUT_DIR)/data: | $(OUTPUT_DIR)/
-	$(SYMLINK) $(abspath $(THIRDPARTY_DIR)/kpvcrlib/crengine/cr3gui/data) $@
+	$(SYMLINK) $(THIRDPARTY_DIR)/kpvcrlib/crengine/cr3gui/data $@
 
 $(OUTPUT_DIR)/data/cr3.css: | $(OUTPUT_DIR)/data
-	$(SYMLINK) $(abspath $(THIRDPARTY_DIR)/kpvcrlib/cr3.css) $@
+	$(SYMLINK) $(THIRDPARTY_DIR)/kpvcrlib/cr3.css $@
 
 $(OUTPUT_DIR)/ffi: | $(OUTPUT_DIR)/
-	$(SYMLINK) $(abspath ffi) $@
+	$(SYMLINK) ffi $@
 
 build/%/:
 	mkdir -p $@
@@ -116,10 +116,10 @@ build/%/:
 ifneq (,$(EMULATE_READER))
 
 $(OUTPUT_DIR)/.busted: | $(OUTPUT_DIR)/
-	$(SYMLINK) $(abspath .busted) $@
+	$(SYMLINK) .busted $@
 
 $(OUTPUT_DIR)/spec/base: | $(OUTPUT_DIR)/spec/
-	$(SYMLINK) $(abspath spec) $@
+	$(SYMLINK) spec $@
 
 test: all test-data
 	cd $(OUTPUT_DIR) && $(BUSTED_LUAJIT) ./spec/base/unit
@@ -131,7 +131,7 @@ TESSDATA_FILE_URL = https://github.com/tesseract-ocr/tessdata/raw/4.1.0/$(notdir
 TESSDATA_FILE_SHA1 = 007b522901a665bc2037428602d4d527f5ead7ed
 
 $(OUTPUT_DIR)/data/tessdata/eng.traineddata: $(TESSDATA_FILE) | $(OUTPUT_DIR)/data/tessdata/
-	$(SYMLINK) $(abspath $(TESSDATA_FILE)) $@
+	$(SYMLINK) $(TESSDATA_FILE) $@
 
 $(TESSDATA_FILE):
 	mkdir -p $(dir $(TESSDATA_FILE))
@@ -142,7 +142,7 @@ DROID_FONT_URL = https://github.com/koreader/koreader-fonts/raw/master/droid/$(n
 DROID_FONT_SHA1 = 0b75601f8ef8e111babb6ed11de6573f7178ce44
 
 $(OUTPUT_DIR)/fonts/droid/DroidSansMono.ttf: $(DROID_FONT) | $(OUTPUT_DIR)/fonts/
-	$(SYMLINK) $(abspath $(dir $(DROID_FONT))) $(OUTPUT_DIR)/fonts/droid
+	$(SYMLINK) $(dir $(DROID_FONT)) $(OUTPUT_DIR)/fonts/droid
 
 $(DROID_FONT):
 	mkdir -p $(dir $(DROID_FONT))

--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,25 @@ all $(LEFTOVERS): skeleton $(BUILD_ENTRYPOINT)
 
 # Output skeleton. {{{
 
+CR3GUI_DATADIR = $(THIRDPARTY_DIR)/kpvcrlib/crengine/cr3gui/data
+
+define CR3GUI_DATADIR_EXCLUDES
+%/KoboUSBMS.tar.gz
+%/cr3.ini
+%/cr3skin-format.txt
+%/desktop
+%/devices
+%/manual
+endef
+
 define SKELETON
 $(CMAKE_DIR)/
 $(OUTPUT_DIR)/cache/
 $(OUTPUT_DIR)/clipboard/
+$(OUTPUT_DIR)/data/
 $(OUTPUT_DIR)/data/cr3.css
+$(OUTPUT_DIR)/data/dict
+$(OUTPUT_DIR)/data/tessdata
 $(OUTPUT_DIR)/ffi
 $(OUTPUT_DIR)/fonts/
 $(STAGING_DIR)/
@@ -94,14 +108,18 @@ define SKELETON +=
 $(OUTPUT_DIR)/spec/base
 endef
 endif
+SKELETON += $(addprefix $(OUTPUT_DIR)/data/,$(notdir $(filter-out $(CR3GUI_DATADIR_EXCLUDES),$(wildcard $(CR3GUI_DATADIR)/*))))
 
 skeleton: $(strip $(SKELETON))
 
-$(OUTPUT_DIR)/data: | $(OUTPUT_DIR)/
-	$(SYMLINK) $(THIRDPARTY_DIR)/kpvcrlib/crengine/cr3gui/data $@
-
-$(OUTPUT_DIR)/data/cr3.css: | $(OUTPUT_DIR)/data
+$(OUTPUT_DIR)/data/cr3.css: | $(OUTPUT_DIR)/data/
 	$(SYMLINK) $(THIRDPARTY_DIR)/kpvcrlib/cr3.css $@
+
+$(OUTPUT_DIR)/data/%: $(CR3GUI_DATADIR)/% | $(OUTPUT_DIR)/data/
+	$(SYMLINK) $(CR3GUI_DATADIR)/$* $@
+
+$(CR3GUI_DATADIR)/%:
+	mkdir $@
 
 $(OUTPUT_DIR)/ffi: | $(OUTPUT_DIR)/
 	$(SYMLINK) ffi $@
@@ -130,7 +148,7 @@ TESSDATA_FILE = thirdparty/tesseract/build/downloads/eng.traineddata
 TESSDATA_FILE_URL = https://github.com/tesseract-ocr/tessdata/raw/4.1.0/$(notdir $(TESSDATA_FILE))
 TESSDATA_FILE_SHA1 = 007b522901a665bc2037428602d4d527f5ead7ed
 
-$(OUTPUT_DIR)/data/tessdata/eng.traineddata: $(TESSDATA_FILE) | $(OUTPUT_DIR)/data/tessdata/
+$(OUTPUT_DIR)/data/tessdata/eng.traineddata: $(TESSDATA_FILE) | $(OUTPUT_DIR)/data/tessdata
 	$(SYMLINK) $(TESSDATA_FILE) $@
 
 $(TESSDATA_FILE):

--- a/Makefile
+++ b/Makefile
@@ -91,21 +91,11 @@ $(BASE_PREFIX)all $(LEFTOVERS): skeleton $(BUILD_ENTRYPOINT)
 
 CR3GUI_DATADIR = $(THIRDPARTY_DIR)/kpvcrlib/crengine/cr3gui/data
 
-define CR3GUI_DATADIR_EXCLUDES
-%/KoboUSBMS.tar.gz
-%/cr3.ini
-%/cr3skin-format.txt
-%/desktop
-%/devices
-%/manual
-endef
-
 define SKELETON
 $(CMAKE_DIR)/
 $(OUTPUT_DIR)/cache/
 $(OUTPUT_DIR)/clipboard/
 $(OUTPUT_DIR)/data/
-$(OUTPUT_DIR)/data/cr3.css
 $(OUTPUT_DIR)/data/dict
 $(OUTPUT_DIR)/data/tessdata
 $(OUTPUT_DIR)/ffi
@@ -117,7 +107,6 @@ define SKELETON +=
 $(OUTPUT_DIR)/spec/base
 endef
 endif
-SKELETON += $(addprefix $(OUTPUT_DIR)/data/,$(notdir $(filter-out $(CR3GUI_DATADIR_EXCLUDES),$(wildcard $(CR3GUI_DATADIR)/*))))
 
 skeleton: $(strip $(SKELETON))
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -277,7 +277,7 @@ define wget_and_validate
 endef
 
 # ln --symbolic --no-dereference --force --relative
-SYMLINK = ln -snf$(if $(DARWINHOST),,r)
+SYMLINK = $(if $(DARWINHOST),gln,ln) -snfr
 
 # set cross-compiler/host CC and CXX
 ifneq (,$(findstring clang, $(CC)))

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -48,17 +48,14 @@ else
   CCACHE := $(or $(CCACHE),$(shell command -v ccache))
 endif
 
-# Should point at the actual directory in which *this* makefile resides, as opposed to $(CURDIR),
-# which is simply $PWD *at the time of the original make call*, which is not necessarily the same thing.
-# NOTE: Will only behave as long as there aren't any spaces in the paths involved!
-MAKEFILE_DIR:=$(dir $(realpath $(lastword $(MAKEFILE_LIST))))
-TOOLCHAIN_DIR:=$(MAKEFILE_DIR)toolchain
-ANDROID_ARCH?=arm
+
+TOOLCHAIN_DIR = $(abspath $(KOR_BASE)/toolchain)
+ANDROID_ARCH ?= arm
 export ANDROID_HOME := $(or $(ANDROID_HOME),$(ANDROID_SDK_ROOT),$(TOOLCHAIN_DIR)/android-sdk-linux)
 export ANDROID_SDK_ROOT := $(ANDROID_HOME)
 export ANDROID_NDK_HOME := $(or $(ANDROID_NDK_HOME),$(ANDROID_NDK_ROOT),$(TOOLCHAIN_DIR)/android-ndk-r23c)
 export ANDROID_NDK_ROOT := $(ANDROID_NDK_HOME)
-ANDROID_TOOLCHAIN := $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64
+ANDROID_TOOLCHAIN = $(ANDROID_NDK_HOME)/toolchains/llvm/prebuilt/linux-x86_64
 ifeq ($(ANDROID_ARCH), arm64)
 	# 64bit arches require at least ABI 21.
 	export NDKABI?=21
@@ -582,7 +579,7 @@ endif
 
 # Improve reproducibility (disabled on ancient toolchains).
 ifeq (,$(filter kindle-legacy pocketbook,$(TARGET)))
-  BASE_CFLAGS += -ffile-prefix-map=$(CURDIR)/=
+  BASE_CFLAGS += -ffile-prefix-map=$(abspath $(KOR_BASE))/=
 endif
 
 HOSTCFLAGS:=$(HOST_ARCH) $(BASE_CFLAGS) $(QFLAGS)
@@ -599,7 +596,7 @@ ifndef DARWIN
 	#       (Assuming no LD_LIBRARY_PATH are set, since the search order is basically RPATH -> LD_LIBRARY_PATH -> RUNPATH).
 	#       c.f., https://github.com/koreader/koreader-base/pull/1638#issuecomment-1636725691
 	#       And https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/1253638/comments/5 for a nice recap.
-	LDFLAGS:=-Wl,-O1 -Wl,--as-needed -Wl,@$(MAKEFILE_DIR)origin.ldflags $(COMPAT_LDFLAGS)
+	LDFLAGS:=-Wl,-O1 -Wl,--as-needed -Wl,@$(abspath $(KOR_BASE)/origin.ldflags) $(COMPAT_LDFLAGS)
 else
 	LDFLAGS:=-Wl,-rpath,@executable_path/libs,-rpath,@executable_path/../koreader/libs
 endif
@@ -620,7 +617,7 @@ ifeq ($(TARGET), win32)
 endif
 
 # this will create a path named build/arm-none-linux-gnueabi or similar
-OUTPUT_DIR ?= build/$(MACHINE)
+OUTPUT_DIR ?= $(KOR_BASE)/build/$(MACHINE)
 CMAKE_DIR = $(OUTPUT_DIR)/cmake
 STAGING_DIR = $(OUTPUT_DIR)/staging
 
@@ -715,7 +712,7 @@ endif
 
 # you can probably leave these settings alone:
 
-THIRDPARTY_DIR = thirdparty
+THIRDPARTY_DIR = $(KOR_BASE)/thirdparty
 
 LUAROCKS_BINARY := $(firstword $(shell command -v luarocks luarocks-5.1))
 ifneq (,$(LUAROCKS_BINARY))
@@ -868,7 +865,7 @@ set(HOSTCXX        "$(strip $(HOSTCXX))")
 set(LIB_EXT        $(LIB_EXT))
 set(VECTO_CFLAGS   "$(VECTO_CFLAGS)")
 
-set(BASE_DIR       $(abspath $(CURDIR)))
+set(BASE_DIR       $(abspath $(KOR_BASE)))
 set(OUTPUT_DIR     $(abspath $(OUTPUT_DIR)))
 set(STAGING_DIR    $(abspath $(STAGING_DIR)))
 set(THIRDPARTY_DIR $(abspath $(THIRDPARTY_DIR)))

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -746,7 +746,7 @@ else ifneq (,$(filter i686-%,$(CHOST)))
 else ifneq (,$(filter x86_64-%,$(CHOST)))
   CMAKE_SYSTEM_PROCESSOR = x86_64
 else ifneq (,$(CHOST))
-  $(warning CMAKE_SYSTEM_PROCESSOR not set! (CHOST is $(CHOST)))
+  $(error CMAKE_SYSTEM_PROCESSOR not set! (CHOST is $(CHOST)))
 endif
 
 # Native & cross definitions.

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -508,12 +508,6 @@ else ifeq ($(TARGET), kindle-legacy)
 	# We're not multi-threaded, so, whatever.
 	# c.f., https://github.com/koreader/koreader/discussions/11246
         COMPAT_CXXFLAGS+=-fno-threadsafe-statics
-	# Avoid pulling stuff from GLIBC_2.7 & 2.9 in glib
-	export glib_cv_eventfd=no
-	export ac_cv_func_pipe2=no
-	# Avoid pulling stuff from GLIBC_2.6 in tar
-	export ac_cv_func_utimensat=no
-	export ac_cv_func_futimens=no
 else ifeq ($(TARGET), android)
 	ifeq ($(ANDROID_ARCH), arm)
 		ARM_ARCH:=$(ANDROID_ARM_ARCH)


### PR DESCRIPTION
Main change: before this PR, the output `data` directory would be symlinked to a directory in crengine submodule (`thirdparty/kpvcrlib/crengine/cr3gui/data`): this would pollute the checkout, and could result in some target specific build artifacts getting picked when building a release for other targets (e.g. `KoboUSBMS.tar.gz`).

Now, `data` is a directory, and the relevant files from `thirdparty/kpvcrlib/crengine/cr3gui/data` are symlinked. Note: `data/dict` and `data/tessdata` are still symlinked to directories created in `thirdparty/kpvcrlib/crengine/cr3gui/data`, so for example installed dictionaries survive a `make re` (which I assumed is by design).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1858)
<!-- Reviewable:end -->
