### PR TITLE
crengine: do not compile unused code

### DIFF
--- a/thirdparty/kpvcrlib/crsetup.h.cmake
+++ b/thirdparty/kpvcrlib/crsetup.h.cmake
@@ -75,6 +75,9 @@
 #define USE_LIBUNIBREAK                      1
 #define USE_UTF8PROC                         1
 
+/// Disable unused code.
+#define CR_ENABLE_PAGE_IMAGE_CACHE           0
+
 #endif//CRSETUP_H_INCLUDED
 
 // vim: ft=cpp


### PR DESCRIPTION
This get rid of one `LVRef` related compilation warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2028)
<!-- Reviewable:end -->
