### PR TITLE
android: don't version shared objects

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -590,17 +590,20 @@ CFLAGS:=$(BASE_CFLAGS) $(QFLAGS) $(CSTD_FLAGS)
 CXXFLAGS:=$(BASE_CFLAGS) $(QFLAGS) $(CXXSTD_FLAGS)
 
 ifndef DARWIN
-	# To prefer our shipped libraries over the system's,
-	# we set a couple rpath via an include file to make sure it goes through buildsystem indirection unscathed...
-	# NOTE: We enforce DT_RPATH over DT_RUNPATH because DT_RUNPATH is *not* honored for *transitive* dependencies,
-	#       which can lead to hilarious catastrophe if such a dependency pulls a SONAME identical to something we ship,
-	#       because it will *not* load ours, but still let ours be loaded after that...
-	#       (Assuming no LD_LIBRARY_PATH are set, since the search order is basically RPATH -> LD_LIBRARY_PATH -> RUNPATH).
-	#       c.f., https://github.com/koreader/koreader-base/pull/1638#issuecomment-1636725691
-	#       And https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/1253638/comments/5 for a nice recap.
-	LDFLAGS:=-Wl,-O1 -Wl,--as-needed -Wl,@$(abspath $(KOR_BASE)/origin.ldflags) $(COMPAT_LDFLAGS)
+  LDFLAGS := -Wl,-O1 -Wl,--as-needed $(COMPAT_LDFLAGS)
+  # To prefer our shipped libraries over the system's,
+  # we set a couple rpath via an include file to make sure it goes through buildsystem indirection unscathed...
+  # NOTE: We enforce DT_RPATH over DT_RUNPATH because DT_RUNPATH is *not* honored for *transitive* dependencies,
+  #       which can lead to hilarious catastrophe if such a dependency pulls a SONAME identical to something we ship,
+  #       because it will *not* load ours, but still let ours be loaded after that...
+  #       (Assuming no LD_LIBRARY_PATH are set, since the search order is basically RPATH -> LD_LIBRARY_PATH -> RUNPATH).
+  #       c.f., https://github.com/koreader/koreader-base/pull/1638#issuecomment-1636725691
+  #       And https://bugs.launchpad.net/ubuntu/+source/eglibc/+bug/1253638/comments/5 for a nice recap.
+  ifneq ($(TARGET), android)
+    LDFLAGS += -Wl,@$(abspath $(KOR_BASE)/origin.ldflags)
+  endif
 else
-	LDFLAGS:=-Wl,-rpath,@executable_path/libs,-rpath,@executable_path/../koreader/libs
+  LDFLAGS := -Wl,-rpath,@executable_path/libs,-rpath,@executable_path/../koreader/libs
 endif
 
 # NOTE: Follow the NDK's lead

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -843,6 +843,8 @@ set(CMAKE_SYSTEM_NAME $(if $(DARWIN),Darwin,$(if $(WIN32),Windows,Linux)))
 # Magical value that inhibits all of CMake's own NDK handling code. (Or shit goes boom.)
 $(if $(ANDROID),set(CMAKE_SYSTEM_VERSION 1))
 $(if $(ANDROID),set(ANDROID_STL c++_shared))
+# Also disable versioning of shared objects.
+$(if $(ANDROID),set(CMAKE_PLATFORM_NO_VERSIONED_SONAME TRUE))
 
 # Target architecture.
 set(CMAKE_SYSTEM_PROCESSOR $(CMAKE_SYSTEM_PROCESSOR))

--- a/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_common.cmake
@@ -20,16 +20,6 @@ macro(assert_var_defined varName)
     endif()
 endmacro()
 
