### PR TITLE
self sufficient testsuite + macos ci run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,4 +193,7 @@ jobs:
 
       # }}}
 
+      - name: Test
+        run: ./utils/fake_tty.py make --assume-old=all test
+
 # vim: foldmethod=marker foldlevel=0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['arm64', 'x86_64']
+        include:
+          - image: '13'
+            platform: 'x86-64'
+            xcode_version: '15.2'
+            deployment_target: '10.15'
+          - image: '14'
+            platform: 'ARM64'
+            xcode_version: '15.4'
+            deployment_target: '11.0'
+          - image: '15'
+            platform: 'ARM64'
+            xcode_version: '16.0'
+            deployment_target: '14.6.1'
 
-    runs-on: ${{ matrix.platform == 'arm64' && 'macos-14' || 'macos-13' }}
+    name: "macOS ${{ matrix.image }} ${{ matrix.platform }} 🔨${{ matrix.xcode_version }} 🎯${{ matrix.deployment_target }}"
+
+    runs-on: "macos-${{ matrix.image }}"
 
     env:
-      # Bump number to reset all caches.
-      CACHE_EPOCH: '1'
+      # Bump first number to reset all caches.
+      CACHE_KEY: "1-macOS-${{ matrix.image }}-${{ matrix.platform }}-XC${{ matrix.xcode_version }}-DT${{ matrix.deployment_target }}"
       CLICOLOR_FORCE: '1'
-      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.platform == 'arm64' && '11.0' || '10.15' }}
+      MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
       MAKEFLAGS: 'OUTPUT_DIR=build'
 
     steps:
@@ -34,9 +48,7 @@ jobs:
 
       - name: XCode version
         run: |
-          # NOTE: don't forget to bump `CACHE_EPOCH`
-          # above when changing the XCode version.
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.platform == 'arm64' && '15.4' || 15.2 }}.app
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app
           xcodebuild -version
           xcode-select -p
 
@@ -113,7 +125,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: build
-          key: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ runner.arch }}-build-${{ hashFiles('cache-key') }}
+          key: ${{ env.CACHE_KEY }}-build-${{ hashFiles('cache-key') }}
 
       - name: Restore build cache
         id: ccache-restore
@@ -122,7 +134,7 @@ jobs:
         with:
           path: /Users/runner/Library/Caches/ccache
           key: ${{ env.CACHE_KEY }}-ccache-${{ hashFiles('cache-key') }}
-          restore-keys: ${{ env.KEY }}-ccache-
+          restore-keys: ${{ env.CACHE_KEY }}-ccache-
 
       - name: Install ccache
         if: steps.build-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
           # Remove some installed packages to prevent brew
           # from attempting (and failing) to upgrade them.
           brew uninstall gradle maven
-          brew install --formula --quiet "${packages[@]}"
+          brew install --formula --overwrite --quiet "${packages[@]}"
 
       - name: Update PATH
         run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,15 +121,15 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: /Users/runner/Library/Caches/ccache
-          key: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ runner.arch }}-ccache-${{ hashFiles('cache-key') }}
-          restore-keys: ${{ env.CACHE_EPOCH }}-${{ runner.os }}-${{ runner.arch }}-ccache-
+          key: ${{ env.CACHE_KEY }}-ccache-${{ hashFiles('cache-key') }}
+          restore-keys: ${{ env.KEY }}-ccache-
 
       - name: Install ccache
         if: steps.build-restore.outputs.cache-hit != 'true'
         run: |
-          wget --progress=dot:mega https://github.com/ccache/ccache/releases/download/v4.9.1/ccache-4.9.1-darwin.tar.gz
-          tar xf ccache-4.9.1-darwin.tar.gz
-          printf '%s\n' "$PWD/ccache-4.9.1-darwin" >>"${GITHUB_PATH}"
+          wget --progress=dot:mega https://github.com/ccache/ccache/releases/download/v4.10.2/ccache-4.10.2-darwin.tar.gz
+          tar xf ccache-4.10.2-darwin.tar.gz
+          printf '%s\n' "$PWD/ccache-4.10.2-darwin" >>"${GITHUB_PATH}"
 
       - name: Setup build cache
         if: steps.build-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,6 @@ jobs:
             cmake
             coreutils
             findutils
-            jq
             libtool
             make
             nasm

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ $(BASE_PREFIX)clean:
 	rm -rf $(OUTPUT_DIR)
 
 $(BASE_PREFIX)distclean:
