### PR TITLE
BlitBuffer: Don't crash on nil input in colorFromName

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2607,6 +2607,7 @@ BB.HIGHLIGHT_COLORS = {
 return a Color value given a common color name (nil for unknown colors)
 --]]
 function BB.colorFromName(name)
+    if not name then return nil end
     local color_hash = BB.HIGHLIGHT_COLORS[name:lower()]
     if not color_hash then return nil end
     return BB.colorFromString(color_hash)


### PR DESCRIPTION
Re https://github.com/koreader/koreader/pull/12438

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1918)
<!-- Reviewable:end -->
