### PR TITLE
use `-fdata-sections -ffunction-sections -Wl,--gc-sections` on all supported targets

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -400,6 +400,10 @@ ifdef KODEBUG
 else
   BASE_CFLAGS += -DNDEBUG
 endif
+ifndef DARWIN
+  # Trim down binary size (when combined with linker `--gc-sections`).
+  BASE_CFLAGS += -fdata-sections -ffunction-sections
+endif
 
 # Misc GCC tricks to ensure backward compatibility with the K2,
 # even when using a fairly recent TC (Linaro/MG).
@@ -456,9 +460,9 @@ ifeq ($(ANDROID_ARCH), arm)
 	ANDROID_ARM_ARCH:=-march=armv7-a -mfpu=vfpv3-d16
 	ANDROID_ARM_ARCH+=-mthumb
 	# NOTE: NDK15c actually uses -fstack-protector-strong
-	ANDROID_ARM_ARCH+=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
+	ANDROID_ARM_ARCH+=-funwind-tables -fstack-protector -no-canonical-prefixes
 else ifeq ($(ANDROID_ARCH), arm64)
-	ANDROID_ARM_ARCH:=-ffunction-sections -funwind-tables -fstack-protector -no-canonical-prefixes
+	ANDROID_ARM_ARCH:=-funwind-tables -fstack-protector -no-canonical-prefixes
 endif
 
 TARGET_MACHINE := $(shell $(CC) -dumpmachine)
@@ -633,7 +637,7 @@ CFLAGS:=$(BASE_CFLAGS) $(QFLAGS) $(CSTD_FLAGS)
 CXXFLAGS:=$(BASE_CFLAGS) $(QFLAGS) $(CXXSTD_FLAGS)
 
 ifndef DARWIN
-  LDFLAGS := -Wl,-O1 -Wl,--as-needed $(COMPAT_LDFLAGS)
+  LDFLAGS := -Wl,-O1,--as-needed,--gc-sections $(COMPAT_LDFLAGS)
   # To prefer our shipped libraries over the system's,
   # we set a couple rpath via an include file to make sure it goes through buildsystem indirection unscathed...
   # NOTE: We enforce DT_RPATH over DT_RUNPATH because DT_RUNPATH is *not* honored for *transitive* dependencies,

--- a/thirdparty/cmake_modules/koreader_targets.cmake
+++ b/thirdparty/cmake_modules/koreader_targets.cmake
@@ -323,7 +323,7 @@ if(MONOLIBTIC)
             # there's no way to tell CMake to add the necessary `-Wl,--end-group` at
             # the end of the line, **after** the libraries. (Proper support is only
             # available from 3.24 onward).
-            target_link_options(koreader-monolibtic PRIVATE -Wl,-Bsymbolic,--gc-sections,--start-group)
+            target_link_options(koreader-monolibtic PRIVATE -Wl,-Bsymbolic,--start-group)
         endif()
         set(CDECLS)
         foreach(NAME IN LISTS KOREADER_TARGETS)


### PR DESCRIPTION
We already used `-ffunction-sections` for Android ARM, and `-Wl,--gc-sections` for the monolibtic library. Extend it to all binaries (`-ffunction-sections` without `--gc-sections` does not make sense), and add `-fdata-sections`.

Code size reduction:

| platform: component     |   reduction        |
| :-                      | -:                 |
| appimage: koreader      |   -2.1 MB ( -7.0%) |
| appimage: sdcv          | -490.8 KB (-49.7%) |
| appimage: tar           |  -10.3 KB ( -2.1%) |
| android-arm: koreader   | -118.5 KB ( -1.0%) |
| android-arm: sdcv       | -354.0 KB (-22.1%) |
| android-arm64: koreader | -196.8 KB ( -1.0%) |
| android-arm64: sdcv     | -485.0 KB (-26.0%) |
| kindlepw2: koreader     |   -1.3 MB ( -6.7%) |
| kindlepw2: dbclient     |   -8.3 KB ( -3.9%) |
| kindlepw2: dropbear     |  -10.2 KB ( -0.8%) |
| kindlepw2: fbink        |  -48.8 KB ( -4.6%) |
| kindlepw2: scp          |  -439   B ( -2.6%) |
| kindlepw2: sdcv         | -318.3 KB (-45.8%) |
| kindlepw2: sftp-server  |  -33.8 KB (-40.1%) |
| kindlepw2: tar          |   -4.6 KB ( -1.5%) |
| kindlepw2: zsync2       | -126.8 KB ( -6.5%) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2075)
<!-- Reviewable:end -->

TODO:
- [x] PR fbink patch
- [x] update fbink
- [x] update kobo-usbms