### PR TITLE
djvu: fix clang-tidy warning

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -126,7 +126,7 @@ static int handle(lua_State *L, ddjvu_context_t *ctx, int wait)
 	if (!ctx)
 		return -1;
 	if (wait)
-		msg = ddjvu_message_wait(ctx);
+		ddjvu_message_wait(ctx);
 	while ((msg = ddjvu_message_peek(ctx)))
 	{
 	  switch(msg->m_any.tag)


### PR DESCRIPTION
The value stored in `msg` is never used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1864)
<!-- Reviewable:end -->
