### PR TITLE
cmake: fix external projects in source tree rebuilds

### DIFF
--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -119,11 +119,11 @@ clean_tree() { (
     killlist="$(list_tree "${tree}" | comm -13 "${srclist}" -)"
     [ -n "${killlist}" ] || return 0
     # Remove files.
-    sed -n '/\\$/!p' <<EOF | xargs --delimiter='\n' --no-run-if-empty rm -v || return 1
+    sed -n '/\/$/!p' <<EOF | xargs --delimiter='\n' --no-run-if-empty rm -v || return 1
 ${killlist}
 EOF
     # Remove directories.
-    sed -n '/\\$/p' <<EOF | xargs --delimiter='\n' --no-run-if-empty rmdir -v || return 1
+    sed -n '/\/$/p' <<EOF | xargs --delimiter='\n' --no-run-if-empty rmdir -v || return 1
 ${killlist}
 EOF
 ); }


### PR DESCRIPTION
Fix cleanup of build artifacts when the build create directories.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1953)
<!-- Reviewable:end -->
