### PR TITLE
kobo-usbms: ensure `KoboUSBMS.tar.gz` binaries are stripped

### DIFF
--- a/thirdparty/kobo-usbms/CMakeLists.txt
+++ b/thirdparty/kobo-usbms/CMakeLists.txt
@@ -3,6 +3,8 @@ set(BINARY_DIR ${SOURCE_DIR})
 
 list(APPEND BUILD_CMD COMMAND make CROSS_TC=${CHOST})
 append_autotools_vars(BUILD_CMD)
+# Make sure the binaries in the `KoboUSBMS.tar.gz` archive are stripped.
+list(APPEND BUILD_CMD "STRIP=${STRIP} --strip-unneeded")
 list(APPEND BUILD_CMD kobo)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2042)
<!-- Reviewable:end -->
