### PR TITLE
make: rework support for using clang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,7 @@ executors:
       - image: koreader/kobase-clang:0.3.4-20.04
     environment:
       <<: *EMU_ENV_LST
-      CC: "clang"
-      CXX: "clang++"
+      USE_CLANG: "1"
 
   # }}}
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -194,8 +194,7 @@ else ifeq ($(TARGET), android)
 	else
 		CHOST?=armv7a-linux-androideabi$(NDKABI)
 	endif
-	CC=clang
-	CXX=clang++
+	USE_CLANG=1
 else ifeq ($(TARGET), win32)
 	CHOST?=x86_64-w64-mingw32
 	WIN32=1
@@ -280,7 +279,7 @@ endef
 SYMLINK = ln -snf$(if $(DARWINHOST),,r)
 
 # set cross-compiler/host CC and CXX
-ifneq (,$(findstring clang, $(CC)))
+ifneq (,$(USE_CLANG))
 	ifdef CHOST
 		CC:=$(CHOST)-clang
 		CXX:=$(CHOST)-clang++


### PR DESCRIPTION
Don't rely on `CC/CXX`: it make it seems like a specific version could be used (`CC=clang-18 make`), but the actual value is ignored and overridden with `clang` (same for `CXX`). And while `make CC=clang-18` is honored, this result in ccache support being partially disabled.

Instead, use a custom dedicated variable: `USE_CLANG`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1861)
<!-- Reviewable:end -->
