### PR TITLE
luajit: patch out library from pkg-config entry when not used

### DIFF
--- a/thirdparty/luajit/CMakeLists.txt
+++ b/thirdparty/luajit/CMakeLists.txt
@@ -91,6 +91,9 @@ endif()
 
 if(USE_LUAJIT_LIB)
     append_shared_lib_install_commands(INSTALL_CMD luajit)
+else()
+    # Prevent LUA modules from linking with the LuaJIT library.
+    list(APPEND INSTALL_CMD COMMAND ${ISED} "s|-l\${libname}||" ${STAGING_DIR}/lib/pkgconfig/luajit.pc)
 endif()
 
 append_tree_install_commands(INSTALL_CMD src/jit jit)


### PR DESCRIPTION
To prevent Lua modules from linking with it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1930)
<!-- Reviewable:end -->
