### PR TITLE
ffi/crypto: AES ECB decryption, PKCS#7 unpadding

### DIFF
--- a/ffi-cdecl/crypto_decl.c
+++ b/ffi-cdecl/crypto_decl.c
@@ -3,3 +3,13 @@
 #include "ffi-cdecl.h"
 
 cdecl_func(PKCS5_PBKDF2_HMAC_SHA1)
+cdecl_func(EVP_CIPHER_CTX_new);
+cdecl_func(EVP_CIPHER_CTX_free);
+cdecl_func(EVP_CIPHER_CTX_set_padding);
+cdecl_func(EVP_CIPHER_block_size);
+cdecl_func(EVP_DecryptInit_ex);
+cdecl_func(EVP_DecryptUpdate);
+cdecl_func(EVP_DecryptFinal_ex);
+cdecl_func(EVP_aes_128_ecb);
+cdecl_func(EVP_aes_192_ecb);
+cdecl_func(EVP_aes_256_ecb);

--- a/ffi/crypto.lua
+++ b/ffi/crypto.lua
@@ -17,4 +17,74 @@ function crypto.pbkdf2_hmac_sha1(pass, salt, iterations, key_len)
     return ffi.string(buf, key_len)
 end
 
+function crypto.pkcs7_unpad(content, length, block_size)
+    if length <= 0 or (length % block_size) ~= 0 then
+        return nil
+    end
+
+    local padding_length = content[length - 1] -- index is zero-based here
+    if padding_length <= 0 or padding_length > block_size then
+        return nil
+    end
+
+    return ffi.string(content, length - padding_length)
+end
+
+function crypto.get_aes_ecb_cipher(block_size)
+    if block_size == 16 then
+        return libcrypto.EVP_aes_128_ecb()
+    elseif block_size == 24 then
+        return libcrypto.EVP_aes_192_ecb()
+    elseif block_size == 32 then
+        return libcrypto.EVP_aes_256_ecb()
+    else
+        return nil
+    end
+end
+
+function crypto.get_cipher_block_size(cipher)
+    return libcrypto.EVP_CIPHER_block_size(cipher)
+end
+
+function crypto.evp_decrypt(cipher, input, key, iv)
+    if cipher == nil then
+        return nil
+    end
+
+    local context = libcrypto.EVP_CIPHER_CTX_new()
+    if context == nil then
+        return nil
+    end
+
+    if libcrypto.EVP_DecryptInit_ex(context, cipher, nil, key, iv) ~= 1 then
+        libcrypto.EVP_CIPHER_CTX_free(context)
+        return nil
+    end
+
+    if libcrypto.EVP_CIPHER_CTX_set_padding(context, 0) ~= 1 then
+        libcrypto.EVP_CIPHER_CTX_free(context)
+        return nil
+    end
+
+    local block_size = crypto.get_cipher_block_size(cipher)
+    local output = ffi.new("char[?]", #input + block_size)
+    local output_length = ffi.new("int[1]")
+    if libcrypto.EVP_DecryptUpdate(context, output, output_length, input, #input) ~= 1 then
+        libcrypto.EVP_CIPHER_CTX_free(context)
+        return nil
+    end
+
+    output_length = output_length[0]
+    local final_length = ffi.new("int[1]")
+    if libcrypto.EVP_DecryptFinal_ex(context, output + output_length, final_length) ~= 1 then
+        libcrypto.EVP_CIPHER_CTX_free(context)
+        return nil
+    end
+    output_length = output_length + final_length[0]
+
+    libcrypto.EVP_CIPHER_CTX_free(context)
+
+    return output, output_length
+end
+
 return crypto

--- a/ffi/crypto_h.lua
+++ b/ffi/crypto_h.lua
@@ -3,5 +3,19 @@
 local ffi = require("ffi")
 
 ffi.cdef[[
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+typedef struct evp_cipher_st EVP_CIPHER;
+typedef struct engine_st ENGINE;
+
 int PKCS5_PBKDF2_HMAC_SHA1(const char *, int, const unsigned char *, int, int, int, unsigned char *);
+EVP_CIPHER_CTX *EVP_CIPHER_CTX_new();
+void EVP_CIPHER_CTX_free(EVP_CIPHER_CTX *a);
+int EVP_CIPHER_CTX_set_padding(EVP_CIPHER_CTX *c, int pad);
+int EVP_CIPHER_block_size(const EVP_CIPHER *cipher);
+int EVP_DecryptInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher, ENGINE *impl, const unsigned char *key, const unsigned char *iv);
+int EVP_DecryptUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out, int *outl, const unsigned char *in, int inl);
+int EVP_DecryptFinal_ex(EVP_CIPHER_CTX *ctx, unsigned char *outm, int *outl);
+const EVP_CIPHER *EVP_aes_128_ecb();
+const EVP_CIPHER *EVP_aes_192_ecb();
+const EVP_CIPHER *EVP_aes_256_ecb();
 ]]


### PR DESCRIPTION
This commit makes it possible to decrypt buffers encrypted with AES using the ECB mode, and unpad buffers using the PKCS#7 algorithm.

It uses OpenSSL's EVP cipher routines, which are a high-level interface to certain symmetric ciphers. So it should be easy to add support for other ciphers beside AES if needed.