### PR TITLE
openssl: do not build support for the async API

### DIFF
--- a/thirdparty/openssl/CMakeLists.txt
+++ b/thirdparty/openssl/CMakeLists.txt
@@ -74,7 +74,7 @@ else()
     list(APPEND CONFIGURE_CMD ${SOURCE_DIR}/Configure)
 endif()
 
-set(CFG_OPTS ${CFG_OPTS} ${ASM_OPT} no-idea no-mdc2 no-rc5 no-tests)
+set(CFG_OPTS ${CFG_OPTS} ${ASM_OPT} no-async no-idea no-mdc2 no-rc5 no-tests)
 list(APPEND CFG_CMD COMMAND
     env ${CFG_ENV_VAR}
     ${CONFIGURE_CMD}


### PR DESCRIPTION
It's not used, and relies on glibc features not implemented on ARM anyway:
```
arm-pocketbook-linux-gnueabi/bin/../lib/gcc/arm-pocketbook-linux-gnueabi/14.2.0/../../../../arm-pocketbook-linux-gnueabi/bin/ld.bfd: crypto/async/arch/async_posix.o: in function `ASYNC_is_capable':
async_posix.c:(.text+0x8): warning: warning: getcontext is not implemented and will always fail
arm-pocketbook-linux-gnueabi/bin/../lib/gcc/arm-pocketbook-linux-gnueabi/14.2.0/../../../../arm-pocketbook-linux-gnueabi/bin/ld.bfd: crypto/async/async.o: in function `async_fibre_swapcontext.constprop.0.isra.0':
async.c:(.text+0x22): warning: warning: setcontext is not implemented and will always fail
arm-pocketbook-linux-gnueabi/bin/../lib/gcc/arm-pocketbook-linux-gnueabi/14.2.0/../../../../arm-pocketbook-linux-gnueabi/bin/ld.bfd: crypto/async/arch/async_posix.o: in function `async_fibre_makecontext':
async_posix.c:(.text+0x74): warning: warning: makecontext is not implemented and will always fail
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2006)
<!-- Reviewable:end -->