-	rm -rf $(dir $(filter $(KOR_BASE)/build/%,$(OUTPUT_DIR))) $(wildcard $(THIRDPARTY_DIR)/*/build)
+	rm -rf $(dir $(filter $(KOR_BASE)/build/%,$(OUTPUT_DIR))) $(wildcard $(THIRDPARTY_DIR)/*/build $(THIRDPARTY_DIR)/spec/*/build)
 
 info:
 	$(strip $(build_info))
@@ -190,7 +190,7 @@ cache-key: $(KOR_BASE)/Makefile $(KOR_BASE)/cache-key.base
 
 define BINARY_PATHS
 $(filter-out
-  $(addprefix $(OUTPUT_DIR)/,cmake staging thirdparty),
+  $(addprefix $(OUTPUT_DIR)/,cmake spec staging thirdparty),
     $(wildcard $(OUTPUT_DIR)/*))
 endef
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -289,7 +289,7 @@ endif
 #       Ensuring Lua/C modules have their own DT_NEEDED entry to the shared LuaJIT library works around this quirk (and is otherwise mostly harmless).
 #       Saner APIs behave like Linux, and wouldn't require this hack.
 USE_LUAJIT_LIB = $(or $(DARWIN),$(ANDROID),$(WIN32))
-SKIP_LUAJIT_BIN = $(or $(ANDROID),$(MACOS))
+SKIP_LUAJIT_BIN = $(ANDROID)
 
 RCP := cp -R
 WGET ?= wget --no-verbose

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -670,6 +670,7 @@ endif
 OUTPUT_DIR ?= $(KOR_BASE)/build/$(MACHINE)
 CMAKE_DIR = $(OUTPUT_DIR)/cmake
 STAGING_DIR = $(OUTPUT_DIR)/staging
+SPEC_ROCKS_DIR = $(OUTPUT_DIR)/spec/rocks
 
 BUILD_ENTRYPOINT = $(CMAKE_DIR)/build.ninja
 
@@ -766,13 +767,7 @@ endif
 
 THIRDPARTY_DIR = $(KOR_BASE)/thirdparty
 
-LUAROCKS_BINARY := $(firstword $(shell command -v luarocks luarocks-5.1))
-ifneq (,$(LUAROCKS_BINARY))
-  # Detect versioned LR 3 binary, see koreader-base/pull/1003
-  ifneq (,$(shell $(LUAROCKS_BINARY) --help | grep -Eo -- --lua-version))
-    LUAROCKS_BINARY += --lua-version=5.1
-  endif
-endif
+LUAROCKS_BINARY := $(abspath $(STAGING_DIR)/bin/luarocks)
 
 # Dynamic libraries must be compiled with "-shared" and "-fPIC".
 # (And we enforce PIC everywhere via CFLAGS/CXXFLAGS).
@@ -930,6 +925,7 @@ set(VECTO_CFLAGS   "$(VECTO_CFLAGS)")
 set(BASE_DIR       $(abspath $(KOR_BASE)))
 set(OUTPUT_DIR     $(abspath $(OUTPUT_DIR)))
 set(STAGING_DIR    $(abspath $(STAGING_DIR)))
+set(SPEC_ROCKS_DIR $(abspath $(SPEC_ROCKS_DIR)))
 set(THIRDPARTY_DIR $(abspath $(THIRDPARTY_DIR)))
 
 set(MAKE $(MAKE))
@@ -1082,7 +1078,8 @@ ifneq (,$(EMULATE_READER))
 
 define busted_fn
 busted() {(
-eval "$$($(LUAROCKS_BINARY) path)";
+export LUA_CPATH='./?.so;$(abspath $(SPEC_ROCKS_DIR)/lib/lua/5.1/?.so)';
+export LUA_PATH='./?.lua;$(abspath $(SPEC_ROCKS_DIR)/share/lua/5.1/?.lua);$(abspath $(SPEC_ROCKS_DIR)/share/lua/5.1/?/init.lua)';
 export TESSDATA_DIR="$$PWD/data";
 ./luajit -e 'require "busted.runner" {standalone = false}' /dev/null
 --exclude-tags=notest

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -305,6 +305,9 @@ declare_project(thirdparty/luajit)
 # luajson
 declare_project(thirdparty/luajson)
 
+# luarocks
+declare_project(thirdparty/luarocks DEPENDS luajit EXCLUDE_FROM_ALL)
+
 # luasec
 declare_project(thirdparty/luasec DEPENDS luajit luasocket openssl)
 
@@ -399,6 +402,29 @@ else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)
 endif()
 declare_project(thirdparty/zsync2 DEPENDS curl openssl zlib ${EXCLUDE_FROM_ALL})
+
+# }}}
+
+# TESTSUITE DEPENDENCIES. {{{
+
+if(EMULATE_READER)
+    add_custom_target(spec-rocks)
+    foreach(PRJ
+            busted
+            dkjson
+            lua-term
+            lua_cliargs
+            luafilesystem
+            luassert
+            luasystem
+            mediator_lua
+            penlight
+            say
+        )
+        declare_project(thirdparty/spec/${PRJ} DEPENDS luarocks)
+        add_dependencies(spec-rocks ${PRJ})
+    endforeach()
+endif()
 
 # }}}
 

--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -99,6 +99,12 @@ extract_archive() { (
     # Of course `cmake -E tar` does not support `--strip-components=n`,
     # so we need to use a temporary directory and move things around…
     rm -rf "${sourcedir}" "${sourcedir}.tmp" || return 1
+    case "${archive}" in
+        *.src.rock)
+            # Luarocks source rock, there's no need to extract it.
+            return 0
+            ;;
+    esac
     mkdir "${sourcedir}.tmp" || return 1
     oldpwd="${PWD}"
     cd "${sourcedir}.tmp"

--- a/thirdparty/luarocks/CMakeLists.txt
+++ b/thirdparty/luarocks/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Build in source tree.
+set(BINARY_DIR ${SOURCE_DIR})
+
+list(APPEND CFG_CMD COMMAND
+    ./configure
+    --prefix=${STAGING_DIR}
+    --with-lua=${STAGING_DIR}
+)
+
+list(APPEND BUILD_CMD COMMAND make)
+
+list(APPEND INSTALL_CMD COMMAND make install)
+
+# Try to use our compilation flags.
+set(LIBFLAGS ${DYNLIB_LDFLAGS})
+foreach(VAR CC CFLAGS LIBFLAGS)
+    list(APPEND INSTALL_CMD COMMAND ${STAGING_DIR}/bin/luarocks config -- ${VAR} "${${VAR}}")
+endforeach()
+
+external_project(
+    DOWNLOAD URL ab95865ced3c123908bd2f1fe6843606
+    https://github.com/luarocks/luarocks/archive/refs/tags/v3.11.1.tar.gz
+    CONFIGURE_COMMAND ${CFG_CMD}
+    BUILD_COMMAND ${BUILD_CMD}
+    INSTALL_COMMAND ${INSTALL_CMD}
+)

--- a/thirdparty/spec/busted/CMakeLists.txt
+++ b/thirdparty/spec/busted/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/lunarmodules/busted-2.2.0-1.src.rock
+    85aa90d2d9d0213fcd8528bc489a3519
+)

--- a/thirdparty/spec/dkjson/CMakeLists.txt
+++ b/thirdparty/spec/dkjson/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/dhkolf/dkjson-2.8-1.src.rock
+    4d002b7591658983248f8214e9459e1d
+)

--- a/thirdparty/spec/lua-term/CMakeLists.txt
+++ b/thirdparty/spec/lua-term/CMakeLists.txt
@@ -1,0 +1,5 @@
+spec_rock(
+    https://github.com/hoelzro/lua-term/archive/0.08.tar.gz
+    672b60c1e856129891fe29e23632c032
+    ROCKSPEC lua-term-0.8-1.rockspec
+)

--- a/thirdparty/spec/lua_cliargs/CMakeLists.txt
+++ b/thirdparty/spec/lua_cliargs/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/lunarmodules/lua_cliargs-3.0-2.src.rock
+    cca85e869fac1b42252692693aed0333
+)

--- a/thirdparty/spec/luafilesystem/CMakeLists.txt
+++ b/thirdparty/spec/luafilesystem/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/hisham/luafilesystem-1.8.0-1.src.rock
+    93bd2cbd66d6fc25ff89920ef9293c6e
+)

--- a/thirdparty/spec/luassert/CMakeLists.txt
+++ b/thirdparty/spec/luassert/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/lunarmodules/luassert-1.9.0-1.src.rock
+    0df52010a5a5f728da0b9b7615a82da6
+)

--- a/thirdparty/spec/luasystem/CMakeLists.txt
+++ b/thirdparty/spec/luasystem/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/lunarmodules/luasystem-0.4.4-1.src.rock
+    608a105f844a052e0055800d80e925f8
+)

--- a/thirdparty/spec/mediator_lua/CMakeLists.txt
+++ b/thirdparty/spec/mediator_lua/CMakeLists.txt
@@ -1,0 +1,5 @@
+spec_rock(
+    https://github.com/Olivine-Labs/mediator_lua/archive/v1.1.2-0.tar.gz
+    3ef01fc6ced99f6e4c2a229e91c459bf
+    ROCKSPEC mediator_lua-1.1.2-0.rockspec
+)

--- a/thirdparty/spec/penlight/CMakeLists.txt
+++ b/thirdparty/spec/penlight/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/tieske/penlight-1.14.0-2.src.rock
+    ab64b4b635e2514db64b4eabfd9d2220
+)

--- a/thirdparty/spec/say/CMakeLists.txt
+++ b/thirdparty/spec/say/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/lunarmodules/say-1.4.1-3.src.rock
+    3b776612edf1e659b2a1e95698597e44
+)

--- a/utils/fake_tty.py
+++ b/utils/fake_tty.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+import os, pty, sys
+
+os.environ['TERM'] = 'xterm-256color'
+status = pty.spawn(sys.argv[1:])
+if os.WIFEXITED(status):
+    exit(os.WEXITSTATUS(status))
+if os.WIFSIGNALED(status):
+    exit(-os.WTERMSIG(status))
+raise ValueError(status)


### PR DESCRIPTION
I wanted to run the tests on the macOS CI, but then I remembered lua5.1 is not supported by brew anymore, and figured I might as well make our testsuite self-sufficient (like with the meson branch): install luarocks to staging and the necessary Lua packages to a dedicated tree under the output `spec` directory.

This led to discovering 2 macOS specific issues: see #1953 & #1954.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1956)
<!-- Reviewable:end -->
