### PR TITLE
ci/macos: fix error annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,6 @@ jobs:
             automake
             bash
             binutils
-            cmake
             coreutils
             findutils
             libtool


### PR DESCRIPTION
```
cmake 3.31.6 is already installed
To upgrade to 4.0.1, run:
  brew upgrade cmake
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2069)
<!-- Reviewable:end -->
