### PR TITLE
cmake: fix external projects cmake bug

### DIFF
--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -162,7 +162,10 @@ generate_depfile() { (
     srclist="$3"
     shift 3
     exec 1>"${depfile}" || return 1
-    printf '%s: \\\n' "${target}"
+    # NOTE: to work around cmake bug https://gitlab.kitware.com/cmake/cmake/-/issues/25428
+    # (introduced in 3.23.0, fixed in 3.27.9), do not create a target with no deps (which
+    # would keep triggering unnecessary rebuilds).
+    printf '%s: %s \\\n' "${target}" "${srclist}"
     sed '/\/$/d;/[~()=]/d;s/[[:space:]\\]/\\&/g;s/\$/$$/g;$!{s/$/ \\/;}' "${srclist}"
 ); }
 


### PR DESCRIPTION
Work around cmake bug https://gitlab.kitware.com/cmake/cmake/-/issues/25428 (introduced in 3.23.0, fixed in 3.27.9): do not create `build.d` dependency files with phony targets (which would keep triggering unnecessary rebuilds of some external projects).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1986)
<!-- Reviewable:end -->
