### PR TITLE
luarocks / luasystem: fix build under koreader/kobase-clang:0.3.6-20.04

### DIFF
--- a/thirdparty/luarocks/CMakeLists.txt
+++ b/thirdparty/luarocks/CMakeLists.txt
@@ -12,10 +12,18 @@ list(APPEND BUILD_CMD COMMAND make)
 list(APPEND INSTALL_CMD COMMAND make install)
 
 # Try to use our compilation flags.
+set(LD ${CC})
 set(LIBFLAGS ${DYNLIB_LDFLAGS})
-foreach(VAR CC CFLAGS LIBFLAGS)
+foreach(VAR CC CFLAGS LD LIBFLAGS)
     list(APPEND INSTALL_CMD COMMAND ${STAGING_DIR}/bin/luarocks config -- ${VAR} "${${VAR}}")
 endforeach()
+# Luarocks needs to be told where librt is when building
+# luasystem with clang in our Ubuntu based docker image.
+if(EMULATE_READER AND NOT APPLE)
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -print-file-name=librt.so OUTPUT_VARIABLE RT_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+    get_filename_component(RT_LIBDIR ${RT_LIB} DIRECTORY)
+    list(APPEND INSTALL_CMD COMMAND ${STAGING_DIR}/bin/luarocks config -- RT_LIBDIR "${RT_LIBDIR}")
+endif()
 
 external_project(
     DOWNLOAD URL ab95865ced3c123908bd2f1fe6843606


### PR DESCRIPTION
- need to set `LD` to our compiler (or luasystem will try to use gcc when building with clang)
- set `RT_LIBDIR` (directory where librt is) or luasystem will fail to build with clang

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2041)
<!-- Reviewable:end -->
