### PR TITLE
freetype2: work around GCC 12 ARM NEON bug

### DIFF
--- a/thirdparty/freetype2/CMakeLists.txt
+++ b/thirdparty/freetype2/CMakeLists.txt
@@ -1,4 +1,8 @@
-list(APPEND PATCH_FILES fix_meson_bzip2_option.patch)
+list(APPEND PATCH_FILES
+    fix_meson_bzip2_option.patch
+    # Work around GCC 12 ARM NEON bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117811).
+    ftcalc_gcc12_arm_neon_fix.patch
+)
 
 list(APPEND CFG_CMD COMMAND
     ${MESON_SETUP} --default-library=$<IF:$<BOOL:${MONOLIBTIC}>,static,shared>

--- a/thirdparty/freetype2/ftcalc_gcc12_arm_neon_fix.patch
+++ b/thirdparty/freetype2/ftcalc_gcc12_arm_neon_fix.patch
@@ -1,0 +1,12 @@
+--- i/src/base/ftcalc.c
++++ w/src/base/ftcalc.c
+@@ -750,7 +750,8 @@
+ 
+     shift = FT_MSB( val ) - 12;
+ 
+-    if ( shift > 0 )
++    if ( shift < 0 )
++        shift = 0;
+     {
+       xx >>= shift;
+       xy >>= shift;


### PR DESCRIPTION
Cf. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=117811.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1994)
<!-- Reviewable:end -->
