### PR TITLE
zsync2: fix build

### DIFF
--- a/thirdparty/zsync2/CMakeLists.txt
+++ b/thirdparty/zsync2/CMakeLists.txt
@@ -1,4 +1,4 @@
-list(APPEND PATCH_FILES cpr_cmake_tweaks.patch)
+list(APPEND PATCH_FILES cmake_tweaks.patch)
 
 list(APPEND CMAKE_ARGS
     -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}

--- a/thirdparty/zsync2/cmake_tweaks.patch
+++ b/thirdparty/zsync2/cmake_tweaks.patch
@@ -1,3 +1,11 @@
+--- i/CMakeLists.txt
++++ w/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.2)
++cmake_minimum_required(VERSION 3.16.3)
+ 
+ project(zsync2)
+ 
 --- i/lib/cpr/CMakeLists.txt
 +++ w/lib/cpr/CMakeLists.txt
 @@ -147,13 +147,10 @@ if(CPR_ENABLE_SSL)


### PR DESCRIPTION
Newer CMake versions dropped compatibility with CMake < 3.5.

Missed this in #2048.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2055)
<!-- Reviewable:end -->
