### PR TITLE
make: fix corner case in -j / -l handling

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -18,10 +18,12 @@ ifeq (,$(V)$(VERBOSE))
 endif
 
 ifeq (,$(PARALLEL_JOBS))
-  PARALLEL_JOBS := $(or $(patsubst -j%,%,$(filter -j%,$(MAKEFLAGS))))
+empty :=
+space := $(empty) $(empty)
+  PARALLEL_JOBS := $(or $(patsubst -j%,%,$(filter -j%,$(MFLAGS))))
 endif
 ifeq (,$(PARALLEL_LOAD))
-  PARALLEL_LOAD := $(or $(patsubst -l%,%,$(filter -l%,$(MAKEFLAGS))))
+  PARALLEL_LOAD := $(or $(patsubst -l%,%,$(filter -l%,$(MFLAGS))))
 endif
 ifeq (,$(and $(PARALLEL_JOBS),$(PARALLEL_LOAD)))
   CORES := $(shell getconf _NPROCESSORS_ONLN)


### PR DESCRIPTION
```bash
▸ ./kodev test -vj1
make TARGET= KODEBUG=1 VERBOSE=1 testall T=-v\ -j\ 1
cd base/build/x86_64-pc-linux-gnu-debug/cmake && ninja -v -j\ -l8 all
ninja: fatal: invalid -j parameter
make: *** [base/Makefile:89: base-all] Error 1
```

Switch to `MFLAGS`: same value as `MAKEFLAGS` except that it does not contain the command line variable definitions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/1995)
<!-- Reviewable:end -->
