### PR TITLE
kopt: improve OCR API

### DIFF
--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -379,10 +379,10 @@ end
 
 function KOPTContext_mt.__index:getTOCRWord(bmp, x, y, w, h, datadir, lang, ocr_type, allow_spaces, std_proc, dpi)
     local word = ffi.new("char[256]")
-    k2pdfopt.k2pdfopt_tocr_single_word(bmp == "src" and self.src or self.dst,
+    local err = k2pdfopt.k2pdfopt_tocr_single_word(bmp == "src" and self.src or self.dst,
         x, y, w, h, dpi or self.dev_dpi, word, 256, ffi.cast("char*", datadir), ffi.cast("char*", lang),
         ocr_type, allow_spaces, std_proc)
-    return ffi.string(word)
+    return err == 0 and ffi.string(word) or nil
 end
 
 function KOPTContext_mt.__index:getAutoBBox()

--- a/ffi/koptcontext_h.lua
+++ b/ffi/koptcontext_h.lua
@@ -156,7 +156,7 @@ void wrectmaps_free(WRECTMAPS *);
 int wrectmap_inside(WRECTMAP *, int, int);
 void k2pdfopt_get_reflowed_word_boxes(KOPTContext *, WILLUSBITMAP *, int, int, int, int);
 void k2pdfopt_get_native_word_boxes(KOPTContext *, WILLUSBITMAP *, int, int, int, int);
-void k2pdfopt_tocr_single_word(WILLUSBITMAP *, int, int, int, int, int, char *, int, char *, char *, int, int, int);
+int k2pdfopt_tocr_single_word(WILLUSBITMAP *, int, int, int, int, int, char *, int, char *, char *, int, int, int);
 void k2pdfopt_reflow_bmp(KOPTContext *);
 void k2pdfopt_tocr_end();
 void k2pdfopt_crop_bmp(KOPTContext *);

--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -4,6 +4,7 @@ list(APPEND PATCH_CMD COMMAND ${ISED} "\$p" -e "\$s|.*|include(${CMAKE_PATCH_FIL
 
 list(APPEND CMAKE_ARGS
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DBUILD_SHARED_LIBS=TRUE
     # Project options.
     -DANDROID=${ANDROID}
 )
@@ -15,7 +16,7 @@ list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 append_shared_lib_install_commands(INSTALL_CMD k2pdfopt VERSION 2)
 
 external_project(
-    DOWNLOAD GIT 8f7a37803eab28005c586bdcf9bd4c775278bdae
+    DOWNLOAD GIT 6e79f026b044beef0015f3ddedc818a6d4a01f44
     https://github.com/koreader/libk2pdfopt.git
     PATCH_COMMAND ${PATCH_CMD}
     CMAKE_ARGS ${CMAKE_ARGS}


### PR DESCRIPTION
Return `nil` (rather than an empty string) when `k2pdfopt_tocr_single_word` failed to initialize tesseract (bad or missing data) so the caller can differentiate with OCR misses (no results).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1932)
<!-- Reviewable:end -->
