### PR TITLE
libk2pdfopt: fix uninitialized memory access

### DIFF
--- a/thirdparty/libk2pdfopt/CMakeLists.txt
+++ b/thirdparty/libk2pdfopt/CMakeLists.txt
@@ -16,7 +16,7 @@ list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 append_shared_lib_install_commands(INSTALL_CMD k2pdfopt VERSION 2)
 
 external_project(
-    DOWNLOAD GIT 6e79f026b044beef0015f3ddedc818a6d4a01f44
+    DOWNLOAD GIT 0be83e5d9d04dfa1c8bd7c7230851d251cf9f429
     https://github.com/koreader/libk2pdfopt.git
     PATCH_COMMAND ${PATCH_CMD}
     CMAKE_ARGS ${CMAKE_ARGS}


### PR DESCRIPTION
Cf. https://github.com/koreader/libk2pdfopt/pull/57

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1937)
<!-- Reviewable:end -->
