### PR TITLE
luarocks / luasystem: fix fix for koreader/kobase-clang:0.3.6-20.04…

### DIFF
--- a/thirdparty/luarocks/CMakeLists.txt
+++ b/thirdparty/luarocks/CMakeLists.txt
@@ -20,9 +20,13 @@ endforeach()
 # Luarocks needs to be told where librt is when building
 # luasystem with clang in our Ubuntu based docker image.
 if(EMULATE_READER AND NOT APPLE)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -print-file-name=librt.so OUTPUT_VARIABLE RT_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
-    get_filename_component(RT_LIBDIR ${RT_LIB} DIRECTORY)
-    list(APPEND INSTALL_CMD COMMAND ${STAGING_DIR}/bin/luarocks config -- RT_LIBDIR "${RT_LIBDIR}")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -print-file-name=librt.so.1 OUTPUT_VARIABLE RT_LIB OUTPUT_STRIP_TRAILING_WHITESPACE)
+    # NOTE: `librt.so.1` may not exists (e.g. when using Alpine Linux),
+    # in which case the compiler will just output `librt.so.1` back.
+    if(NOT RT_LIB STREQUAL "librt.so.1")
+        get_filename_component(RT_LIBDIR ${RT_LIB} DIRECTORY)
+        list(APPEND INSTALL_CMD COMMAND ${STAGING_DIR}/bin/luarocks config -- RT_LIBDIR "${RT_LIBDIR}")
+    endif()
 endif()
 
 external_project(


### PR DESCRIPTION
The `librt.so` library (symlink) may not exists:
- Alpine Linux uses musl libc
- Arch Linux has `librt.so.1` (no `librt.so` symlink)
- Ubuntu only has the `librt.so` symlink when `libc6-dev` is installed

Follow-up to #2041.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2044)
<!-- Reviewable:end -->
