### PR TITLE
ci/circle: manually cap build jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,7 +130,7 @@ jobs:
       BASH_ENV: "~/.bashrc"
       CCACHE_MAXSIZE: << parameters.ccache_maxsize >>
       CLICOLOR_FORCE: "1"
-      MAKEFLAGS: "OUTPUT_DIR=build"
+      MAKEFLAGS: "PARALLEL_JOBS=3 OUTPUT_DIR=build"
     steps:
       # Checkout / fetch. {{{
       - checkout


### PR DESCRIPTION
Can't look at `/sys/fs/cgroup/cpu/cpu.shares` anymore…

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1976)
<!-- Reviewable:end -->
