### PR TITLE
mxcfb: Commit an experiment for posterity's sake

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -719,6 +719,16 @@ local function refresh_kobo_mtk(fb, is_flashing, waveform_mode, x, y, w, h, dith
         fb.update_data.dither_mode = 0
     end
 
+    --[[
+    -- Disable CFA processing on A2/DU
+    -- NOTE: Well, that leads to... interesting... results when used @ 32bpp...
+    --       The driver seems to have trouble choosing the right working buffer,
+    --       so you get to see a lot of weird crap ;).
+    if waveform_mode == C.HWTCON_WAVEFORM_MODE_A2 or waveform_mode == C.HWTCON_WAVEFORM_MODE_DU then
+        fb.update_data.flags = bor(fb.update_data.flags, C.HWTCON_FLAG_CFA_SKIP)
+    end
+    --]]
+
     return mxc_update(fb, C.HWTCON_SEND_UPDATE, fb.update_data, is_flashing, waveform_mode, x, y, w, h, dither)
 end
 


### PR DESCRIPTION
This was an attempt to alleviate highlight flickers, given that it's caused by the CFA pass.

Unfortunately, the non-CFA pass uses different MDP buffers, and apparently the driver looses its damn mind when mixed with actual CFA updates.

This is not an issue when *nothing* uses CFA (e.g., 8bpp or Eclipse).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1874)
<!-- Reviewable:end -->
