### PR TITLE
android: fix 32bits builds

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -519,6 +519,7 @@ else ifeq ($(TARGET), android)
 		# NOTE: to be removed when upgrading the minimal supported API level to 24.
 		# (https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md)
 		export ac_cv_sys_file_offset_bits=32
+		COMPAT_CFLAGS += -U_FILE_OFFSET_BITS -D_FILE_OFFSET_BITS=32
 	endif
 else ifeq ($(TARGET), remarkable)
 	ARM_ARCH:=$(ARMV7_A9_ARCH)


### PR DESCRIPTION
MuPDF would fail to open some ZIPs:

> MuPDF cannot open file.: cannot find end of central directory (7)

Make sure all code is compiled with `-U_FILE_OFFSET_BITS -D_FILE_OFFSET_BITS=32`.

NOTE: the initial `-U_FILE_OFFSET_BITS` is for meson external projects (cf. https://github.com/mesonbuild/meson/issues/3519).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1917)
<!-- Reviewable:end -->
