### PR TITLE
ffi/jpeg: fix turbojpeg library load fallback

### DIFF
--- a/ffi/jpeg.lua
+++ b/ffi/jpeg.lua
@@ -16,7 +16,10 @@ require("ffi/turbojpeg_h")
 -- The turbojpeg library symbols are versioned, so it should always be
 -- backward compatible: the major & patch numbers are always 0, and when
 -- a new API version is made available, the minor number is incremented.
-local turbojpeg = ffi.loadlib("turbojpeg", "0.3.0") or ffi.load("turbojpeg")
+local ok, turbojpeg = pcall(ffi.loadlib, "turbojpeg", "0.3.0")
+if not ok then
+    turbojpeg = ffi.load("turbojpeg")
+end
 
 local Jpeg = {}
 


### PR DESCRIPTION
Fix the fix…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1941)
<!-- Reviewable:end -->
