### PR TITLE
sdl2: update to 2.32.4

### DIFF
--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -41,8 +41,8 @@ list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 append_shared_lib_install_commands(INSTALL_CMD SDL2-2.0 VERSION 0)
 
 external_project(
-    DOWNLOAD URL 4f4888f48213a400fdaedef38620fe13
-    https://github.com/libsdl-org/SDL/releases/download/release-2.30.12/SDL2-2.30.12.tar.gz
+    DOWNLOAD URL 4decfd2da9ea8534df73ce26f17f2c95
+    https://github.com/libsdl-org/SDL/releases/download/release-2.32.4/SDL2-2.32.4.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/sdl2/cmake_tweaks.patch
+++ b/thirdparty/sdl2/cmake_tweaks.patch
@@ -6,6 +6,6 @@
  
 -cmake_minimum_required(VERSION 3.0.0...3.10)
 +cmake_minimum_required(VERSION 3.16.3)
- project(SDL2 C CXX)
+ project(SDL2 C)
  
  if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)


### PR DESCRIPTION
- https://github.com/libsdl-org/SDL/releases/tag/release-2.32.0
- https://github.com/libsdl-org/SDL/releases/tag/release-2.32.2
- https://github.com/libsdl-org/SDL/releases/tag/release-2.32.4

A small code size reduction: -30.8 K for `x86_64-pc-linux-gnu`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2052)
<!-- Reviewable:end -->
