### PR TITLE
make: prevent automatic removal of intermediates

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -2,6 +2,9 @@ ifneq (4.1,$(firstword $(sort $(MAKE_VERSION) 4.1)))
   $(error your version of make is too old: $(MAKE_VERSION), need at least 4.1)
 endif
 
+# Prevent make from removing targets it considers as intermediate.
+.SECONDARY:
+
 # Note: ensure our possibly updated `PATH` variable is picked up by
 # `$(shell …)` invocations when using older (<4.4) make versions.
 ifeq (,$(filter shell-export,$(.FEATURES)))


### PR DESCRIPTION
Prevent make from removing targets it considers as intermediate; e.g. when building from a pristine crengine's checkout:
```
[*] Install data files
make:
unlink: base/thirdparty/kpvcrlib/crengine/cr3gui/data/tessdata: Is a directory
make:
unlink: base/thirdparty/kpvcrlib/crengine/cr3gui/data/dict: Is a directory
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1962)
<!-- Reviewable:end -->
