### PR TITLE
libk2pdfopt: fix configure after `make libk2pdfopt-clean`

### DIFF
--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(CMAKE_PATCH_FILE ${CMAKE_CURRENT_BINARY_DIR}/k2pdfopt_exports.cmake)
+set(CMAKE_PATCH_FILE ${CMAKE_BINARY_DIR}/k2pdfopt_exports.cmake)
 target_exports(k2pdfopt FILELIST_VAR CDECLS_FILES WRITE_TO_FILE ${CMAKE_PATCH_FILE} CDECLS koptcontext_cdecl)
 list(APPEND PATCH_CMD COMMAND ${ISED} "\$p" -e "\$s|.*|include(${CMAKE_PATCH_FILE})|" lib/CMakeLists.txt)
 


### PR DESCRIPTION
Don't generate `k2pdfopt_exports.cmake` in libk2pdfopt cmake build directory, or it will not survive cleaning the external project.

Cf. https://github.com/koreader/koreader-base/issues/1873#issuecomment-2254775309.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1877)
<!-- Reviewable:end -->
