### PR TITLE
build sdl2 for appimage

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -358,7 +358,7 @@ declare_project(thirdparty/proxy-libintl EXCLUDE_FROM_ALL)
 declare_project(thirdparty/sdcv DEPENDS glib zlib)
 
 # sdl2
-if(MACOS)
+if(APPIMAGE OR MACOS)
     set(EXCLUDE_FROM_ALL)
 else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)

--- a/thirdparty/glib/CMakeLists.txt
+++ b/thirdparty/glib/CMakeLists.txt
@@ -25,6 +25,11 @@ list(APPEND CFG_CMD COMMAND
 list(APPEND BUILD_CMD COMMAND ninja glib/libglib-2.0.a)
 
 list(APPEND INSTALL_CMD COMMAND ${MESON_INSTALL} --tags devel)
+# Don't install the pkg-config entry:
+# - sdcv is the only user, and needs to be manually coaxed into using our GLib anyway.
+# - when building SDL2 for the AppImage, IBus headers include some GObject headers,
+#   which our patched version does not include.
+list(APPEND INSTALL_CMD COMMAND rm -f ${STAGING_DIR}/lib/pkgconfig/glib-2.0.pc)
 
 external_project(
     DOWNLOAD URL 4334211338220a165350d1c4a1597b0e

--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -1,19 +1,38 @@
 list(APPEND PATCH_FILES
+    cmake_tweaks.patch
     # Remove workarounds for standalone applications and add
     # a couple of actions to be used from the osx main menu.
     cocoa.patch
 )
+if(APPIMAGE)
+    # Tweak pkg-config search path (allow system packages),
+    # help stupid cmake find system libraries, and fail if
+    # required features / subsystems can't be enabled.
+    list(APPEND PATCH_FILES appimage.patch)
+endif()
 
 list(APPEND CMAKE_ARGS
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
     # Project options.
     -DSDL2_DISABLE_SDL2MAIN=ON
-    -DSDL_AUDIO=OFF
     -DSDL_CMAKE_DEBUG_POSTFIX= # Remove 'd' suffix for the debug build library.
     -DSDL_SHARED=ON
     -DSDL_STATIC=OFF
     -DSDL_TEST=OFF
+    # We don't need audio support.
+    -DSDL_AUDIO=OFF
+    -DSDL_LIBSAMPLERATE=OFF
 )
+if(APPIMAGE)
+    list(APPEND CMAKE_ARGS
+        # Miscellaneous video features/subsystems we don't care about.
+        -DSDL_DIRECTFB=OFF
+        -DSDL_KMSDRM=OFF
+        -DSDL_RPI=OFF
+        # No libdecor-0-dev package in Ubuntu Focal.
+        -DSDL_WAYLAND_LIBDECOR=OFF
+    )
+endif()
 
 list(APPEND BUILD_CMD COMMAND ninja)
 

--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -22,8 +22,8 @@ list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 append_shared_lib_install_commands(INSTALL_CMD SDL2-2.0 VERSION 0)
 
 external_project(
-    DOWNLOAD URL a344eb827a03045c9b399e99af4af13d
-    https://github.com/libsdl-org/SDL/releases/download/release-2.28.5/SDL2-2.28.5.tar.gz
+    DOWNLOAD URL ab12cc1cf58a5dd25e69c924acb93402
+    https://github.com/libsdl-org/SDL/releases/download/release-2.30.6/SDL2-2.30.6.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/sdl2/appimage.patch
+++ b/thirdparty/sdl2/appimage.patch
@@ -1,0 +1,84 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -8,6 +8,13 @@
+ cmake_minimum_required(VERSION 3.15)
+ project(SDL2 C CXX)
+ 
++execute_process(COMMAND pkg-config --variable pc_path pkg-config RESULT_VARIABLE RET OUTPUT_VARIABLE OUT OUTPUT_STRIP_TRAILING_WHITESPACE)
++if(NOT RET EQUAL 0)
++  message(FATAL_ERROR "could not get pkg-config builtin search path")
++endif()
++set(ENV{PKG_CONFIG_LIBDIR} ${OUT})
++set(CMAKE_LIBRARY_ARCHITECTURE x86_64-linux-gnu)
++
+ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+   set(SDL2_SUBPROJECT OFF)
+ else()
+@@ -1588,7 +1595,7 @@
+ 
+     if(PKG_CONFIG_FOUND)
+       if(SDL_DBUS)
+-        pkg_search_module(DBUS dbus-1 dbus)
++        pkg_search_module(DBUS REQUIRED dbus-1 dbus)
+         if(DBUS_FOUND)
+           set(HAVE_DBUS_DBUS_H TRUE)
+           target_include_directories(sdl-build-options INTERFACE "${DBUS_INCLUDE_DIRS}")
+@@ -1599,7 +1606,7 @@
+       endif()
+ 
+       if(SDL_IBUS)
+-        pkg_search_module(IBUS ibus-1.0 ibus)
++        pkg_search_module(IBUS REQUIRED ibus-1.0 ibus)
+         find_path(HAVE_SYS_INOTIFY_H NAMES sys/inotify.h)
+         if(IBUS_FOUND AND HAVE_SYS_INOTIFY_H)
+           set(HAVE_IBUS_IBUS_H TRUE)
+--- i/cmake/sdlchecks.cmake
++++ w/cmake/sdlchecks.cmake
+@@ -427,6 +427,10 @@
+   if(SDL_X11)
+     foreach(_LIB X11 Xext Xcursor Xi Xfixes Xrandr Xrender Xss)
+         FindLibraryAndSONAME("${_LIB}")
++        string(TOUPPER ${_LIB} _ULIB)
++        if(NOT ${_ULIB}_LIB)
++          message(FATAL_ERROR "Library ${_LIB} not found")
++        endif()
+     endforeach()
+ 
+     set(X11_dirs)
+@@ -658,7 +662,7 @@
+ macro(CheckWayland)
+   if(SDL_WAYLAND)
+     set(WAYLAND_FOUND FALSE)
+-    pkg_check_modules(PKG_WAYLAND "wayland-client>=1.18" wayland-egl wayland-cursor egl "xkbcommon>=0.5.0")
++    pkg_check_modules(PKG_WAYLAND REQUIRED "wayland-client>=1.18" wayland-egl wayland-cursor egl "xkbcommon>=0.5.0")
+ 
+     if(PKG_WAYLAND_FOUND)
+       set(WAYLAND_FOUND TRUE)
+@@ -726,7 +730,7 @@
+       endif()
+ 
+       if(SDL_WAYLAND_LIBDECOR)
+-        pkg_check_modules(PKG_LIBDECOR libdecor-0)
++        pkg_check_modules(PKG_LIBDECOR REQUIRED libdecor-0)
+         if(PKG_LIBDECOR_FOUND)
+             set(HAVE_WAYLAND_LIBDECOR TRUE)
+             set(HAVE_LIBDECOR_H 1)
+@@ -858,7 +862,7 @@
+ # - PkgCheckModules
+ macro(CheckEGL)
+   if (SDL_OPENGL OR SDL_OPENGLES)
+-    pkg_check_modules(EGL egl)
++    pkg_check_modules(EGL REQUIRED egl)
+     set(CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS} ${EGL_CFLAGS}")
+     check_c_source_compiles("
+         #define EGL_API_FB
+@@ -1361,6 +1365,9 @@
+         set(HAVE_LIBUDEV TRUE)
+       endif()
+     endif()
++    if(NOT HAVE_LIBUDEV)
++      message(FATAL_ERROR "udev library not found")
++    endif()
+   endif()
+ endmacro()
+ 

--- a/thirdparty/sdl2/cmake_tweaks.patch
+++ b/thirdparty/sdl2/cmake_tweaks.patch
@@ -1,0 +1,11 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -5,7 +5,7 @@
+ # MSVC runtime library flags are selected by an abstraction.
+ set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
+ 
+-cmake_minimum_required(VERSION 3.0.0...3.5)
++cmake_minimum_required(VERSION 3.15)
+ project(SDL2 C CXX)
+ 
+ execute_process(COMMAND pkg-config --variable pc_path pkg-config RESULT_VARIABLE RET OUTPUT_VARIABLE OUT OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Getting an updated version fix an issue with some erroneous   key events being processed when using a X11 window manager:
 - start KOReader on a virtual desktop, say the first one
 - switch to another desktop, and back using the WM shortcut  (`Super+1`)
 - on getting back focus, KOReader somehow end up processing a `1` key press event, jumping to the beginning of the current book

Note: will need an updated `koappimage` docker image.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1946)
<!-- Reviewable:end -->
