### PR TITLE
helper to generate / update FFI cdecls

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -205,6 +205,15 @@ set(fbdepth_CMAKE_SOURCE_DIR ${fbink_CMAKE_SOURCE_DIR})
 declare_project(thirdparty/libfbink_input ${EXCLUDE_FROM_ALL})
 set(libfbink_input_CMAKE_SOURCE_DIR ${fbink_CMAKE_SOURCE_DIR})
 
+# ffi-cdecl
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(DEPENDS)
+    if(EMULATE_READER)
+        list(APPEND DEPENDS luajit)
+    endif()
+    declare_project(thirdparty/ffi-cdecl DEPENDS ${DEPENDS} EXCLUDE_FROM_ALL)
+endif()
+
 # freetype
 declare_project(thirdparty/freetype2)
 

--- a/thirdparty/ffi-cdecl/CMakeLists.txt
+++ b/thirdparty/ffi-cdecl/CMakeLists.txt
@@ -1,0 +1,61 @@
+# Build in source tree.
+set(BINARY_DIR ${SOURCE_DIR})
+
+set(MAKE_CMD make CROSSCC=${CC} CROSSCXX=${CXX} HOSTCC=${HOSTCC})
+if(EMULATE_READER)
+    # Native compiler, use our own luajit.
+    list(APPEND MAKE_CMD LUAMOD=luajit
+        "LUACFLAGS=-I${STAGING_DIR}/include/luajit-2.1"
+        "LUALIBS=-L${STAGING_DIR}/lib -lluajit -Wl,-rpath,'$$ORIGIN/../..'"
+    )
+else()
+    # We're building for a cross-compiler, let's hope Lua is installed
+    # in the standard locations (as pkg-config can't be used since
+    # we've overriden its environment in `Makefile.defs`). 🤞
+    list(APPEND MAKE_CMD LUAMOD= LUACFLAGS= LUALIBS=-llua)
+endif()
+
+list(APPEND PATCH_FILES ffi-cdecl.patch)
+
+list(APPEND PATCH_CMD COMMAND ${MAKE_CMD} patch)
+
+list(APPEND BUILD_CMD COMMAND ${MAKE_CMD})
+
+# Install GCC plugin.
+list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} -C gcc-lua install DESTDIR=${STAGING_DIR} INSTALL_GCC_PLUGIN=/lib/gcc/plugin)
+
+# Install Lua code.
+set(INSTALL_LUADIR ${STAGING_DIR}/share/lua/5.1)
+append_install_commands(INSTALL_CMD ffi-cdecl.lua DESTINATION ${INSTALL_LUADIR})
+append_install_commands(INSTALL_CMD gcc-lua-cdecl/ffi-cdecl/ffi-cdecl.lua DESTINATION ${INSTALL_LUADIR}/ffi-cdecl)
+append_install_commands(INSTALL_CMD gcc-lua-cdecl/gcc/cdecl.lua DESTINATION ${INSTALL_LUADIR}/gcc)
+
+# Install headers.
+append_install_commands(
+    INSTALL_CMD DESTINATION ${STAGING_DIR}/include/ffi-cdecl
+    gcc-lua-cdecl/ffi-cdecl/C.c
+    gcc-lua-cdecl/ffi-cdecl/C99.c
+    gcc-lua-cdecl/ffi-cdecl/ffi-cdecl.h
+)
+
+# Install helper.
+list(APPEND INSTALL_CMD COMMAND mkdir -p ${STAGING_DIR}/bin)
+list(APPEND INSTALL_CMD COMMAND
+    sh -c "in=\"$1\" out=\"$2\" && shift 2 && sed \"$@\" <\"$in\" >\"$out\"" sed
+    ${CMAKE_CURRENT_SOURCE_DIR}/ffi-cdecl.sh.in ${STAGING_DIR}/bin/ffi-cdecl
+    -e "s,@CC@,${CMAKE_C_COMPILER},"
+    -e "s,@CXX@,${CMAKE_CXX_COMPILER},"
+    -e "s,@PREFIX@,${STAGING_DIR},"
+    -e "s,@PLUGIN@,${STAGING_DIR}/lib/gcc/plugin/gcclua${LIB_EXT},"
+    -e "s,@SCRIPT@,${INSTALL_LUADIR}/ffi-cdecl.lua,"
+)
+list(APPEND INSTALL_CMD COMMAND chmod +x ${STAGING_DIR}/bin/ffi-cdecl)
+
+external_project(
+    DOWNLOAD GIT ea45fb34782a29738334e250e820c825d75e5087
+    https://github.com/koreader/ffi-cdecl.git
+    PATCH_FILES ${PATCH_FILES}
+    PATCH_COMMAND ${PATCH_CMD}
+    BUILD_COMMAND ${BUILD_CMD}
+    INSTALL_COMMAND ${INSTALL_CMD}
+)

--- a/thirdparty/ffi-cdecl/ffi-cdecl.patch
+++ b/thirdparty/ffi-cdecl/ffi-cdecl.patch
@@ -1,0 +1,9 @@
+--- a/ffi-cdecl.lua
++++ b/ffi-cdecl.lua
+@@ -1,5 +1,5 @@
+ local script_dir = arg["script"]:gsub("[^/]+$","")
+-package.path = script_dir .. "gcc-lua-cdecl/?.lua;" .. package.path
++package.path = script_dir .. "/?.lua;" .. package.path
+ 
+ local gcc = require("gcc")
+ local cdecl = require("gcc.cdecl")

