### PR TITLE
libwebp: update to 1.5.0

### DIFF
--- a/thirdparty/libwebp/CMakeLists.txt
+++ b/thirdparty/libwebp/CMakeLists.txt
@@ -32,8 +32,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 34869086761c0e2da6361035f7b64771
-    https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.3.2.tar.gz
+    DOWNLOAD URL 8f659e426eaa2aeec4b36bc9ea43b3f3
+    https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.5.0.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
- https://github.com/webmproject/libwebp/releases/tag/v1.4.0
- https://github.com/webmproject/libwebp/releases/tag/v1.5.0

A small code size increase: +11.1 KB for `x86_64-pc-linux-gnu`, +8.3 KB for `arm-kindlepw2-linux-gnueabi`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2050)
<!-- Reviewable:end -->