-if(ANDROID)
-    set(ANDROID_LIBTOOL_FIX_CMD ${ISED} $<SEMICOLON>
-        -e "s|version_type=none|version_type=linux|"
-        -e "s|need_lib_prefix=no|need_lib_prefix=yes|"
-        -e "s|need_version=no|need_version=yes|"
-        -e "s|library_names_spec=.*|library_names_spec=\"\\\\$libname\\\\$release\\\\$shared_ext\\\\$versuffix \\\\$libname\\\\$release\\\\$shared_ext\\\\$major \\\\$libname\\\\$shared_ext\"|"
-        -e "s|soname_spec=.*|soname_spec=\"\\\\$libname\\\\$release\\\\$shared_ext\\\\$major\"|"
-        libtool)
-endif()
-
 # Append autotools variables ("VAR=value") to `list`.
 function(append_autotools_vars list)
     foreach(var CC CFLAGS CPPFLAGS CXX CXXFLAGS LD LDFLAGS LIBS AR NM RANLIB RC STRIP)
@@ -48,7 +38,9 @@ function(set_libname VAR NAME)
     endif()
     set(NAME lib${NAME} ${_EXT})
     if(DEFINED _VERSION)
-        if(APPLE)
+        if(ANDROID)
+            # No versioning on Android.
+        elseif(APPLE)
             list(INSERT NAME 1 .${_VERSION})
         elseif(WIN32)
             list(INSERT NAME 1 -${_VERSION})

--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -32,10 +32,6 @@ list(APPEND CFG_CMD
     --without-tiff
 )
 
-if(ANDROID)
-    list(APPEND CFG_CMD COMMAND ${ANDROID_LIBTOOL_FIX_CMD})
-endif()
-
 list(APPEND BUILD_CMD COMMAND make -C libdjvu)
 
 list(APPEND INSTALL_CMD COMMAND make -C libdjvu DESTDIR=${STAGING_DIR} install)

--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -14,10 +14,7 @@ list(APPEND BUILD_CMD COMMAND ninja)
 
 list(APPEND INSTALL_CMD COMMAND ${MESON_INSTALL})
 
-set(LIB_SPEC freetype)
-if(NOT ANDROID)
-    list(APPEND LIB_SPEC VERSION 6)
-endif()
+set(LIB_SPEC freetype VERSION 6)
 if(APPLE)
     append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
 endif()

--- a/thirdparty/fribidi/CMakeLists.txt
+++ b/thirdparty/fribidi/CMakeLists.txt
@@ -10,10 +10,7 @@ list(APPEND BUILD_CMD COMMAND ninja)
 
 list(APPEND INSTALL_CMD COMMAND ${MESON_INSTALL})
 
-set(LIB_SPEC fribidi)
-if(NOT ANDROID)
-    list(APPEND LIB_SPEC VERSION 0)
-endif()
+set(LIB_SPEC fribidi VERSION 0)
 if(APPLE)
     append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
 endif()

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -38,10 +38,7 @@ list(APPEND BUILD_CMD COMMAND ninja)
 
 list(APPEND INSTALL_CMD COMMAND ${MESON_INSTALL})
 
-set(LIB_SPEC harfbuzz)
-if(NOT ANDROID)
-    list(APPEND LIB_SPEC VERSION 0)
-endif()
+set(LIB_SPEC harfbuzz VERSION 0)
 if(APPLE)
     append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
 endif()

--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -6,10 +6,6 @@ list(APPEND CFG_CMD
     --enable-silent-rules
 )
 
-if(ANDROID)
-    list(APPEND CFG_CMD COMMAND ${ANDROID_LIBTOOL_FIX_CMD})
-endif()
-
 list(APPEND BUILD_CMD COMMAND make)
 
 list(APPEND INSTALL_CMD COMMAND make install)

--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -78,6 +78,10 @@ list(APPEND CFG_CMD COMMAND
     --prefix=${STAGING_DIR}
     ${CFG_OPTS}
 )
+if(ANDROID)
+    # Disable versioning of shared objects.
+    list(APPEND CFG_CMD COMMAND ${ISED} "s|^SHLIB_EXT=.*|SHLIB_EXT=${LIB_EXT}|" Makefile)
+endif()
 
 set(MAKE_CMD
     make


### PR DESCRIPTION
- autotools doesn't by default
- ditto with meson
- gradle will ignore versioned libraries, and not include them in the APK

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1907)
<!-- Reviewable:end -->
