### PR TITLE
harfbuzz: fix android debug build

### DIFF
--- a/thirdparty/harfbuzz/android.patch
+++ b/thirdparty/harfbuzz/android.patch
@@ -13,3 +13,19 @@ index fe466fe1..d728bb99 100644
  #ifndef HB_NO_SETLOCALE
  
  #include <locale.h>
+--- a/src/hb-buffer-verify.cc
++++ b/src/hb-buffer-verify.cc
+@@ -46,11 +46,13 @@
+ {
+   va_list ap;
+   va_start (ap, fmt);
++#ifndef HB_NO_BUFFER_MESSAGE
+   if (buffer->messaging ())
+   {
+     buffer->message_impl (font, fmt, ap);
+   }
+   else
++#endif
+   {
+     fprintf (stderr, "harfbuzz ");
+     vfprintf (stderr, fmt, ap);


### PR DESCRIPTION
```
ld: error: undefined hidden symbol: hb_buffer_t::message_impl(hb_font_t*, char const*, std::__va_list)
>>> referenced by hb-buffer-verify.cc:51 (../source/src/hb-buffer-verify.cc:51)
>>>               hb-buffer-verify.cc.o:(buffer_verify_error(hb_buffer_t*, hb_font_t*, char const*, ...)) in archive […]/build/aarch64-unknown-linux-android21-debug/staging/lib/libharfbuzz.a
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Cf. https://github.com/koreader/koreader/issues/13207.