### PR TITLE
sqlite: update to 3.49.0

### DIFF
--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -12,8 +12,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL f4a55c46043c8a9aecf0b07aa4a42f13
-    https://sqlite.org/2024/sqlite-amalgamation-3470200.zip
+    DOWNLOAD URL cd3ab9d58238ebf5e9b18689181e2805
+    https://sqlite.org/2025/sqlite-amalgamation-3490000.zip
     PATCH_OVERLAY overlay
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -1,43 +1,21 @@
-string(APPEND CPPFLAGS " -DNDEBUG -DSQLITE_DEFAULT_MEMSTATUS=0 -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1 -DSQLITE_LIKE_DOESNT_MATCH_BLOBS -DSQLITE_MAX_EXPR_DEPTH=0 -DSQLITE_OMIT_DECLTYPE -DSQLITE_OMIT_DEPRECATED -DSQLITE_OMIT_PROGRESS_CALLBACK -DSQLITE_OMIT_SHARED_CACHE -DSQLITE_USE_ALLOCA")
-
-list(APPEND CFG_CMD env)
-append_autotools_vars(CFG_CMD)
-list(APPEND CFG_CMD
-    # Explicitly disable zlib, because it's only optionally used by the shell & extensions, and we disable both of those.
-    # This should hopefully prevent Android from picking it up...
-    ac_cv_header_zlib_h=no
-    ${SOURCE_DIR}/configure --host=${CHOST} --prefix=/
-    --disable-$<IF:$<BOOL:${MONOLIBTIC}>,shared,static>
-    --disable-dynamic-extensions
-    --disable-editline
-    --disable-readline
-    --disable-static-shell
-    --enable-$<IF:$<BOOL:${MONOLIBTIC}>,static,shared>
-    --enable-silent-rules
-    --enable-threadsafe
+list(APPEND CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DBUILD_SHARED_LIBS=$<NOT:$<BOOL:${MONOLIBTIC}>>
 )
 
-list(APPEND BUILD_CMD COMMAND make libsqlite3.la)
+list(APPEND BUILD_CMD COMMAND ninja)
 
-list(APPEND INSTALL_CMD COMMAND make
-    DESTDIR=${STAGING_DIR}
-    install-includeHEADERS
-    install-libLTLIBRARIES
-    install-pkgconfigDATA
-)
+list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
 if(NOT MONOLIBTIC)
-    set(LIB_SPEC sqlite3 VERSION 0)
-    if(APPLE)
-        append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
-    endif()
-    append_shared_lib_install_commands(INSTALL_CMD ${LIB_SPEC})
+    append_shared_lib_install_commands(INSTALL_CMD sqlite3 VERSION 0)
 endif()
 
 external_project(
-    DOWNLOAD URL 6bf0697af5b609e186cc223eca9c2cb1
-    https://sqlite.org/2024/sqlite-autoconf-3470200.tar.gz
-    CONFIGURE_COMMAND ${CFG_CMD}
+    DOWNLOAD URL f4a55c46043c8a9aecf0b07aa4a42f13
+    https://sqlite.org/2024/sqlite-amalgamation-3470200.zip
+    PATCH_OVERLAY overlay
+    CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}
 )

--- a/thirdparty/sqlite/overlay/CMakeLists.txt
+++ b/thirdparty/sqlite/overlay/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CHECKS
 )
 while(CHECKS)
     list(POP_FRONT CHECKS HEADER DEFINE)
-    CHECK_INCLUDE_FILE(${HEADER} ${DEFINE})
+    check_include_file(${HEADER} ${DEFINE})
     if(${DEFINE})
         list(APPEND DEFINITIONS ${DEFINE})
     endif()

--- a/thirdparty/sqlite/overlay/CMakeLists.txt
+++ b/thirdparty/sqlite/overlay/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(sqlite LANGUAGES C)
+
+include(CheckIncludeFile)
+include(CheckSymbolExists)
+
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
+set(CMAKE_REQUIRED_FLAGS "-D_GNU_SOURCE -D_REENTRANT")
+
+set(DEFINITIONS _GNU_SOURCE _REENTRANT)
+
+set(CHECKS
+    "inttypes.h" HAVE_INTTYPES_H
+    "stdint.h"   HAVE_STDINT_H
+)
+while(CHECKS)
+    list(POP_FRONT CHECKS HEADER DEFINE)
+    CHECK_INCLUDE_FILE(${HEADER} ${DEFINE})
+    if(${DEFINE})
+        list(APPEND DEFINITIONS ${DEFINE})
+    endif()
+endwhile()
+
+set(CHECKS
+    fdatasync       "unistd.h" HAVE_FDATASYNC
+    gmtime_r        "time.h"   HAVE_GMTIME_R
+    localtime_r     "time.h"   HAVE_LOCALTIME_R
+    posix_fallocate "fcntl.h"  HAVE_POSIX_FALLOCATE
+    strchrnul       "string.h" HAVE_STRCHRNUL
+    strerror_r      "string.h" HAVE_STRERROR_R
+    usleep          "unistd.h" HAVE_USLEEP
+)
+while(CHECKS)
+    list(POP_FRONT CHECKS SYMBOL HEADER DEFINE)
+    check_symbol_exists(${SYMBOL} ${HEADER} ${DEFINE})
+    if(${DEFINE})
+        list(APPEND DEFINITIONS ${DEFINE})
+    endif()
+endwhile()
+
+add_library(sqlite3)
+set_target_properties(sqlite3 PROPERTIES SOVERSION 0)
+target_compile_definitions(sqlite3 PRIVATE
+    ${DEFINITIONS}
+    SQLITE_DEFAULT_MEMSTATUS=0
+    SQLITE_DEFAULT_WAL_SYNCHRONOUS=1
+    SQLITE_ENABLE_FTS4
+    SQLITE_ENABLE_FTS5
+    SQLITE_ENABLE_GEOPOLY
+    SQLITE_ENABLE_MATH_FUNCTIONS
+    SQLITE_ENABLE_RTREE
+    SQLITE_LIKE_DOESNT_MATCH_BLOBS
+    SQLITE_MAX_EXPR_DEPTH=0
+    SQLITE_OMIT_DECLTYPE
+    SQLITE_OMIT_DEPRECATED
+    SQLITE_OMIT_LOAD_EXTENSION=1
+    SQLITE_OMIT_PROGRESS_CALLBACK
+    SQLITE_OMIT_SHARED_CACHE
+    SQLITE_THREADSAFE=1
+    SQLITE_USE_ALLOCA
+)
+target_sources(sqlite3 PRIVATE sqlite3.c)
+target_link_libraries(sqlite3 m Threads::Threads)
+
+install(TARGETS sqlite3)
+install(FILES sqlite3.h sqlite3ext.h TYPE INCLUDE)


### PR DESCRIPTION
- https://sqlite.org/releaselog/3_48_0.html
- https://sqlite.org/releaselog/3_49_0.html

Additionally, switch to cmake for building: version (3.49.0) switches to autosetup, which depends on tclsh. There's a fallback on an automatically compiled jimsh binary, but at this point we might as well switch to the smallest amalgam source distribution plus a custom CMake build (as we only need the library).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2030)
<!-- Reviewable:end -->
