### PR TITLE
dropbear: add missing server key location override

### DIFF
--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -30,6 +30,7 @@ endif()
 set(DSS_PRIV_FILENAME "settings/SSH/dropbear_dss_host_key")
 set(RSA_PRIV_FILENAME "settings/SSH/dropbear_rsa_host_key")
 set(ECDSA_PRIV_FILENAME "settings/SSH/dropbear_ecdsa_host_key")
+set(ED25519_PRIV_FILENAME "settings/SSH/dropbear_ed25519_host_key")
 
 configure_file(localoptions.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/localoptions.h ESCAPE_QUOTES)
 set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/localoptions.h)

--- a/thirdparty/dropbear/localoptions.h.cmake
+++ b/thirdparty/dropbear/localoptions.h.cmake
@@ -13,5 +13,6 @@
 #cmakedefine DSS_PRIV_FILENAME   "@DSS_PRIV_FILENAME@"
 #cmakedefine RSA_PRIV_FILENAME   "@RSA_PRIV_FILENAME@"
 #cmakedefine ECDSA_PRIV_FILENAME "@ECDSA_PRIV_FILENAME@"
+#cmakedefine ED25519_PRIV_FILENAME "@ED25519_PRIV_FILENAME@"
 // Extra part of the SSH server identification string.
 #define IDENT_VERSION_PART "_" DROPBEAR_VERSION " (KOReader)"


### PR DESCRIPTION
The ED25519 variant was missing, resulting in a failure to automatically generate the host key:
```
[15145] Nov 22 17:13:15 Couldn't create new file /etc/dropbear/dropbear_ed25519_host_key.tmp15145: No such file or directory
[15145] Nov 22 17:13:15 Exit before auth from <192.168.0.1:60314>: Couldn't read or generate hostkey /etc/dropbear/dropbear_ed25519_host_key
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1987)
<!-- Reviewable:end -->