--- a/thirdparty/ffi-cdecl/ffi-cdecl.sh.in
+++ b/thirdparty/ffi-cdecl/ffi-cdecl.sh.in
@@ -1,0 +1,118 @@
+#!/bin/bash
+
+set -eo pipefail
+
+CC=(@CC@)
+CXX=(@CXX@)
+PREFIX=@PREFIX@
+PLUGIN=@PLUGIN@
+SCRIPT=@SCRIPT@
+
+usage() {
+    cat 1>&2 <<-EOF
+usage: $0 [-c compiler] [-d dependency] [-o output.lua] [-n] [-D…|-I…|-U…]* input.c
+
+    -c compiler    Select compiler: c or c++ (otherwise determined by the input extension)
+    -d dependency  Add additional cflags from specified pkg-config dependency
+    -o output      Set output file (instead of stdout)
+
+    -D/-I/-U       Those flags are forwarded to the compiler
+
+    -n             Dry-run, show final compiler command only
+EOF
+    exit 1
+}
+
+[[ $# -gt 0 ]] || usage
+
+pkg-config() {
+    env \
+        PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig" \
+        pkg-config --env-only --cflags "$@"
+}
+
+compiler=''
+dry_run=0
+output='/proc/self/fd/1'
+
+cflags=(
+    -fplugin="${PLUGIN}"
+    -fplugin-arg-gcclua-script="${SCRIPT}"
+    -I"${PREFIX}/include/ffi-cdecl"
+    -I"${PREFIX}/include"
+)
+
+while getopts 'c:d:o:D:I:U:h:n' opt; do
+    case "${opt}" in
+        c)
+            case "${OPTARG}" in
+                c | c++)
+                    compiler="${OPTARG}"
+                    ;;
+                *)
+                    usage
+                    ;;
+            esac
+            ;;
+        d)
+            read -ra a < <(pkg-config --cflags "${OPTARG}")
+            cflags+=("${a[@]}")
+            ;;
+        n)
+            dry_run=1
+            ;;
+        o)
+            output="${OPTARG}"
+            ;;
+        [DIU])
+            cflags+=("-${opt}${OPTARG}")
+            ;;
+        [h?])
+            usage
+            ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+# echo "OPTIND: ${OPTIND}"
+# echo "$#: $@"
+# echo "output: ${output}"
+# echo "cflags: ${cflags[@]}"
+# exit
+
+[[ $# -eq 1 ]] || usage
+
+if [[ -z "${compiler}" ]]; then
+    case "$1" in
+        *.C | *.cc | *.cpp | *.CPP | *.c++ | *.cp | *.cxx)
+            compiler='c++'
+            ;;
+        *)
+            compiler='c'
+            ;;
+    esac
+fi
+
+case "${compiler}" in
+    c)
+        cmd=("${CC[@]}")
+        ;;
+    c++)
+        cmd=("${CXX[@]}")
+        ;;
+esac
+
+cmd+=("${cflags[@]}")
+
+cmd+=(-fplugin-arg-gcclua-output="${output}" -S -o /dev/null "$1")
+
+if [[ ${dry_run} -ne 0 ]]; then
+    printf '%q ' "${cmd[@]}"
+    echo
+    exit
+fi
+
+exec "${cmd[@]}"
+
+# vim: sw=4

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -1,11 +1,15 @@
-list(APPEND CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
-
 # Pre-emptively rename `zconf.h`: this is normaly done
 # by `CMakeLists.txt` at configure time, and wreaks havoc
 # with `build.d` generation. Since the later is done before
 # configuring, a missing `zconf.h` would endlessly trigger
 # a new zlib build.
 list(APPEND PATCH_CMD COMMAND mv zconf.h zconf.h.included)
+
+list(APPEND CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    # Project options.
+    -DINSTALL_PKGCONFIG_DIR=${STAGING_DIR}/lib/pkgconfig
+)
 
 list(APPEND BUILD_CMD COMMAND ninja zlib zlibstatic)
 


### PR DESCRIPTION
Only for native emulator builds with GCC: after compiling base, use `make gcc-lua-cdecl` to compile and install to staging a small helper script and everything needed to run it. Example use:

```C
▹ ./build/x86_64-pc-linux-gnu-debug/staging/bin/ffi-cdecl.sh -I . -d lept -n ffi-cdecl/leptonica_cdecl.c
/usr/bin/gcc -fplugin=[…]/base/build/x86_64-pc-linux-gnu-debug/staging/lib/gcc/plugin/gcclua.so -fplugin-arg-gcclua-script=[…]/base/build/x86_64-pc-linux-gnu-debug/staging/share/lua/5.1/ffi-cdecl.lua -I[…]/base/build/x86_64-pc-linux-gnu-debug/staging/include/ffi-cdecl -I[…]/base/build/x86_64-pc-linux-gnu-debug/staging/include -I. -I[…]/base/build/x86_64-pc-linux-gnu-debug/staging/include -I[…]/base/build/x86_64-pc-linux-gnu-debug/staging/include/leptonica -I[…]/base/build/x86_64-pc-linux-gnu-debug/staging/include/libpng16 -fplugin-arg-gcclua-output=/proc/self/fd/1 -S -o /dev/null ffi-cdecl/leptonica_cdecl.c
▹ ./build/x86_64-pc-linux-gnu-debug/staging/bin/ffi-cdecl.sh -I . -d lept ffi-cdecl/leptonica_cdecl.c
local ffi = require("ffi")

ffi.cdef[[
typedef signed char l_int8;
typedef unsigned char l_uint8;
typedef short int l_int16;
typedef short unsigned int l_uint16;
typedef int l_int32;
[…]
PIX *pixThresholdToBinary(PIX *, l_int32);
int pixWriteMemPng(l_uint8 **, size_t *, PIX *, l_float32);
int pixWritePng(const char *, PIX *, l_float32);
]]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1904)
<!-- Reviewable:end -->
