### PR TITLE
dropbear & openssh: fix scp binary

### DIFF
--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -24,6 +24,7 @@ set(DEFAULT_PATH "/sbin:/usr/sbin:/bin:/usr/bin")
 set(DROPBEAR_PIDFILE "settings/SSH/dropbear.pid")
 if(PLATFORM_KOREADER_DIR)
     set(DBSCP_PATH ${PLATFORM_KOREADER_DIR})
+    set(DROPBEAR_PATH_SSH_PROGRAM "${PLATFORM_KOREADER_DIR}/dbclient")
     set(SFTPSERVER_PATH "${PLATFORM_KOREADER_DIR}/sftp-server")
 endif()
 # Keys.
@@ -63,9 +64,11 @@ list(APPEND CFG_CMD
 )
 list(APPEND CFG_CMD COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/localoptions.h localoptions.h)
 
-list(APPEND BUILD_CMD COMMAND make strip PROGRAMS=dropbear)
+set(PROGRAMS dbclient dropbear scp)
 
-append_binary_install_command(INSTALL_CMD dropbear)
+list(APPEND BUILD_CMD make ${PROGRAMS})
+
+append_binary_install_command(INSTALL_CMD ${PROGRAMS})
 
 external_project(
     DOWNLOAD URL bb72335b40c90397cb1c182143524800

--- a/thirdparty/dropbear/localoptions.h.cmake
+++ b/thirdparty/dropbear/localoptions.h.cmake
@@ -5,10 +5,11 @@
 #cmakedefine01 INETD_MODE
 #cmakedefine01 LOG_COMMANDS
 // Paths.
-#cmakedefine DBSCP_PATH       "@DBSCP_PATH@"
-#cmakedefine DEFAULT_PATH     "@DEFAULT_PATH@"
-#cmakedefine DROPBEAR_PIDFILE "@DROPBEAR_PIDFILE@"
-#cmakedefine SFTPSERVER_PATH  "@SFTPSERVER_PATH@"
+#cmakedefine DBSCP_PATH                "@DBSCP_PATH@"
+#cmakedefine DEFAULT_PATH              "@DEFAULT_PATH@"
+#cmakedefine DROPBEAR_PATH_SSH_PROGRAM "@DROPBEAR_PATH_SSH_PROGRAM@"
+#cmakedefine DROPBEAR_PIDFILE          "@DROPBEAR_PIDFILE@"
+#cmakedefine SFTPSERVER_PATH           "@SFTPSERVER_PATH@"
 // Keys.
 #cmakedefine DSS_PRIV_FILENAME   "@DSS_PRIV_FILENAME@"
 #cmakedefine RSA_PRIV_FILENAME   "@RSA_PRIV_FILENAME@"

--- a/thirdparty/openssh/CMakeLists.txt
+++ b/thirdparty/openssh/CMakeLists.txt
@@ -19,9 +19,11 @@ list(APPEND CFG_CMD
     --without-zlib
 )
 
-list(APPEND BUILD_CMD COMMAND make sftp-server scp)
+set(PROGRAMS sftp-server)
 
-append_binary_install_command(INSTALL_CMD scp sftp-server)
+list(APPEND BUILD_CMD COMMAND make ${PROGRAMS})
+
+append_binary_install_command(INSTALL_CMD ${PROGRAMS})
 
 external_project(
     DOWNLOAD URL 5e90def5af3ffb27e149ca6fff12bef3


### PR DESCRIPTION
We can't use the openssh one without shipping the `ssh` binary too, so instead, ship the one provided by dropbear (and the `dbclient` binary, which is dropbear equivalent for `ssh`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2012)
<!-- Reviewable:end -->
