### PR TITLE
ffi/jpeg: fix turbojpeg library load fallback

### DIFF
--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -16,7 +16,7 @@ require("ffi/turbojpeg_h")
 -- The turbojpeg library symbols are versioned, so it should always be
 -- backward compatible: the major & patch numbers are always 0, and when
 -- a new API version is made available, the minor number is incremented.
-local turbojpeg = ffi.loadlib("turbojpeg", "0.3.0", "turbojpeg")
+local turbojpeg = ffi.loadlib("turbojpeg", "0.3.0") or ffi.load("turbojpeg")
 
 local Jpeg = {}
 


### PR DESCRIPTION
We want to fallback on the unversioned system library if we're not shipping ours and the system version is different: if the version is too old, the symbols we need will be unresolved, otherwise, any newer version should be backward compatible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1940)
<!-- Reviewable:end -->
