### PR TITLE
ci/macos: pin XCode version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
     env:
       # Bump number to reset all caches.
-      CACHE_EPOCH: '0'
+      CACHE_EPOCH: '1'
       CLICOLOR_FORCE: '1'
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'arm64' && '11.0' || '10.15' }}
       MAKEFLAGS: 'OUTPUT_DIR=build'
@@ -33,7 +33,12 @@ jobs:
       # Install dependencies. {{{
 
       - name: XCode version
-        run: xcode-select -p
+        run: |
+          # NOTE: don't forget to bump `CACHE_EPOCH`
+          # above when changing the XCode version.
+          sudo xcode-select -s /Applications/Xcode_15.2.app
+          xcodebuild -version
+          xcode-select -p
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Avoid breakage on runner image update, like the recent update to XCode 15.4 on arm64 which breaks our (ancient) glib build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1870)
<!-- Reviewable:end -->
