### PR TITLE
mupdf: fix finalizers

### DIFF
--- a/cache-key.base
+++ b/cache-key.base
@@ -19,6 +19,6 @@
 
 # Exceptions.
 /ffi-cdecl/koptcontext_cdecl.c
-/ffi-cdecl/mupdf_decl.c
+/ffi-cdecl/wrap-mupdf_cdecl.c
 
 # vim: ft=gitignore

--- a/ffi-cdecl/wrap-mupdf_cdecl.c
+++ b/ffi-cdecl/wrap-mupdf_cdecl.c
@@ -33,6 +33,8 @@ cdecl_type(fz_locks_context)
 cdecl_func(fz_new_context_imp)
 cdecl_func(fz_drop_context)
 cdecl_func(fz_register_document_handlers)
+cdecl_func(fz_set_user_context)
+cdecl_func(fz_user_context)
 
 /* images */
 cdecl_type(fz_image)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -56,11 +56,11 @@ local function keep_context(ctx)
     return ctx
 end
 
-local save_ctx = nil
+local save_ctx = setmetatable({}, {__mode="kv"})
 
 -- provides an fz_context for mupdf
 local function context()
-    local ctx = save_ctx
+    local ctx = save_ctx[1]
     if ctx then return ctx end
 
     ctx = M.fz_new_context_imp(
@@ -82,7 +82,7 @@ local function context()
     M.fz_install_external_font_funcs(ctx)
     M.fz_register_document_handlers(ctx)
 
-    save_ctx = ctx
+    save_ctx[1] = ctx
     return ctx
 end
 

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -62,6 +62,8 @@ typedef struct {
 fz_context *fz_new_context_imp(const fz_alloc_context *, const fz_locks_context *, size_t, const char *);
 void fz_drop_context(fz_context *);
 void fz_register_document_handlers(fz_context *);
+void fz_set_user_context(fz_context *, void *);
+void *fz_user_context(fz_context *);
 typedef struct fz_image fz_image;
 typedef struct fz_pixmap fz_pixmap;
 fz_image *mupdf_new_image_from_buffer(fz_context *, fz_buffer *);


### PR DESCRIPTION
Some of the MuPDF tests segfault on quit pretty regularly (e.g.: `make --assume-old=all test T='mupdf -f jbig'`), this is because there's no guarantee that the context used to open a document or page won't be dropped before that document / page is.

Use the context private user pointer to keep a reference count and ensure it's only dropped last.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2001)
<!-- Reviewable:end -->
