### PR TITLE
make: drop kindle-legacy / pocketbook workaround

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -626,10 +626,8 @@ ifneq (yes,$(firstword $(call hasminstd,$(CXX),c++,__cplusplus,201700)))
 	CXXSTD_FLAGS := -std=gnu++17
 endif
 
-# Improve reproducibility (disabled on ancient toolchains).
-ifeq (,$(filter kindle-legacy pocketbook,$(TARGET)))
-  BASE_CFLAGS += -ffile-prefix-map=$(abspath $(KOR_BASE))/=
-endif
+# Improve reproducibility.
+BASE_CFLAGS += -ffile-prefix-map=$(abspath $(KOR_BASE))/=
 
 HOSTCFLAGS:=$(HOST_ARCH) $(BASE_CFLAGS) $(QFLAGS)
 


### PR DESCRIPTION
Not necessary anymore with the latest toolchains.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2021)
<!-- Reviewable:end -->
