### PR TITLE
mupdf: update to 1.24.9

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -33,7 +33,7 @@ local mupdf = {
 }
 -- this cannot get adapted by the cdecl file because it is a
 -- string constant. Must match the actual mupdf API:
-local FZ_VERSION = "1.24.8"
+local FZ_VERSION = "1.24.9"
 
 local document_mt = { __index = {} }
 local page_mt = { __index = {} }

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -110,8 +110,8 @@ list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
 
 external_project(
-    DOWNLOAD URL dee21c13ebfa542f3001c85b2a36b627
-    https://mupdf.com/downloads/archive/mupdf-1.24.8-source.tar.lz
+    DOWNLOAD URL 72bb7fcb940cacd28e640ea86f081895
+    https://mupdf.com/downloads/archive/mupdf-1.24.9-source.tar.lz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
> MuPDF 1.24.9 (2024-08-29)
> 
> The 1.24.9 source only release is now available.
> 
>     Improve memory usage for shadings.
>     Improve rendering speed when applying transfer functions to softmasks.
>     Avoid crashing due to colorspaces.
>     Fix bug with SVG clip paths.
>     Fix several bugs concerning text extraction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1923)
<!-- Reviewable:end -->
