### PR TITLE
djvulibre: add missing dependencies

### DIFF
--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -50,7 +50,11 @@ target_compile_options(_crengine__crengine INTERFACE -include ${OUTPUT_DIR}/thir
 target_include_directories(_crengine__crengine INTERFACE ${THIRDPARTY_DIR}/kpvcrlib/crengine/crengine/include)
 
 # djvulibre
-declare_dependency(djvulibre::djvulibre SHARED jpeg STATIC djvulibre LIBRARIES m stdc++)
+set(LIBRARIES m stdc++)
+if(APPLE)
+    list(APPEND LIBRARIES "-framework CoreFoundation")
+endif()
+declare_dependency(djvulibre::djvulibre SHARED jpeg STATIC djvulibre LIBRARIES ${LIBRARIES})
 
 # freetype
 declare_dependency(freetype2::freetype INCLUDES freetype2 SHARED freetype)

--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -50,7 +50,7 @@ target_compile_options(_crengine__crengine INTERFACE -include ${OUTPUT_DIR}/thir
 target_include_directories(_crengine__crengine INTERFACE ${THIRDPARTY_DIR}/kpvcrlib/crengine/crengine/include)
 
 # djvulibre
-declare_dependency(djvulibre::djvulibre SHARED jpeg STATIC djvulibre LIBRARIES m)
+declare_dependency(djvulibre::djvulibre SHARED jpeg STATIC djvulibre LIBRARIES m stdc++)
 
 # freetype
 declare_dependency(freetype2::freetype INCLUDES freetype2 SHARED freetype)


### PR DESCRIPTION
- need to link with `libpthread` on Linux
- need to link with `CoreFoundation` on macOS

Note: depends on #1867 (for `DARWIN` → `APPLE`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1868)
<!-- Reviewable:end -->
