### PR TITLE
mupdf: add missing `libm` dependency

### DIFF
--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -90,7 +90,7 @@ get_target_property(LUAJIT_INC luajit::luajit INTERFACE_INCLUDE_DIRECTORIES)
 declare_dependency(lunasvg::lunasvg SHARED lunasvg)
 
 # mupdf
-set(LIBRARIES)
+set(LIBRARIES m)
 if(ANDROID)
     list(APPEND LIBRARIES log)
 endif()


### PR DESCRIPTION
Fix loading `libwrap-mupdf` on some (KitKat era?) Android devices.

Cf. https://github.com/koreader/koreader/issues/12207.