### PR TITLE
ffi: avoid loading 2 different zlib libraries

### DIFF
--- a/ffi/zipwriter.lua
+++ b/ffi/zipwriter.lua
@@ -14,7 +14,14 @@ local ffi = require "ffi"
 require "ffi/zlib_h"
 
 -- We only need to wrap 2 zlib functions to make a zip file
-local _zlib = ffi.load(ffi.os == "Windows" and "zlib1" or "z")
+local _zlib
+if ffi.os == "Windows" then
+    _zlib = ffi.load("libs/libz1.dll")
+elseif ffi.os == "OSX" then
+    _zlib = ffi.load("libs/libz.1.dylib")
+else
+    _zlib = ffi.load("libs/libz.so.1")
+end
 local function zlibCompress(data)
     local n = _zlib.compressBound(#data)
     local buf = ffi.new("uint8_t[?]", n)


### PR DESCRIPTION
Avoid loading the system version instead of ours.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1912)
<!-- Reviewable:end -->
