### PR TITLE
tests: install luacov & cluacov to spec tree

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -411,9 +411,11 @@ if(EMULATE_READER)
     add_custom_target(spec-rocks)
     foreach(PRJ
             busted
+            cluacov
             dkjson
             lua-term
             lua_cliargs
+            luacov
             luafilesystem
             luassert
             luasystem

--- a/thirdparty/spec/cluacov/CMakeLists.txt
+++ b/thirdparty/spec/cluacov/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/luarocks/cluacov-0.1.4-1.src.rock
+    076273d593b0aa95666f1d3238d6549e
+)

--- a/thirdparty/spec/luacov/CMakeLists.txt
+++ b/thirdparty/spec/luacov/CMakeLists.txt
@@ -1,0 +1,4 @@
+spec_rock(
+    https://luarocks.org/manifests/hisham/luacov-0.15.0-1.src.rock
+    5a3bc7c5b5ee85eb06cc8c4cc5cc3d94
+)


### PR DESCRIPTION
This fix coverage on master (https://app.circleci.com/pipelines/github/koreader/koreader/11659/workflows/527da8a7-fe87-4125-8656-dd1a707a2a9e/jobs/17231). The addition of cluacov (which must be compiled for the luajit version used during coverage, or things go boom) also greatly speeds up things (see https://app.circleci.com/pipelines/github/benoit-pierre/koreader/528/workflows/59965b76-8cfa-4e07-a75e-454aefc6c088/jobs/547).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1984)
<!-- Reviewable:end -->
