### PR TITLE
fix build with newer CMake versions

### DIFF
--- a/thirdparty/libzmq/cmake_tweaks.patch
+++ b/thirdparty/libzmq/cmake_tweaks.patch
@@ -8,7 +8,7 @@
 +  cmake_minimum_required(VERSION 3.16.3)
  else()
 -  cmake_minimum_required(VERSION 2.8.12)
-+  cmake_minimum_required(VERSION 2.15)
++  cmake_minimum_required(VERSION 3.16.3)
  endif()
  
  include(CheckIncludeFiles)

--- a/thirdparty/lua-rapidjson/cmake_tweaks.patch
+++ b/thirdparty/lua-rapidjson/cmake_tweaks.patch
@@ -1,5 +1,11 @@
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
+ 
+ project(lua-rapidjson)
+ 
 @@ -24,19 +24,6 @@ if (LUA_RAPIDJSON_VERSION)
  endif()
  

--- a/thirdparty/lunasvg/CMakeLists.txt
+++ b/thirdparty/lunasvg/CMakeLists.txt
@@ -1,4 +1,7 @@
-list(APPEND PATCH_FILES extended.patch)
+list(APPEND PATCH_FILES
+    cmake_tweaks.patch
+    extended.patch
+)
 
 list(APPEND CMAKE_ARGS
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}

--- a/thirdparty/lunasvg/cmake_tweaks.patch
+++ b/thirdparty/lunasvg/cmake_tweaks.patch
@@ -1,0 +1,8 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.3)
++cmake_minimum_required(VERSION 3.16.3)
+ 
+ project(lunasvg VERSION 2.3.8 LANGUAGES CXX C)
+ 


### PR DESCRIPTION
Newer CMake versions dropped compatibility with CMake < 3.5:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2048)
<!-- Reviewable:end -->
