### PR TITLE
SDL: call SDL_StopTextInput() on start

### DIFF
--- a/ffi/SDL2_0.lua
+++ b/ffi/SDL2_0.lua
@@ -129,6 +129,10 @@ function S.open(w, h, x, y)
         SDL.SDL_SetHint("SDL_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR", "0")
     end
 
+    -- Disable TextInput until we enable it.
+    -- Also see <https://github.com/slouken/SDL/commit/c0f9a3d814a815ec6e2822d7fd2e8648df79f7b9>.
+    S.stopTextInput()
+
     -- set up screen (window)
     local pos_x = tonumber(os.getenv("KOREADER_WINDOW_POS_X")) or x or SDL.SDL_WINDOWPOS_UNDEFINED
     local pos_y = tonumber(os.getenv("KOREADER_WINDOW_POS_Y")) or y or SDL.SDL_WINDOWPOS_UNDEFINED


### PR DESCRIPTION
To prevent things like unexpected textinput or popups, see <https://github.com/koreader/koreader/pull/12162#issuecomment-2243812140> for more details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1862)
<!-- Reviewable:end -->
