### PR TITLE
glib: update to 2.82.1

### DIFF
--- a/thirdparty/glib/CMakeLists.txt
+++ b/thirdparty/glib/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 list(APPEND CFG_CMD COMMAND
     ${MESON_SETUP} --default-library=static
     -Dglib_assert=false
+    -Dglib_debug=disabled
     -Dtests=false
     -Dxattr=false
     ${SOURCE_DIR}
@@ -32,8 +33,8 @@ list(APPEND INSTALL_CMD COMMAND ${MESON_INSTALL} --tags devel)
 list(APPEND INSTALL_CMD COMMAND rm -f ${STAGING_DIR}/lib/pkgconfig/glib-2.0.pc)
 
 external_project(
-    DOWNLOAD URL 4334211338220a165350d1c4a1597b0e
-    https://download.gnome.org/sources/glib/2.80/glib-2.80.4.tar.xz
+    DOWNLOAD URL d101f1acab6805d4d6d3104e9634b8e3
+    https://download.gnome.org/sources/glib/2.82/glib-2.82.1.tar.xz
     PATCH_FILES ${PATCH_FILES}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/glib/libglib-only.patch
+++ b/thirdparty/glib/libglib-only.patch
@@ -1,15 +1,15 @@
 --- i/glib/meson.build
 +++ w/glib/meson.build
-@@ -462,6 +462,8 @@ pkg.generate(libglib,
+@@ -462,6 +462,8 @@
  )
  meson.override_dependency('glib-2.0', libglib_dep)
  
 +if false
 +
- # On Windows, glib needs a spawn helper for g_spawn* API
- if host_system == 'windows'
-   if host_machine.cpu_family() == 'x86'
-@@ -499,6 +501,8 @@ else
+ # FIXME: This needs to be added to the `depends` of every invocation of
+ # glib_compile_resources in the build process. We can drop this when
+ # https://github.com/mesonbuild/meson/issues/13385 is fixed.
+@@ -503,6 +505,8 @@
    meson.override_find_program('gtester', gtester)
  endif
  
@@ -17,7 +17,7 @@
 +
  report_conf = configuration_data()
  report_conf.set('GLIB_VERSION', glib_version)
- report_conf.set('PYTHON', python_name)
+ report_conf.set('PYTHON', python.full_path())
 --- i/meson.build
 +++ w/meson.build
 @@ -2214,13 +2214,13 @@ else
@@ -38,15 +38,6 @@
  
  # First check in libc, fallback to libintl, and as last chance build
  # proxy-libintl subproject.
-@@ -2422,7 +2422,7 @@ endif
- 
- glib_conf.set('HAVE_PROC_SELF_CMDLINE', have_proc_self_cmdline)
- 
--python = import('python').find_installation(modules: ['packaging'])
-+python = import('python').find_installation()
- # used for '#!/usr/bin/env <name>'
- python_name = 'python3'
- 
 @@ -2570,25 +2570,19 @@ gnome = import('gnome')
  
  subdir('tools')

--- a/thirdparty/glib/no_glibc_2.6_or_above_symbols.patch
+++ b/thirdparty/glib/no_glibc_2.6_or_above_symbols.patch
@@ -1,6 +1,6 @@
 --- i/meson.build
 +++ w/meson.build
-@@ -692,7 +692,6 @@
+@@ -709,7 +709,6 @@ functions = [
    'memalign',
    'mmap',
    'newlocale',
@@ -8,7 +8,7 @@
    'poll',
    'prlimit',
    'readlink',
-@@ -932,14 +931,6 @@
+@@ -945,14 +944,6 @@ else
  endif
  message('Checking whether to use statfs or statvfs .. ' + stat_func_to_use)
  
@@ -23,7 +23,7 @@
  osx_ldflags = []
  glib_have_os_x_9_or_later = false
  glib_have_carbon = false
-@@ -1001,16 +992,6 @@
+@@ -1014,16 +1005,6 @@ if cc.compiles('''#include <linux/futex.h>
    glib_conf.set('HAVE_FUTEX_TIME64', 1)
  endif
  
@@ -37,10 +37,10 @@
 -  glib_conf.set('HAVE_EVENTFD', 1)
 -endif
 -
- # Check for pidfd_open(2)
- if cc.links('''#include <sys/syscall.h>
-                #include <sys/wait.h>
-@@ -2065,9 +2065,6 @@
+ # Check for ppoll(2)
+ if cc.links('''#define _GNU_SOURCE
+                #include <poll.h>
+@@ -2113,9 +2094,6 @@ else
    if cc.has_header_symbol('pthread.h', 'pthread_getname_np', prefix : pthread_prefix)
      glib_conf.set('HAVE_PTHREAD_GETNAME_NP', 1)
    endif

--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -1,9 +1,11 @@
 list(APPEND PATCH_FILES
     # Revert 6e36e7730caf07b6cd0bfa265cdf9b5e31e7acad, because it's
     # not helpful in our workflow, and just causes logging noise.
-    ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-no-unknown-dict-warning.patch
+    sdcv-no-unknown-dict-warning.patch
     # Force UTF-8 command line parsing.
-    ${CMAKE_CURRENT_SOURCE_DIR}/sdcv-locale-hack.patch
+    sdcv-locale-hack.patch
+    # Fix compilation with newer GLib.
+    compat_with_newer_glib.patch
 )
 
 string(APPEND GLIB2_INCLUDE_DIRS

--- a/thirdparty/sdcv/compat_with_newer_glib.patch
+++ b/thirdparty/sdcv/compat_with_newer_glib.patch
@@ -1,0 +1,16 @@
+--- i/src/stardict_lib.cpp
++++ w/src/stardict_lib.cpp
+@@ -1047,9 +1047,9 @@
+         }
+         // Upper the first character and lower others.
+         if (!bFound) {
+-            gchar *nextchar = g_utf8_next_char(sWord);
+-            gchar *firstchar = g_utf8_strup(sWord, nextchar - sWord);
+-            nextchar = g_utf8_strdown(nextchar, -1);
++            size_t nextchar_pos = g_utf8_next_char(sWord) - sWord;
++            gchar *firstchar = g_utf8_strup(sWord, nextchar_pos);
++            gchar *nextchar = g_utf8_strdown(sWord + nextchar_pos, -1);
+             casestr = g_strdup_printf("%s%s", firstchar, nextchar);
+             g_free(firstchar);
+             g_free(nextchar);
+


### PR DESCRIPTION
Highlight: fix `futex_time64()` use on Android ≤ 10 (cf. https://github.com/koreader/koreader/issues/12601).

Full changelogs:
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.81.0
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.81.1
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.81.2
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.82.0
- https://gitlab.gnome.org/GNOME/glib/-/releases/2.82.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1960)
<!-- Reviewable:end -->
