### PR TITLE
openssh: drop openssl and zlib dependencies

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -348,7 +348,7 @@ if(CERVANTES OR KINDLE OR KOBO OR POCKETBOOK)
 else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)
 endif()
-declare_project(thirdparty/openssh ${EXCLUDE_FROM_ALL} DEPENDS openssl zlib)
+declare_project(thirdparty/openssh ${EXCLUDE_FROM_ALL})
 
 # openssl
 declare_project(thirdparty/openssl)

--- a/thirdparty/openssh/CMakeLists.txt
+++ b/thirdparty/openssh/CMakeLists.txt
@@ -13,12 +13,10 @@ list(APPEND CFG_CMD
     --disable-etc-default-login
     --disable-lastlog
     --with-md5-passwords
-    --with-openssl
-    --with-ssl-engine
     --without-hardening
+    --without-openssl
     --without-stackprotect
-    --with-ssl-dir=${STAGING_DIR}
-    --with-zlib=${STAGING_DIR}
+    --without-zlib
 )
 
 list(APPEND BUILD_CMD COMMAND make sftp-server scp)


### PR DESCRIPTION
We actually don't need them for building the only 2 executables we care about (scp & sftp-server).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2011)
<!-- Reviewable:end -->
