### PR TITLE
ffi/mupdf: fix metadata strings

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -274,15 +274,20 @@ end
 local function getMetadataInfo(doc, info)
     local bufsize = 255
     local buf = ffi.new("char[?]", bufsize)
+    -- `fz_lookup_metadata` return the number of bytes needed
+    -- to store the string, **including** the null terminator.
     local res = M.fz_lookup_metadata(context(), doc, info, buf, bufsize)
     if res > bufsize then
-        bufsize = res + 1
+        -- Buffer was too small.
+        bufsize = res
         buf = ffi.new("char[?]", bufsize)
         res = M.fz_lookup_metadata(context(), doc, info, buf, bufsize)
     end
-    if res > -1 then
-        return ffi.string(buf, res)
+    if res > 1 then
+        -- Note: strip the null terminator.
+        return ffi.string(buf, res - 1)
     end
+    -- Empty string or error (-1).
     return ""
 end
 


### PR DESCRIPTION
Don't create Lua strings with an embedded null terminator.

Cf. https://github.com/koreader/koreader/pull/12468.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1921)
<!-- Reviewable:end -->
