### PR TITLE
libjpeg-turbo: use versioned `turbojpeg` library

### DIFF
--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -14,12 +14,15 @@ require("ffi/posix_h")
 require("ffi/turbojpeg_h")
 
 local turbojpeg
+-- The turbojpeg library symbols are versioned, so it should always be
+-- backward compatible: the major & patch numbers are always 0, and when
+-- a new API version is made available, the minor number is incremented.
 if ffi.os == "Windows" then
     turbojpeg = ffi.load("libs/libturbojpeg.dll")
 elseif ffi.os == "OSX" then
-    turbojpeg = ffi.load("libs/libturbojpeg.dylib")
+    turbojpeg = ffi.load("libs/libturbojpeg.0.3.0.dylib")
 else
-    turbojpeg = ffi.load("libs/libturbojpeg.so")
+    turbojpeg = ffi.load("libs/libturbojpeg.so.0.3.0")
 end
 
 local Jpeg = {}

--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -7,16 +7,12 @@ list(APPEND CMAKE_ARGS
     -DENABLE_SHARED=ON
     -DWITH_JAVA=OFF
     -DWITH_JPEG8=ON
+    # Make sure we disable ASM if we don't support SIMD.
+    -DREQUIRE_SIMD=$<BOOL:${WANT_SIMD}>
+    -DWITH_SIMD=$<BOOL:${WANT_SIMD}>
     # Reproducible builds: use release date.
     -DBUILD=20240508
 )
-# Make sure we disable ASM if we don't support SIMD.
-if(NOT WANT_SIMD)
-    list(APPEND CMAKE_ARGS
-        -DREQUIRE_SIMD=OFF
-        -DWITH_SIMD=OFF
-    )
-endif()
 
 list(APPEND BUILD_CMD COMMAND ninja)
 

--- a/thirdparty/libjpeg-turbo/CMakeLists.txt
+++ b/thirdparty/libjpeg-turbo/CMakeLists.txt
@@ -23,7 +23,7 @@ list(APPEND BUILD_CMD COMMAND ninja)
 list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
 append_shared_lib_install_commands(INSTALL_CMD jpeg VERSION 8)
-append_shared_lib_install_commands(INSTALL_CMD turbojpeg)
+append_shared_lib_install_commands(INSTALL_CMD turbojpeg VERSION 0.3.0)
 
 external_project(
     DOWNLOAD GIT 3.0.3


### PR DESCRIPTION
The turbojpeg library symbols are versioned, so it should always be  backward compatible: the major & patch numbers are always 0, and when a new API version is made available, the minor number is incremented.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1927)
<!-- Reviewable:end -->
