### PR TITLE
harfbuzz: update to 11.0.1

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -62,8 +62,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 5c020fc8e60d8a64d149fcd71ff46cc5
-    https://github.com/harfbuzz/harfbuzz/releases/download/10.3.0/harfbuzz-10.3.0.tar.xz
+    DOWNLOAD URL 5de828e8e05c3f69d98c3c34eb6faa5c
+    https://github.com/harfbuzz/harfbuzz/releases/download/11.0.1/harfbuzz-11.0.1.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}


### PR DESCRIPTION
- https://github.com/harfbuzz/harfbuzz/releases/tag/10.4.0
- https://github.com/harfbuzz/harfbuzz/releases/tag/11.0.0
- https://github.com/harfbuzz/harfbuzz/releases/tag/11.0.1

A small code size increase: +30.4 KB for `x86_64-pc-linux-gnu`, +25.6 KB for `arm-kindlepw2-linux-gnueabi`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2049)
<!-- Reviewable:end -->
