### PR TITLE
sdcv: Don't walk into "res/" subdirectories

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND PATCH_FILES
     sdcv-locale-hack.patch
     # Fix compilation with newer GLib.
     compat_with_newer_glib.patch
+    # Don't walk into "res/" subdirectories.
+    sdcv-ignore-res.patch
 )
 
 string(APPEND GLIB2_INCLUDE_DIRS

--- a/thirdparty/sdcv/sdcv-ignore-res.patch
+++ b/thirdparty/sdcv/sdcv-ignore-res.patch
@@ -1,0 +1,19 @@
+diff --git a/src/utils.cpp b/src/utils.cpp
+index 33bfeaac..a1fbdf1e 100644
+--- a/src/utils.cpp
++++ b/src/utils.cpp
+@@ -66,7 +66,13 @@ static void __for_each_file(const std::string &dirname, const std::string &suff,
+         while ((filename = g_dir_read_name(dir)) != nullptr) {
+             const std::string fullfilename(dirname + G_DIR_SEPARATOR_S + filename);
+             if (g_file_test(fullfilename.c_str(), G_FILE_TEST_IS_DIR))
+-                __for_each_file(fullfilename, suff, order_list, disable_list, f);
++                {
++                    // Don't walk into "res/" subdirectories, as per Stardict specs, they
++                    // may contain possibly many resource files (image, audio files...)
++                    // that could slow down our walk here.
++                    if (strcmp(filename, "res"))
++                        __for_each_file(fullfilename, suff, order_list, disable_list, f);
++                }
+             else if (g_str_has_suffix(filename, suff.c_str()) && std::find(order_list.begin(), order_list.end(), fullfilename) == order_list.end()) {
+                 const bool disable = std::find(disable_list.begin(),
+                                                disable_list.end(),


### PR DESCRIPTION
When searching for .ifo files use the same optimization as we do in the koreader frontend in getIfosInDir(path) in readerdictionary.lua.

Fortunately sdcv uses the for_each_file function exclusively to search for .ifo files, making the patch trivial.

I have several dictionaries on my Kobo Aura One, some of which contain 'res' subdirectories with many files. After a restart or cold boot, the first dictionary lookup would take around 45s, while subsequent lookups would only take merely around 0.5s. My theory for this massive difference is that after reboot, the file system cache is empty, and therefore the file system structure for all the resource directories must first be loaded from the flash, which seems to be quite slow.

With the patched sdcv there is now no difference between the first and the following lookups anymore. In addition, the average lookup time on my device drops from 0.5s to about 0.3s.