### PR TITLE
harfbuzz: update to 10.2.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -18,14 +18,6 @@ list(APPEND PATCH_CMD COMMAND ${ISED} "/^#line/d"
     src/hb-buffer-deserialize-text-unicode.hh
 )
 
-# We've apparently hit a weird corner-case w/ XText where GCC/STL atomics *sometimes* horribly blow up on an ARM1136JF-S CPU w/ GCC 7.5 & up...
-# c.f., https://github.com/koreader/koreader/issues/5780 & https://github.com/koreader/koreader/issues/6024
-# NOTE: Our initial approach was to only disable atomics in a very dirty manner, which only helped with the first issue.
-#       This, on the other hand, appears to help with both.
-if(LEGACY OR POCKETBOOK)
-    list(APPEND PATCH_CMD COMMAND ${ISED} "/^#define HB_CONFIG_HH\$/{p$<SEMICOLON>s//#define HB_NO_MT/}" src/hb-config.hh)
-endif()
-
 list(APPEND CFG_CMD COMMAND
     ${MESON_SETUP} --default-library=$<IF:$<BOOL:${MONOLIBTIC}>,static,shared>
     -Dfreetype=enabled
@@ -33,6 +25,18 @@ list(APPEND CFG_CMD COMMAND
     -Dutilities=disabled
     ${SOURCE_DIR}
 )
+
+set(DEFINES)
+
+# We've apparently hit a weird corner-case w/ XText where GCC/STL atomics *sometimes* horribly blow up on an ARM1136JF-S CPU w/ GCC 7.5 & up...
+# c.f., https://github.com/koreader/koreader/issues/5780 & https://github.com/koreader/koreader/issues/6024
+# NOTE: Our initial approach was to only disable atomics in a very dirty manner, which only helped with the first issue.
+#       This, on the other hand, appears to help with both.
+if(LEGACY OR POCKETBOOK)
+    list(APPEND DEFINES HB_NO_MT)
+endif()
+
+list(APPEND CFG_CMD COMMAND sh -c "printf '#define %s\\n' \"$@\" >>config.h" -- ${DEFINES})
 
 list(APPEND BUILD_CMD COMMAND ninja)
 
@@ -47,8 +51,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 75969de59a3e09f7a7fb34dbbacb3b68
-    https://github.com/harfbuzz/harfbuzz/releases/download/10.1.0/harfbuzz-10.1.0.tar.xz
+    DOWNLOAD URL f68c05409f18b4a044d71628548aacd9
+    https://github.com/harfbuzz/harfbuzz/releases/download/10.2.0/harfbuzz-10.2.0.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -26,7 +26,18 @@ list(APPEND CFG_CMD COMMAND
     ${SOURCE_DIR}
 )
 
-set(DEFINES)
+set(DEFINES
+    HB_DISABLE_DEPRECATED
+    HB_NO_BUFFER_MESSAGE
+    HB_NO_BUFFER_SERIALIZE
+    HB_NO_COLOR
+    HB_NO_LAYOUT_COLLECT_GLYPHS
+    HB_NO_LAYOUT_RARELY_USED
+    HB_NO_LAYOUT_UNUSED
+    HB_NO_META
+    HB_NO_PAINT
+    HB_NO_STYLE
+)
 
 # We've apparently hit a weird corner-case w/ XText where GCC/STL atomics *sometimes* horribly blow up on an ARM1136JF-S CPU w/ GCC 7.5 & up...
 # c.f., https://github.com/koreader/koreader/issues/5780 & https://github.com/koreader/koreader/issues/6024

--- a/thirdparty/harfbuzz/android.patch
+++ b/thirdparty/harfbuzz/android.patch
@@ -1,7 +1,8 @@
 diff --git a/src/hb.hh b/src/hb.hh
+index fe466fe1..d728bb99 100644
 --- a/src/hb.hh
 +++ b/src/hb.hh
-@@ -487,6 +487,10 @@ static int HB_UNUSED _hb_errno = 0;
+@@ -500,6 +500,10 @@ static int HB_UNUSED _hb_errno = 0;
  #define HB_NO_SETLOCALE 1
  #endif
  

--- a/thirdparty/harfbuzz/no-subset.patch
+++ b/thirdparty/harfbuzz/no-subset.patch
@@ -1,6 +1,8 @@
---- i/src/meson.build
-+++ w/src/meson.build
-@@ -609,7 +609,7 @@
+diff --git a/src/meson.build b/src/meson.build
+index b9daabf0..b5a04745 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -620,7 +620,7 @@ defs_list += [harfbuzz_subset_def]
  
  libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
    include_directories: incconfig,
@@ -9,7 +11,7 @@
    link_with: [libharfbuzz],
    cpp_args: cpp_args + extra_hb_cpp_args,
    soversion: hb_so_version,
-@@ -620,7 +620,7 @@
+@@ -631,7 +631,7 @@ libharfbuzz_subset = library('harfbuzz-subset', hb_subset_sources,
  )
  
  custom_target('harfbuzz-subset.cc',


### PR DESCRIPTION
https://github.com/harfbuzz/harfbuzz/releases/tag/10.2.0

Additionally, don't compile support for unused APIs. Example code size reduction for release builds (vs master with 10.1.0):
 - `android-arm64`: -70.3 KB
 - `emu-x86_64`: -141.1 KB
 - `kindlepw2`: -87.1 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2018)
<!-- Reviewable:end -->
