### PR TITLE
libk2pdfopt: fix macOS build

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -858,6 +858,8 @@ set(CMAKE_STRIP $(STRIP) CACHE FILEPATH "Strip")
 # Set path(s) to search for libraries/binaries/headers.
 set(CMAKE_FIND_ROOT_PATH $(abspath $(STAGING_DIR)))
 set(CMAKE_PREFIX_PATH $${CMAKE_FIND_ROOT_PATH})
+# So we don't include an outdated `png.h` provided by one of macOS' frameworks.
+set(CMAKE_FIND_FRAMEWORK LAST)
 
 # Install directories.
 set(CMAKE_INSTALL_PREFIX $(abspath $(STAGING_DIR)) CACHE FILEPATH "install prefix")


### PR DESCRIPTION
Make sure we use our libpng headers, and not an older framework version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1954)
<!-- Reviewable:end -->
