### PR TITLE
mupdf: update to 1.24.8

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -33,7 +33,7 @@ local mupdf = {
 }
 -- this cannot get adapted by the cdecl file because it is a
 -- string constant. Must match the actual mupdf API:
-local FZ_VERSION = "1.24.2"
+local FZ_VERSION = "1.24.8"
 
 local document_mt = { __index = {} }
 local page_mt = { __index = {} }

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -108,8 +108,8 @@ list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
 
 external_project(
-    DOWNLOAD URL d8f835e414202946d1c6c8192dd4315d
-    https://mupdf.com/downloads/archive/mupdf-1.24.2-source.tar.lz
+    DOWNLOAD URL dee21c13ebfa542f3001c85b2a36b627
+    https://mupdf.com/downloads/archive/mupdf-1.24.8-source.tar.lz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/mupdf/visibility.patch
+++ b/thirdparty/mupdf/visibility.patch
@@ -98,7 +98,7 @@ diff --git a/include/mupdf/fitz/document.h b/include/mupdf/fitz/document.h
  typedef struct fz_document_handler fz_document_handler;
  typedef struct fz_page fz_page;
  typedef intptr_t fz_bookmark;
-@@ -973,6 +975,8 @@ void fz_delete_link(fz_context *ctx, fz_page *page, fz_link *link);
+@@ -1014,6 +1016,8 @@ void fz_delete_link(fz_context *ctx, fz_page *page, fz_link *link);
  */
  void *fz_process_opened_pages(fz_context *ctx, fz_document *doc, fz_process_opened_page_fn *process_openend_page, void *state);
  
@@ -146,7 +146,7 @@ diff --git a/include/mupdf/fitz/font.h b/include/mupdf/fitz/font.h
  
  void fz_decouple_type3_font(fz_context *ctx, fz_font *font, void *t3doc);
 @@ -815,6 +819,7 @@ fz_buffer *fz_subset_cff_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, i
- char *get_font_file(char *name);
+ char *get_font_file(const char *name);
  char *fz_lookup_base14_font_from_file(fz_context *ctx, const char *name);
  char *fz_lookup_cjk_font_from_file(fz_context *ctx, int registry, int serif, int wmode);
 +FZ_FUNCTION
@@ -273,7 +273,7 @@ diff --git a/include/mupdf/fitz/stream.h b/include/mupdf/fitz/stream.h
  /**
  	Return true if the named file exists and is readable.
  */
-@@ -622,6 +624,8 @@ static inline int fz_is_eof_bits(fz_context *ctx, fz_stream *stm)
+@@ -635,6 +637,8 @@ static inline int fz_is_eof_bits(fz_context *ctx, fz_stream *stm)
  	return fz_is_eof(ctx, stm) && (stm->avail == 0 || stm->bits == EOF);
  }
  
@@ -294,7 +294,7 @@ diff --git a/include/mupdf/fitz/string-util.h b/include/mupdf/fitz/string-util.h
  /* The Unicode character used to incoming character whose value is
   * unknown or unrepresentable. */
  #define FZ_REPLACEMENT_CHARACTER 0xFFFD
-@@ -278,4 +280,6 @@ const char *fz_parse_page_range(fz_context *ctx, const char *s, int *a, int *b,
+@@ -283,4 +285,6 @@ const char *fz_parse_page_range(fz_context *ctx, const char *s, int *a, int *b,
  int fz_tolower(int c);
  int fz_toupper(int c);
  
@@ -351,7 +351,7 @@ diff --git a/include/mupdf/pdf/annot.h b/include/mupdf/pdf/annot.h
  typedef struct pdf_annot pdf_annot;
  
  enum pdf_annot_type
-@@ -938,4 +940,6 @@ void pdf_set_annot_hidden_for_editing(fz_context *ctx, pdf_annot *annot, int hid
+@@ -962,4 +964,6 @@ void pdf_set_annot_hidden_for_editing(fz_context *ctx, pdf_annot *annot, int hid
   */
  int pdf_apply_redaction(fz_context *ctx, pdf_annot *annot, pdf_redact_options *opts);
  
@@ -370,7 +370,7 @@ diff --git a/include/mupdf/pdf/document.h b/include/mupdf/pdf/document.h
  typedef struct pdf_xref pdf_xref;
  typedef struct pdf_ocg_descriptor pdf_ocg_descriptor;
  
-@@ -819,4 +821,6 @@ fz_structure pdf_structure_type(fz_context *ctx, pdf_obj *role_map, pdf_obj *tag
+@@ -839,4 +841,6 @@ fz_structure pdf_structure_type(fz_context *ctx, pdf_obj *role_map, pdf_obj *tag
  void pdf_run_document_structure(fz_context *ctx, pdf_document *doc, fz_device *dev, fz_cookie *cookie);
  
  

--- a/thirdparty/mupdf/webp-upstream-697749.patch
+++ b/thirdparty/mupdf/webp-upstream-697749.patch
@@ -48,7 +48,7 @@ diff --git a/source/cbz/mucbz.c b/source/cbz/mucbz.c
 diff --git a/source/cbz/muimg.c b/source/cbz/muimg.c
 --- a/source/cbz/muimg.c
 +++ b/source/cbz/muimg.c
-@@ -191,7 +191,7 @@ img_open_document(fz_context *ctx, fz_stream *file, fz_stream *accel, fz_archive
+@@ -191,7 +191,7 @@ img_open_document(fz_context *ctx, const fz_document_handler *handler, fz_stream
  		len = fz_buffer_storage(ctx, doc->buffer, &data);
  
  		fmt = FZ_IMAGE_UNKNOWN;
@@ -57,17 +57,18 @@ diff --git a/source/cbz/muimg.c b/source/cbz/muimg.c
  			fmt = fz_recognize_image_format(ctx, data);
  		if (fmt == FZ_IMAGE_TIFF)
  		{
-@@ -236,16 +236,16 @@ img_open_document(fz_context *ctx, fz_stream *file, fz_stream *accel, fz_archive
+@@ -236,7 +236,7 @@ img_open_document(fz_context *ctx, const fz_document_handler *handler, fz_stream
  static int
- img_recognize_content(fz_context *ctx, fz_stream *stream, fz_archive *dir)
+ img_recognize_content(fz_context *ctx, const fz_document_handler *handler, fz_stream *stream, fz_archive *dir, void **state, fz_document_recognize_state_free_fn **free_state)
  {
 -	unsigned char data[8];
 +	unsigned char data[12];
  	size_t n;
  	int fmt;
  
- 	if (stream == NULL)
- 		return 0;
+@@ -248,9 +248,9 @@ img_recognize_content(fz_context *ctx, const fz_document_handler *handler, fz_st
+ 	if (free_state)
+ 		*free_state = NULL;
  
 -	n = fz_read(ctx, stream, data, 8);
 +	n = fz_read(ctx, stream, data, 12);


### PR DESCRIPTION
Changelog: https://www.mupdf.com/releases/history

Potentialy relevant?
> Fix font size bug when parsing html without a font size unit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1893)
<!-- Reviewable:end -->
