### PR TITLE
ci/circle: fix ccache cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # Bump this to reset all caches.
     cache_epoch:
       type: integer
-      default: 2
+      default: 3
 
 # }}}
 
@@ -193,7 +193,7 @@ jobs:
           name: Save build cache
           key: *CACHE_KEY_BUILD_CACHE
           paths:
-            - /home/ko/.ccache
+            - /home/ko/.cache/ccache
       - save_cache:
           name: Save build directory
           key: *CACHE_KEY_BUILD_DIR


### PR DESCRIPTION
New ccache versions respect the XDG spec: `~/.ccache` → `~/.cache/ccache`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1993)
<!-- Reviewable:end -->
