### PR TITLE
BlitBuffer: add partial support for paintRoundedRect using RGB colours

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2078,7 +2078,7 @@ function BB_mt.__index:paintBorder(x, y, w, h, bw, c, r, anti_alias)
 end
 
 --[[
-paintBorder varient that uses ColorRGB32 instead of a luminance value,
+paintBorder variant that uses ColorRGB32 instead of a luminance value,
 no support for rounded corners therefore no need for anti aliasing flag
 --]]
 function BB_mt.__index:paintBorderRGB32(x, y, w, h, bw, c)
@@ -2136,7 +2136,7 @@ function BB_mt.__index:paintRoundedRect(x, y, w, h, c, r)
 end
 
 --[[
-paintRoundedRect varient that uses ColorRGB32 instead of a luminance value
+paintRoundedRect variant that uses ColorRGB32 instead of a luminance value
 --]]
 function BB_mt.__index:paintRoundedRectRGB32(x, y, w, h, c, r)
     x, y = ceil(x), ceil(y)

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2078,6 +2078,19 @@ function BB_mt.__index:paintBorder(x, y, w, h, bw, c, r, anti_alias)
 end
 
 --[[
+paintBorder varient that uses ColorRGB32 instead of a luminance value,
+no support for rounded corners therefore no need for anti aliasing flag
+--]]
+function BB_mt.__index:paintBorderRGB32(x, y, w, h, bw, c)
+    x, y = ceil(x), ceil(y)
+    h, w = ceil(h), ceil(w)
+    self:paintRectRGB32(x, y, w, bw, c)
+    self:paintRectRGB32(x, y+h-bw, w, bw, c)
+    self:paintRectRGB32(x, y+bw, bw, h - 2*bw, c)
+    self:paintRectRGB32(x+w-bw, y+bw, bw, h - 2*bw, c)
+end
+
+--[[
 Draw an inner border
 
 @x:  start position in x axis
@@ -2122,6 +2135,21 @@ function BB_mt.__index:paintRoundedRect(x, y, w, h, c, r)
     end
 end
 
+--[[
+paintRoundedRect varient that uses ColorRGB32 instead of a luminance value
+--]]
+function BB_mt.__index:paintRoundedRectRGB32(x, y, w, h, c, r)
+    x, y = ceil(x), ceil(y)
+    h, w = ceil(h), ceil(w)
+    if not r or r == 0 then
+        self:paintRectRGB32(x, y, w, h, c)
+    else
+        if h < 2*r then r = floor(h/2) end
+        if w < 2*r then r = floor(w/2) end
+        self:paintBorderRGB32(x, y, w, h, r, c)
+        self:paintRectRGB32(x+r, y+r, w-2*r, h-2*r, c)
+    end
+end
 
 --[[
 Paint hatches in a rectangle

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2137,6 +2137,7 @@ end
 
 --[[
 paintRoundedRect variant that uses ColorRGB32 instead of a luminance value
+NOTE: Be aware that `paintBorderRGB32` currently does *NOT* support rounded corners, so this implementation is *also* incomplete!
 --]]
 function BB_mt.__index:paintRoundedRectRGB32(x, y, w, h, c, r)
     x, y = ceil(x), ceil(y)


### PR DESCRIPTION
Add RGB32 variants for paintBorder and paintRoundedRect functions, currently the paintborder variant doesn't have support to rounded corners.

Allows for framecontainers with coloured backgrounds to be used io statistics plugin calendar view.
See: https://github.com/koreader/koreader/pull/13453#issue-2944166320

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2047)
<!-- Reviewable:end -->
