### PR TITLE
cmake: fix cleaning an external project source tree

### DIFF
--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -130,7 +130,7 @@ clean_tree() { (
     shift 2
     # shellcheck disable=SC2030
     export LANG=C
-    killlist="$(list_tree "${tree}" | comm -13 "${srclist}" -)"
+    killlist="$(list_tree "${tree}" | comm -13 "${srclist}" - | tac)"
     [ -n "${killlist}" ] || return 0
     # Remove files.
     sed -n '/\/$/!p' <<EOF | xargs --delimiter='\n' --no-run-if-empty rm -v || return 1


### PR DESCRIPTION
Cleaning directories need to be done in reverse order.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2019)
<!-- Reviewable:end -->
