### PR TITLE
cmake: fix build machine checks for macOS

### DIFF
--- a/thirdparty/cmake_modules/koreader_external_project.cmake
+++ b/thirdparty/cmake_modules/koreader_external_project.cmake
@@ -7,7 +7,7 @@ endif()
 
 # Crappy macOS command line utilities strike again…
 set(PRINTF_QS "%q")
-if(APPLE)
+if(CMAKE_HOST_APPLE)
     set(PRINTF_QS "'%s'")
 endif()
 set(KOENV ${CMAKE_BINARY_DIR}/koenv.sh)

--- a/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
@@ -1,13 +1,17 @@
 include_guard(GLOBAL)
 
 if(APPLE)
+    set(STRIP_CMD ${CMAKE_STRIP} -x)
+else()
+    set(STRIP_CMD ${CMAKE_STRIP} --strip-unneeded)
+endif()
+
+if(CMAKE_HOST_APPLE)
     # Note: can't use `sed -i "" -e`, because cmake "helpfully"
     # filter-out the empty argument during command invocation…
     set(ISED sh -c "sed -i '' -e \"$@\"" --)
-    set(STRIP_CMD ${CMAKE_STRIP} -x)
 else()
     set(ISED sed -i -e)
-    set(STRIP_CMD ${CMAKE_STRIP} --strip-unneeded)
 endif()
 
 macro(assert_var_defined varName)

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -10,7 +10,7 @@ list(APPEND PATCH_FILES
 
 # Remove the 7 years-old copy of a CA bundle that turbo doesn't actually use.
 list(APPEND PATCH_CMD COMMAND rm turbo/ca-certificates.crt)
-if(APPLE AND ANDROID)
+if(CMAKE_HOST_APPLE AND ANDROID)
     # Makefile of turbo hardcodes the shared library filename on macOS.
     list(APPEND PATCH_CMD COMMAND ${ISED} "s|libtffi_wrap.dylib|libtffi_wrap.so|" Makefile)
 endif()


### PR DESCRIPTION
- `APPLE` → `TRUE` when the host machine system is macOS
- `CMAKE_HOST_APPLE` → `TRUE` when the build machine system is macOS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1895)
<!-- Reviewable:end -->
