### PR TITLE
mupdf: update to 1.24.11

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -33,7 +33,7 @@ local mupdf = {
 }
 -- this cannot get adapted by the cdecl file because it is a
 -- string constant. Must match the actual mupdf API:
-local FZ_VERSION = "1.24.10"
+local FZ_VERSION = "1.24.11"
 
 local document_mt = { __index = {} }
 local page_mt = { __index = {} }

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -110,8 +110,8 @@ list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
 
 external_project(
-    DOWNLOAD URL 9634ed1444943a62796c68ec25507619
-    https://mupdf.com/downloads/archive/mupdf-1.24.10-source.tar.lz
+    DOWNLOAD URL 7f02c87260948160e2e21f9685bdcda0
+    https://mupdf.com/downloads/archive/mupdf-1.24.11-source.tar.lz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
Changelog:
> - Fix fz_image reference counting bug when redacting.
> - Fix bug with ordered list number in Story.
> - Fix bug where SMask TR needed to be cleared when SMask changes.
> - Add API to enumerate a cmap.
> - Various fixes for python bindings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1978)
<!-- Reviewable:end -->
