### PR TITLE
ffi/posix: fix typo in cdecls

### DIFF
--- a/ffi-cdecl/posix_decl.c
+++ b/ffi-cdecl/posix_decl.c
@@ -162,7 +162,7 @@ cdecl_func(strcasecmp)
 cdecl_const(F_OK)
 cdecl_const(R_OK)
 cdecl_const(W_OK)
-cdecl_const(W_OK)
+cdecl_const(X_OK)
 cdecl_func(access)
 
 cdecl_type(FILE)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1983)
<!-- Reviewable:end -->
