### PR TITLE
mupdf: allow memory streams to load resources

### DIFF
--- a/ffi-cdecl/wrap-mupdf_cdecl.c
+++ b/ffi-cdecl/wrap-mupdf_cdecl.c
@@ -21,6 +21,11 @@ cdecl_type(fz_context)
 cdecl_type(fz_font)
 cdecl_func(fz_install_external_font_funcs)
 
+/* archive */
+cdecl_type(fz_archive)
+cdecl_func(mupdf_open_directory)
+cdecl_func(mupdf_drop_archive)
+
 /* buffer */
 cdecl_type(fz_buffer)
 cdecl_func(mupdf_new_buffer_from_shared_data)
@@ -57,7 +62,7 @@ cdecl_type(fz_document)
 cdecl_type(fz_device)
 
 cdecl_func(mupdf_open_document)
-cdecl_func(mupdf_open_document_with_stream)
+cdecl_func(mupdf_open_document_with_stream_and_dir)
 cdecl_func(fz_is_document_reflowable)
 cdecl_func(fz_needs_password)
 cdecl_func(fz_authenticate_password)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -134,13 +134,23 @@ function mupdf.openDocument(filename)
     return mupdf_doc
 end
 
-function mupdf.openDocumentFromText(text, magic)
+function mupdf.openDocumentFromText(text, magic, html_resource_directory)
     local ctx = context()
     local stream = W.mupdf_open_memory(ctx, ffi.cast("const unsigned char*", text), #text)
+
+    local archive = nil
+    if html_resource_directory ~= nil then
+        archive = W.mupdf_open_directory(ctx, html_resource_directory)
+    end
+
     local mupdf_doc = {
-        doc = W.mupdf_open_document_with_stream(ctx, magic, stream),
+        doc = W.mupdf_open_document_with_stream_and_dir(ctx, magic, stream, archive),
     }
     W.mupdf_drop_stream(ctx, stream)
+
+    if archive ~= nil then
+        W.mupdf_drop_archive(ctx, archive)
+    end
 
     if mupdf_doc.doc == nil then
         merror(ctx, "MuPDF cannot open document from text")

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -94,12 +94,13 @@ typedef struct {
   int errors;
   int incomplete;
 } fz_cookie;
+typedef struct fz_archive fz_archive;
 typedef struct fz_separations fz_separations;
 typedef struct fz_page fz_page;
 typedef struct fz_document fz_document;
 typedef struct fz_device fz_device;
 fz_document *mupdf_open_document(fz_context *, const char *);
-fz_document *mupdf_open_document_with_stream(fz_context *, const char *, fz_stream *);
+fz_document *mupdf_open_document_with_stream_and_dir(fz_context *, const char *, fz_stream *, fz_archive *);
 int fz_is_document_reflowable(fz_context *, fz_document *);
 int fz_needs_password(fz_context *, fz_document *);
 int fz_authenticate_password(fz_context *, fz_document *, const char *);
@@ -127,6 +128,8 @@ int mupdf_fz_page_number_from_location(fz_context *, fz_document *, fz_location 
 void *mupdf_fz_location_from_page_number(fz_context *, fz_document *, fz_location *, int);
 fz_outline *mupdf_load_outline(fz_context *, fz_document *);
 void fz_drop_outline(fz_context *, fz_outline *);
+fz_archive *mupdf_open_directory(fz_context *, const char *);
+void mupdf_drop_archive(fz_context *, fz_archive *);
 void *mupdf_drop_stream(fz_context *, fz_stream *);
 fz_stream *mupdf_open_memory(fz_context *, const unsigned char *, size_t);
 typedef struct fz_stext_char fz_stext_char;

--- a/wrap-mupdf.h
+++ b/wrap-mupdf.h
@@ -75,12 +75,18 @@ DLL_PUBLIC fz_rect *mupdf_fz_bound_page(fz_context *ctx, fz_page *page, fz_rect 
 MUPDF_WRAP(mupdf_open_document, fz_document*, NULL,
     ret = fz_open_document(ctx, filename),
     const char* filename)
-MUPDF_WRAP(mupdf_open_document_with_stream, fz_document*, NULL,
-    ret = fz_open_document_with_stream(ctx, magic, stream),
-    const char *magic, fz_stream *stream)
+MUPDF_WRAP(mupdf_open_document_with_stream_and_dir, fz_document*, NULL,
+    ret = fz_open_document_with_stream_and_dir(ctx, magic, stream, archive),
+    const char *magic, fz_stream *stream, fz_archive *archive)
 MUPDF_WRAP(mupdf_open_memory, fz_stream*, NULL,
     ret = fz_open_memory(ctx, data, len),
     const unsigned char *data, size_t len)
+MUPDF_WRAP(mupdf_open_directory, fz_archive*, NULL,
+    ret = fz_open_directory(ctx, path),
+    const char *path)
+MUPDF_WRAP(mupdf_drop_archive, void*, NULL,
+    { fz_drop_archive(ctx, archive); ret = (void*) -1; },
+    fz_archive *archive)
 MUPDF_WRAP(mupdf_drop_stream, void*, NULL,
     { fz_drop_stream(ctx, stm); ret = (void*) -1; },
     fz_stream *stm)


### PR DESCRIPTION
Use fz_open_document_with_stream_and_dir instead of fz_open_document_with_stream to allow MuPDF to load resources (images and CSS) when it is loading a HTML document from a memory stream.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2002)
<!-- Reviewable:end -->
