### PR TITLE
tar: disable selinux support

### DIFF
--- a/thirdparty/tar/CMakeLists.txt
+++ b/thirdparty/tar/CMakeLists.txt
@@ -34,6 +34,7 @@ list(APPEND CFG_CMD
     --disable-gcc-warnings
     --disable-nls
     --without-posix-acls
+    --without-selinux
     --without-xattrs
 )
 if(LEGACY OR POCKETBOOK)


### PR DESCRIPTION
We don't need it, and the added dependency on `libselinux.so.1` breaks the AppImage's tar binary on distribution that don't have that library (e.g. Arch Linux).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2061)
<!-- Reviewable:end -->
