### PR TITLE
freetype2: ensure bzip2 support is disabled

### DIFF
--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -1,3 +1,5 @@
+list(APPEND PATCH_FILES fix_meson_bzip2_option.patch)
+
 list(APPEND CFG_CMD COMMAND
     ${MESON_SETUP} --default-library=shared
     -Dmmap=enabled
@@ -24,6 +26,7 @@ append_shared_lib_install_commands(INSTALL_CMD ${LIB_SPEC})
 external_project(
     DOWNLOAD URL 4425315beb50f913ae12d643e4e121e1
     https://github.com/freetype/freetype/archive/refs/tags/VER-2-13-3.tar.gz
+    PATCH_FILES ${PATCH_FILES}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}

--- a/thirdparty/freetype2/fix_meson_bzip2_option.patch
+++ b/thirdparty/freetype2/fix_meson_bzip2_option.patch
@@ -1,0 +1,22 @@
+--- a/meson.build
++++ b/meson.build
+@@ -320,11 +320,16 @@ else
+ endif
+ 
+ # BZip2 support.
+-bzip2_dep = dependency('bzip2', required: false)
++bzip2_dep = dependency(
++  'bzip2',
++  required: get_option('bzip2').disabled() ? get_option('bzip2') : false,
++)
+ if not bzip2_dep.found()
+-  bzip2_dep = cc.find_library('bz2',
++  bzip2_dep = cc.find_library(
++    'bz2',
+     has_headers: ['bzlib.h'],
+-    required: get_option('bzip2'))
++    required: get_option('bzip2'),
++  )
+ endif
+ 
+ if bzip2_dep.found()


### PR DESCRIPTION
Otherwise the macOS CI build of freetype2 end-up with bzip2 support:
```
   freetype2 2.13.3

    Operating System
      OS             : darwin

    Used Libraries
      Zlib           : none
      Bzip2          : yes
      Png            : no
      Harfbuzz       : no
      Brotli         : no
```
```
 build/libs/libfreetype.6.dylib:
  SONAME    : @rpath/libfreetype.6.dylib
  RPATH     : @executable_path/libs:@executable_path/../koreader/libs
  NEEDED    : /usr/lib/libbz2.1.0.dylib
  NEEDED    : /usr/lib/libSystem.B.dylib
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1916)
<!-- Reviewable:end -->
