### PR TITLE
android: bump sdk build tools

### DIFF
--- a/toolchain/Makefile
+++ b/toolchain/Makefile
@@ -31,7 +31,7 @@ $(TOOLCHAIN_DIR)/$(SDK_DIR): $(SDK_TARBALL)
 	cd latest/bin
 	yes | ./sdkmanager --update
 	yes | ./sdkmanager --licenses
-	./sdkmanager 'platform-tools' 'build-tools;30.0.2' 'platforms;android-30'
+	./sdkmanager 'platform-tools' 'build-tools;34.0.0' 'platforms;android-30'
 	./sdkmanager --uninstall 'emulator' # Installed automatically but we don't need it.
 	rm -f $(TOOLCHAIN_DIR)/$(SDK_TARBALL)
 


### PR DESCRIPTION
Android Gradle Plugin 8.4.0 needs at least 34.0.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1897)
<!-- Reviewable:end -->
