### PR TITLE
libiconv: disable NLS support

### DIFF
--- a/thirdparty/libiconv/CMakeLists.txt
+++ b/thirdparty/libiconv/CMakeLists.txt
@@ -3,6 +3,7 @@ append_autotools_vars(CFG_CMD)
 list(APPEND CFG_CMD
     ${SOURCE_DIR}/configure --host=${CHOST} --prefix=/
     --enable-shared=false --enable-static=true
+    --disable-nls
     --with-threads=none
 )
 


### PR DESCRIPTION
To ensure we don't risk pulling a dependency on a (possibly external) libintl library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2067)
<!-- Reviewable:end -->
