### PR TITLE
ffi/loadlib: add module

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1037,6 +1037,7 @@ eval "$$($(LUAROCKS_BINARY) path)";
 export TESSDATA_DIR="$$PWD/data";
 ./luajit -e 'require "busted.runner" {standalone = false}' /dev/null
 --exclude-tags=notest
+--helper=ffi/loadlib.lua
 --output=gtest
 --sort-files
 "$$@";

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2676,7 +2676,7 @@ BB.TYPE_TO_BPP = {
 
 BB.has_cblitbuffer = false
 -- Load the C blitter, and default to using it if available
-BB.has_cblitbuffer, cblitbuffer = pcall(ffi.load, "blitbuffer")
+BB.has_cblitbuffer, cblitbuffer = pcall(ffi.loadlib, "blitbuffer")
 if BB.has_cblitbuffer then
     -- If we can, assume we'll want to use it
     use_cblitbuffer = true

--- a/ffi/crypto.lua
+++ b/ffi/crypto.lua
@@ -7,15 +7,7 @@ LuaJIT FFI wrapper for libcrypto (OpenSSL).
 local ffi = require("ffi")
 require("ffi/crypto_h")
 
-local libcrypto
-if ffi.os == "Windows" then
-    libcrypto = ffi.load("libs/libcrypto.dll")
-elseif ffi.os == "OSX" then
-    libcrypto = ffi.load("libs/libcrypto.1.1.dylib")
-else
-    libcrypto = ffi.load("libs/libcrypto.so.1.1")
-end
-
+local libcrypto = ffi.loadlib("crypto", "1.1")
 local crypto = {}
 
 function crypto.pbkdf2_hmac_sha1(pass, salt, iterations, key_len)

--- a/ffi/freetype.lua
+++ b/ffi/freetype.lua
@@ -12,14 +12,7 @@ local C = ffi.C
 -- the header definitions
 require("ffi/freetype_h")
 
-local ft2
-if ffi.os == "Windows" then
-    ft2 = ffi.load("libs/libfreetype-6.dll")
-elseif ffi.os == "OSX" then
-    ft2 = ffi.load("libs/libfreetype.6.dylib")
-else
-    ft2 = ffi.load("libs/libfreetype.so.6")
-end
+local ft2 = ffi.loadlib("freetype", "6")
 
 local freetypelib = ffi.new("FT_Library[1]")
 assert(ft2.FT_Init_FreeType(freetypelib) == 0, "Couldn't initialize Freetype!")

--- a/ffi/harfbuzz.lua
+++ b/ffi/harfbuzz.lua
@@ -1,6 +1,6 @@
 local coverage = require("ffi/harfbuzz_coverage")
 local ffi = require("ffi")
-local hb = ffi.load("libs/libharfbuzz." .. (ffi.os == "OSX" and "0.dylib" or "so.0"))
+local hb = ffi.loadlib("harfbuzz", "0")
 local HB = setmetatable({}, {__index = hb})
 
 require("ffi/harfbuzz_h")

--- a/ffi/input_pocketbook.lua
+++ b/ffi/input_pocketbook.lua
@@ -15,10 +15,10 @@ require("ffi/inkview_h")
 -- emulates those in a semaphore step-locked thread.
 local compat, compat2 = inkview, inkview
 if not pcall(function() local _ = inkview.PrepareForLoop end) then
-    compat = ffi.load("inkview-compat")
+    compat = ffi.loadlib("inkview-compat")
     compat2 = compat
 elseif not pcall(function() local _ = inkview.GetTouchInfoI end) then
-    compat2 = ffi.load("inkview-compat")
+    compat2 = ffi.loadlib("inkview-compat")
 end
 
 local input = {

--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -13,17 +13,10 @@ local BB = require("ffi/blitbuffer")
 require("ffi/posix_h")
 require("ffi/turbojpeg_h")
 
-local turbojpeg
 -- The turbojpeg library symbols are versioned, so it should always be
 -- backward compatible: the major & patch numbers are always 0, and when
 -- a new API version is made available, the minor number is incremented.
-if ffi.os == "Windows" then
-    turbojpeg = ffi.load("libs/libturbojpeg.dll")
-elseif ffi.os == "OSX" then
-    turbojpeg = ffi.load("libs/libturbojpeg.0.3.0.dylib")
-else
-    turbojpeg = ffi.load("libs/libturbojpeg.so.0.3.0")
-end
+local turbojpeg = ffi.loadlib("turbojpeg", "0.3.0", "turbojpeg")
 
 local Jpeg = {}
 

--- a/ffi/koptcontext.lua
+++ b/ffi/koptcontext.lua
@@ -72,17 +72,8 @@ local C = ffi.C
 require("ffi/koptcontext_h")
 require("ffi/leptonica_h")
 local Blitbuffer = require("ffi/blitbuffer")
-local leptonica, k2pdfopt
-if ffi.os == "Windows" then
-    leptonica = ffi.load("libs/libleptonica-6.dll")
-    k2pdfopt = ffi.load("libs/libk2pdfopt-2.dll")
-elseif ffi.os == "OSX" then
-    leptonica = ffi.load("libs/libleptonica.6.dylib")
-    k2pdfopt = ffi.load("libs/libk2pdfopt.2.dylib")
-else
-    leptonica = ffi.load("libs/libleptonica.so.6")
-    k2pdfopt = ffi.load("libs/libk2pdfopt.so.2")
-end
+local leptonica = ffi.loadlib("leptonica", "6")
+local k2pdfopt = ffi.loadlib("k2pdfopt", "2")
 
 local KOPTContext = {
     k2pdfopt = k2pdfopt -- offer the libraries' functions to other users

--- a/ffi/loadlib.lua
+++ b/ffi/loadlib.lua
@@ -1,0 +1,81 @@
+local ffi = require("ffi")
+local android = ffi.os == "Linux" and os.getenv("IS_ANDROID") and require("android")
+local log = android and android.LOGI or print
+
+local lib_search_path
+local lib_basic_format
+local lib_version_format
+
+local function libname(name, version)
+    return string.format(version and lib_version_format or lib_basic_format, name, version)
+end
+
+local function findlib(...)
+    local name, version = ...
+    if not name then
+        return
+    end
+    log("ffi.findlib: " .. name .. (version and (" [" .. version .. "]") or ""))
+    local lib = libname(name, version)
+    local path = package.searchpath(lib, lib_search_path, "/", "/")
+    if path then
+        return path
+    end
+    return findlib(select(3, ...))
+end
+
+local ffi_load = ffi.load
+
+ffi.load = function(lib, global)
+    log("ffi.load: " .. lib .. (global and " (RTLD_GLOBAL)" or ""))
+    return ffi_load(lib, global)
+end
+
+ffi.loadlib = function(...)
+    local lib = findlib(...) or libname(...)
+    return ffi.load(lib)
+end
+
+if android then
+    -- Note: our libraries are not versioned on Android.
+    lib_search_path = android.nativeLibraryDir .. "/?"
+    lib_basic_format = "lib%s.so"
+    lib_version_format = "lib%s.so"
+    -- Android need some custom code for KOReader Lua modules loaded
+    -- with `require("libs/libkoreader-xxx")`, but actually stored
+    -- under the application's directory for native libraries.
+    table.insert(package.loaders, 1, function (modulename)
+        if modulename:sub(1, 17) ~= "libs/libkoreader-" then
+            return
+        end
+        local path = android.nativeLibraryDir .. "/" .. libname(modulename:sub(9))
+        log(string.format("package.loadlib: %s [%s]", path, modulename))
+        return package.loadlib(path, "luaopen_" .. modulename:sub(18))
+    end)
+elseif ffi.os == "Linux" then
+    lib_search_path = "libs/?"
+    lib_basic_format = "lib%s.so"
+    lib_version_format = "lib%s.so.%s"
+elseif ffi.os == "OSX" then
+    -- Apple M1 homebrew installs libraries outside of default search paths,
+    -- and dyld environment variables are sip-protected on MacOS, cf.
+    -- https://github.com/Homebrew/brew/issues/13481#issuecomment-1181592842
+    local libprefix = os.getenv("KO_DYLD_PREFIX")
+    if not libprefix then
+        local std_out = io.popen("brew --prefix", "r")
+        if std_out then
+            libprefix = std_out:read("*line")
+            std_out:close()
+        end
+    end
+    lib_search_path = "libs/?"
+    if libprefix then
+        lib_search_path = lib_search_path .. ";" .. libprefix .. "/lib/?"
+    end
+    lib_basic_format = "lib%s.dylib"
+    lib_version_format = "lib%s.%s.dylib"
+end
+
+log("lib_search_path: " .. lib_search_path)
+log("lib_basic_format: " .. lib_basic_format)
+log("lib_version_format: " .. lib_version_format)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -16,7 +16,7 @@ require("ffi/posix_h") -- for malloc
 
 local BlitBuffer = require("ffi/blitbuffer")
 
-local W = ffi.load("libs/libwrap-mupdf.so")
+local W = ffi.loadlib("wrap-mupdf")
 local M = W
 
 --- @fixme: Don't make cache_size too low, at least not until we bump MµPDF,

--- a/ffi/pic.lua
+++ b/ffi/pic.lua
@@ -103,13 +103,7 @@ local giflib
 local ensure_giflib_loaded = function()
     if giflib then return end
     require("ffi/giflib_h")
-    if ffi.os == "Windows" then
-        giflib = ffi.load("libs/libgif-7.dll")
-    elseif ffi.os == "OSX" then
-        giflib = ffi.load("libs/libgif.7.dylib")
-    else
-        giflib = ffi.load("libs/libgif.so.7")
-    end
+    giflib = ffi.loadlib("gif", "7")
 end
 
 local GifPage = PicPage:extend{}

--- a/ffi/png.lua
+++ b/ffi/png.lua
@@ -9,14 +9,7 @@ Currently, this is a LuaJIT FFI wrapper for lodepng lib.
 local ffi = require("ffi")
 require("ffi/lodepng_h")
 
-local lodepng
-if ffi.os == "Windows" then
-    lodepng = ffi.load("libs/liblodepng.dll")
-elseif ffi.os == "OSX" then
-    lodepng = ffi.load("libs/liblodepng.dylib")
-else
-    lodepng = ffi.load("libs/liblodepng.so")
-end
+local lodepng = ffi.loadlib("lodepng")
 
 local Png = {}
 

--- a/ffi/utf8proc.lua
+++ b/ffi/utf8proc.lua
@@ -12,14 +12,7 @@ local C = ffi.C
 require("ffi/posix_h")
 require("ffi/utf8proc_h")
 
-local libutf8proc
-if ffi.os == "Windows" then
-    libutf8proc = ffi.load("libs/libutf8proc-3.dll")
-elseif ffi.os == "OSX" then
-    libutf8proc = ffi.load("libs/libutf8proc.3.dylib")
-else
-    libutf8proc = ffi.load("libs/libutf8proc.so.3")
-end
+local libutf8proc = ffi.loadlib("utf8proc", "3")
 
 local Utf8Proc = {}
 

--- a/ffi/webp.lua
+++ b/ffi/webp.lua
@@ -11,9 +11,9 @@ local BB = require("ffi/blitbuffer")
 
 require("ffi/libwebp_h")
 
--- local libwebp = ffi.load("libs/libwebp." .. (ffi.os == "OSX" and "7.dylib" or "so.7"))
+-- local libwebp = ffi.loadlib("webp", "7")
 -- We only need the stuff provided by libwebpdemux.so (which itself uses libwebp.so)
-local libwebpdemux = ffi.load("libs/libwebpdemux." .. (ffi.os == "OSX" and "2.dylib" or "so.2"))
+local libwebpdemux = ffi.loadlib("webpdemux", "2")
 
 local Webp = {
     webp_decoder = nil,

--- a/ffi/zipwriter.lua
+++ b/ffi/zipwriter.lua
@@ -14,14 +14,7 @@ local ffi = require "ffi"
 require "ffi/zlib_h"
 
 -- We only need to wrap 2 zlib functions to make a zip file
-local _zlib
-if ffi.os == "Windows" then
-    _zlib = ffi.load("libs/libz1.dll")
-elseif ffi.os == "OSX" then
-    _zlib = ffi.load("libs/libz.1.dylib")
-else
-    _zlib = ffi.load("libs/libz.so.1")
-end
+local _zlib = ffi.loadlib("z", 1)
 local function zlibCompress(data)
     local n = _zlib.compressBound(#data)
     local buf = ffi.new("uint8_t[?]", n)

--- a/ffi/zlib.lua
+++ b/ffi/zlib.lua
@@ -7,14 +7,7 @@ LuaJIT FFI wrapper for zlib.
 local ffi = require("ffi")
 require("ffi/zlib_h")
 
-local libz
-if ffi.os == "Windows" then
-    libz = ffi.load("libs/libz1.dll")
-elseif ffi.os == "OSX" then
-    libz = ffi.load("libs/libz.1.dylib")
-else
-    libz = ffi.load("libs/libz.so.1")
-end
+local libz = ffi.loadlib("z", 1)
 
 local zlib = {}
 

--- a/ffi/zstd.lua
+++ b/ffi/zstd.lua
@@ -10,14 +10,7 @@ local C = ffi.C
 require("ffi/posix_h")
 require("ffi/zstd_h")
 
-local zst
-if ffi.os == "Windows" then
-    zst = ffi.load("libs/libzstd.dll")
-elseif ffi.os == "OSX" then
-    zst = ffi.load("libs/libzstd.1.dylib")
-else
-    zst = ffi.load("libs/libzstd.so.1")
-end
+local zst = ffi.loadlib("zstd", "1")
 
 local zstd = {}
 

--- a/spec/unit/font_spec.lua
+++ b/spec/unit/font_spec.lua
@@ -5,7 +5,7 @@ describe("Low level font interfaces", function()
     it("FreeType and HarfBuzz FFI should work", function()
         assert.has_no.errors(function()
             -- HL wrappers are omitted deliberately - faster bisect in case those fail, but we don't.
-            local ft = ffi.load("libs/libfreetype." .. (ffi.os == "OSX" and "6.dylib" or "so.6"))
+            local ft = ffi.loadlib("freetype", "6")
             require("ffi/freetype_h")
             local hb = require("ffi/harfbuzz")
 

--- a/spec/unit/koptcontext_spec.lua
+++ b/spec/unit/koptcontext_spec.lua
@@ -1,7 +1,7 @@
 local ffi = require("ffi")
 local KOPTContext = require("ffi/koptcontext")
 local mupdf = require("ffi/mupdf")
-local k2pdfopt = ffi.load("libs/libk2pdfopt.so.2")
+local k2pdfopt = ffi.loadlib("k2pdfopt", "2")
 
 local sample_pdf = "spec/base/unit/data/Alice.pdf"
 local paper_pdf = "spec/base/unit/data/Paper.pdf"

--- a/thirdparty/lua-ljsqlite3/init.lua
+++ b/thirdparty/lua-ljsqlite3/init.lua
@@ -200,15 +200,7 @@ int sqlite3_create_function(
 ]]
 
 -- --------------------------------------------------------------------------------
-local sql
-if ffi.os == "Windows" then
-    sql = ffi.load("libs/sqlite3.dll")
-elseif ffi.os == "OSX" then
-    sql = ffi.load("libs/libsqlite3.0.dylib")
-else
-    sql = ffi.load("libs/libsqlite3.so.0")
-end
-
+local sql = ffi.loadlib("sqlite3", "0")
 local transient = ffi.cast("sqlite3_destructor_type", -1)
 local int64_ct = ffi.typeof("int64_t")
 

--- a/thirdparty/turbo/CMakeLists.txt
+++ b/thirdparty/turbo/CMakeLists.txt
@@ -28,7 +28,7 @@ list(APPEND BUILD_CMD COMMAND
     all
 )
 
-append_binary_install_command(INSTALL_CMD libtffi_wrap${LIB_EXT} DESTINATION common)
+append_binary_install_command(INSTALL_CMD libtffi_wrap${LIB_EXT} DESTINATION libs)
 append_install_commands(INSTALL_CMD turbo.lua turbovisor.lua DESTINATION common)
 append_tree_install_commands(INSTALL_CMD turbo common/turbo)
 

--- a/thirdparty/turbo/turbo.patch
+++ b/thirdparty/turbo/turbo.patch
@@ -141,15 +141,19 @@ index 7edb21a..834c12c
 +end
 diff --git a/turbo/util.lua b/turbo/util.lua
 index 18c00bb..c8dfc14 100644
+diff --git a/turbo/util.lua b/turbo/util.lua
 --- a/turbo/util.lua
 +++ b/turbo/util.lua
-@@ -350,6 +350,9 @@ function util.load_libtffi(name)
-         if not have_name then
-             ok, lib = pcall(ffi.load, "/usr/local/lib/libtffi_wrap.so")
-         end
-+        if not ok then
-+            ok, lib = pcall(ffi.load, "common/libtffi_wrap.so")
+@@ -342,6 +342,12 @@ end
+ -- @param name Custom library name or path
+ function util.load_libtffi(name)
+     local have_name = name and true or false
++    if not have_name then
++        local ok, lib = pcall(ffi.loadlib, "tffi_wrap")
++        if ok then
++            return lib
 +        end
-         if not ok then
-             -- Still not OK...
-             error("Could not load " .. name .. " \
++    end
+     name = name or os.getenv("TURBO_LIBTFFI") or "libtffi_wrap"
+     local ok, lib = pcall(ffi.load, name)
+     if not ok then


### PR DESCRIPTION
Provide a `ffi.loadlib` helper, replacing `ffi.load` and `util.ffiLoadCandidates` for loading our libraries.

Prerequisite for #1920 & https://github.com/koreader/koreader/pull/12545.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1938)
<!-- Reviewable:end -->
