### PR TITLE
libarchive support

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -260,6 +260,9 @@ declare_project(thirdparty/kobo-usbms ${EXCLUDE_FROM_ALL})
 # leptonica
 declare_project(thirdparty/leptonica DEPENDS libpng)
 
+# libarchive
+declare_project(thirdparty/libarchive DEPENDS zlib zstd)
+
 # libiconv
 declare_project(thirdparty/libiconv EXCLUDE_FROM_ALL)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -554,6 +554,9 @@ endforeach()
 # leptonica
 ffi_target(leptonica leptonica_h.lua leptonica_cdecl.c ARGS -d lept)
 
+# libarchive
+ffi_target(libarchive libarchive_h.lua libarchive_cdecl.c ARGS -d libarchive)
+
 # libjpeg-turbo
 ffi_target(libjpeg-turbo turbojpeg_h.lua turbojpeg_decl.c ARGS -d libturbojpeg)
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -344,7 +344,7 @@ declare_project(thirdparty/md4c EXCLUDE_FROM_ALL)
 declare_project(thirdparty/minizip EXCLUDE_FROM_ALL)
 
 # mupdf
-declare_project(thirdparty/mupdf DEPENDS freetype2 harfbuzz libjpeg-turbo libwebp minizip zlib)
+declare_project(thirdparty/mupdf DEPENDS freetype2 harfbuzz libarchive libjpeg-turbo libwebp minizip zlib)
 
 # nanosvg
 declare_project(thirdparty/nanosvg)

--- a/ffi-cdecl/libarchive_cdecl.c
+++ b/ffi-cdecl/libarchive_cdecl.c
@@ -1,0 +1,50 @@
+// FIXME: ffi-cdecl is not doing the right thing when using:
+//
+// typedef int64_t la_int64_t;
+// typedef ssize_t la_ssize_t;
+//
+#include <sys/types.h>
+#include <stdint.h>
+#define __LA_INT64_T_DEFINED
+#define la_int64_t int64_t
+#define __LA_SSIZE_T_DEFINED
+#define la_ssize_t ssize_t
+
+#include <archive.h>
+#include <archive_entry.h>
+
+#include "ffi-cdecl.h"
+
+cdecl_const(AE_IFMT)
+cdecl_const(AE_IFREG)
+cdecl_const(AE_IFLNK)
+cdecl_const(AE_IFSOCK)
+cdecl_const(AE_IFCHR)
+cdecl_const(AE_IFBLK)
+cdecl_const(AE_IFDIR)
+cdecl_const(AE_IFIFO)
+
+cdecl_const(ARCHIVE_OK)
+
+cdecl_func(archive_entry_free)
+cdecl_func(archive_entry_new)
+cdecl_func(archive_entry_set_filetype)
+cdecl_func(archive_entry_set_mtime)
+cdecl_func(archive_entry_set_pathname)
+cdecl_func(archive_entry_set_perm)
+cdecl_func(archive_entry_set_size)
+
+cdecl_func(archive_error_string)
+
+cdecl_func(archive_write_add_filter_none)
+cdecl_func(archive_write_add_filter_compress)
+cdecl_func(archive_write_close)
+cdecl_func(archive_write_data)
+cdecl_func(archive_write_free)
+cdecl_func(archive_write_header)
+cdecl_func(archive_write_new)
+cdecl_func(archive_write_open_filename)
+cdecl_func(archive_write_set_format_zip)
+
+cdecl_func(archive_write_zip_set_compression_deflate)
+cdecl_func(archive_write_zip_set_compression_store)

--- a/ffi/libarchive_h.lua
+++ b/ffi/libarchive_h.lua
@@ -1,0 +1,34 @@
+-- Automatically generated with ffi-cdecl.
+
+local ffi = require("ffi")
+
+ffi.cdef[[
+static const int AE_IFMT = 61440;
+static const int AE_IFREG = 32768;
+static const int AE_IFLNK = 40960;
+static const int AE_IFSOCK = 49152;
+static const int AE_IFCHR = 8192;
+static const int AE_IFBLK = 24576;
+static const int AE_IFDIR = 16384;
+static const int AE_IFIFO = 4096;
+static const int ARCHIVE_OK = 0;
+void archive_entry_free(struct archive_entry *);
+struct archive_entry *archive_entry_new(void);
+void archive_entry_set_filetype(struct archive_entry *, unsigned int);
+void archive_entry_set_mtime(struct archive_entry *, long int, long int);
+void archive_entry_set_pathname(struct archive_entry *, const char *);
+void archive_entry_set_perm(struct archive_entry *, unsigned int);
+void archive_entry_set_size(struct archive_entry *, int64_t);
+const char *archive_error_string(struct archive *);
+int archive_write_add_filter_none(struct archive *);
+int archive_write_add_filter_compress(struct archive *);
+int archive_write_close(struct archive *);
+ssize_t archive_write_data(struct archive *, const void *, size_t);
+int archive_write_free(struct archive *);
+int archive_write_header(struct archive *, struct archive_entry *);
+struct archive *archive_write_new(void);
+int archive_write_open_filename(struct archive *, const char *);
+int archive_write_set_format_zip(struct archive *);
+int archive_write_zip_set_compression_deflate(struct archive *);
+int archive_write_zip_set_compression_store(struct archive *);
+]]

--- a/ffi/zipwriter.lua
+++ b/ffi/zipwriter.lua
@@ -1,44 +1,10 @@
 --[[--
-Zip packing workflow & code from luarocks' zip.lua :
-   https://github.com/luarocks/luarocks/blob/master/src/luarocks/tools/zip.lua
- Modified to not require lua-zlib (we can wrap zlib with ffi)
-   cf: http://luajit.org/ext_ffi_tutorial.html, which uses zlib as an example !
- Simplified to take filename and content from strings and not from disk
-
 @module ffi.zipwriter
 ]]
 
--- We only need a few functions from zlib
-local bit = require "bit"
 local ffi = require "ffi"
-require "ffi/zlib_h"
-
--- We only need to wrap 2 zlib functions to make a zip file
-local _zlib = ffi.loadlib("z", 1)
-local function zlibCompress(data)
-    local n = _zlib.compressBound(#data)
-    local buf = ffi.new("uint8_t[?]", n)
-    local buflen = ffi.new("unsigned long[1]", n)
-    local res = _zlib.compress2(buf, buflen, data, #data, 9)
-    assert(res == 0)
-    return ffi.string(buf, buflen[0])
-end
-local function zlibCrc32(data, chksum)
-    chksum = chksum or 0
-    data = data or ""
-    return _zlib.crc32(chksum, data, #data)
-end
-
-local function numberToByteString(number, nbytes)
-    local out = {}
-    for _ = 1, nbytes do
-        local byte = number % 256
-        table.insert(out, string.char(byte))
-        number = (number - byte) / 256
-    end
-    return table.concat(out)
-end
-
+local libarchive = ffi.loadlib("archive", "13")
+require "ffi/libarchive_h"
 
 -- Pure lua zip writer
 local ZipWriter = {}
@@ -50,153 +16,45 @@ function ZipWriter:new()
     return o
 end
 
---- Begin a new file to be stored inside the zipfile.
-function ZipWriter:_open_new_file_in_zip(filename)
-    if self.in_open_file then
-        self:_close_file_in_zip()
-        return nil
-    end
-    local lfh = {}
-    self.local_file_header = lfh
-    lfh.last_mod_file_time = self.started_time -- 0 = 00:00
-    lfh.last_mod_file_date = self.started_date -- 0 = 1980-00-00 00:00
-    lfh.file_name_length = #filename
-    lfh.extra_field_length = 0
-    lfh.file_name = filename:gsub("\\", "/")
-    lfh.external_attr = 0
-    self.in_open_file = true
-    return true
-end
-
---- Write data to the file currently being stored in the zipfile.
-function ZipWriter:_write_file_in_zip(data, no_compression)
-    if not self.in_open_file then
-        return nil
-    end
-    local lfh = self.local_file_header
-    lfh.crc32 = tonumber(zlibCrc32(data))
-    lfh.uncompressed_size = #data
-    if no_compression then
-        lfh.compressed_size = lfh.uncompressed_size
-        self.data = data
-        lfh._no_compression = true
-    else
-        local compressed = zlibCompress(data):sub(3, -5)
-        lfh.compressed_size = #compressed
-        self.data = compressed
-    end
-    return true
-end
-
---- Complete the writing of a file stored in the zipfile.
-function ZipWriter:_close_file_in_zip()
-    local zh = self.ziphandle
-    if not self.in_open_file then
-        return nil
-    end
-    -- Local file header
-    local lfh = self.local_file_header
-    lfh.offset = zh:seek()
-    zh:write(numberToByteString(0x04034b50, 4)) -- signature
-    zh:write(numberToByteString(20, 2)) -- version needed to extract: 2.0
-    zh:write(numberToByteString(0, 2)) -- general purpose bit flag
-    if lfh._no_compression then
-        zh:write(numberToByteString(0, 2)) -- compression method: store
-    else
-        zh:write(numberToByteString(8, 2)) -- compression method: deflate
-    end
-    zh:write(numberToByteString(lfh.last_mod_file_time, 2))
-    zh:write(numberToByteString(lfh.last_mod_file_date, 2))
-    zh:write(numberToByteString(lfh.crc32, 4))
-    zh:write(numberToByteString(lfh.compressed_size, 4))
-    zh:write(numberToByteString(lfh.uncompressed_size, 4))
-    zh:write(numberToByteString(lfh.file_name_length, 2))
-    zh:write(numberToByteString(lfh.extra_field_length, 2))
-    zh:write(lfh.file_name)
-    -- File data
-    zh:write(self.data)
-    -- Data descriptor
-    zh:write(numberToByteString(lfh.crc32, 4))
-    zh:write(numberToByteString(lfh.compressed_size, 4))
-    zh:write(numberToByteString(lfh.uncompressed_size, 4))
-    -- Done, add it to list of files
-    table.insert(self.files, lfh)
-    self.in_open_file = false
-    return true
-end
-
 --- Complete the writing of the zipfile.
 function ZipWriter:close()
-    local zh = self.ziphandle
-    local central_directory_offset = zh:seek()
-    local size_of_central_directory = 0
-    -- Central directory structure
-    for _, lfh in ipairs(self.files) do
-        zh:write(numberToByteString(0x02014b50, 4)) -- signature
-        zh:write(numberToByteString(3, 2)) -- version made by: UNIX
-        zh:write(numberToByteString(20, 2)) -- version needed to extract: 2.0
-        zh:write(numberToByteString(0, 2)) -- general purpose bit flag
-        if lfh._no_compression then
-            zh:write(numberToByteString(0, 2)) -- compression method: store
-        else
-            zh:write(numberToByteString(8, 2)) -- compression method: deflate
-        end
-        zh:write(numberToByteString(lfh.last_mod_file_time, 2))
-        zh:write(numberToByteString(lfh.last_mod_file_date, 2))
-        zh:write(numberToByteString(lfh.crc32, 4))
-        zh:write(numberToByteString(lfh.compressed_size, 4))
-        zh:write(numberToByteString(lfh.uncompressed_size, 4))
-        zh:write(numberToByteString(lfh.file_name_length, 2))
-        zh:write(numberToByteString(lfh.extra_field_length, 2))
-        zh:write(numberToByteString(0, 2)) -- file comment length
-        zh:write(numberToByteString(0, 2)) -- disk number start
-        zh:write(numberToByteString(0, 2)) -- internal file attributes
-        zh:write(numberToByteString(lfh.external_attr, 4)) -- external file attributes
-        zh:write(numberToByteString(lfh.offset, 4)) -- relative offset of local header
-        zh:write(lfh.file_name)
-        size_of_central_directory = size_of_central_directory + 46 + lfh.file_name_length
-    end
-    -- End of central directory record
-    zh:write(numberToByteString(0x06054b50, 4)) -- signature
-    zh:write(numberToByteString(0, 2)) -- number of this disk
-    zh:write(numberToByteString(0, 2)) -- number of disk with start of central directory
-    zh:write(numberToByteString(#self.files, 2)) -- total number of entries in the central dir on this disk
-    zh:write(numberToByteString(#self.files, 2)) -- total number of entries in the central dir
-    zh:write(numberToByteString(size_of_central_directory, 4))
-    zh:write(numberToByteString(central_directory_offset, 4))
-    zh:write(numberToByteString(0, 2)) -- zip file comment length
-    zh:close()
+    libarchive.archive_write_close(self.archive)
+    libarchive.archive_write_free(self.archive)
+    self.archive = nil
     return true
 end
 
 -- Open zipfile
 function ZipWriter:open(zipfilepath)
-    self.files = {}
-    self.in_open_file = false
-    -- set modification date and time of files to now
-    local t = os.date("*t")
-    self.started_date = bit.bor(
-        bit.lshift(t.year-1980, 9),
-        bit.lshift(t.month,     5),
-        bit.lshift(t.day,       0)
-    )
-    self.started_time = bit.bor(
-        bit.lshift(t.hour,     11),
-        bit.lshift(t.min,       5),
-        bit.rshift(t.sec+2,     1)
-    )
-    self.ziphandle = io.open(zipfilepath, "wb")
-    if not self.ziphandle then
-        return nil
+    self.archive = libarchive.archive_write_new()
+    self.started_time = os.time()
+    libarchive.archive_write_set_format_zip(self.archive)
+    if libarchive.archive_write_open_filename(self.archive, zipfilepath) ~= libarchive.ARCHIVE_OK then
+        local err = ffi.string(libarchive.archive_error_string(self.archive))
+        print("archive_write_open_filename failed:", err)
+        libarchive.archive_write_free(self.archive)
+        self.archive = nil
+        return false
     end
     return true
 end
 
 -- Add to zipfile content with the name in_zip_filepath
 function ZipWriter:add(in_zip_filepath, content, no_compression)
-    self:_open_new_file_in_zip(in_zip_filepath)
-    self:_write_file_in_zip(content, no_compression)
-    self:_close_file_in_zip()
+    local entry = libarchive.archive_entry_new()
+    libarchive.archive_entry_set_pathname(entry, in_zip_filepath)
+    libarchive.archive_entry_set_size(entry, #content)
+    libarchive.archive_entry_set_filetype(entry, libarchive.AE_IFREG)
+    libarchive.archive_entry_set_mtime(entry, self.started_time, 0);
+    libarchive.archive_entry_set_perm(entry, 0644);
+    if no_compression then
+        libarchive.archive_write_zip_set_compression_store(self.archive)
+    else
+        libarchive.archive_write_zip_set_compression_deflate(self.archive)
+    end
+    libarchive.archive_write_header(self.archive, entry);
+    libarchive.archive_write_data(self.archive, content, #content)
+    libarchive.archive_entry_free(entry)
 end
 
 -- Convenience function

--- a/thirdparty/cmake_modules/koreader_targets.cmake
+++ b/thirdparty/cmake_modules/koreader_targets.cmake
@@ -290,6 +290,7 @@ if(MONOLIBTIC)
         DEPENDS ${DEPENDS}
         # We still need to manually add some transitive dependencies because
         # CMake is shit at handling mutiple level of static libraries.
+        libarchive::libarchive
         czmq::czmq
         freetype2::freetype
         giflib::gif

--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -182,7 +182,7 @@ if(ANDROID)
 endif()
 declare_dependency(
     mupdf::mupdf
-    MONOLIBTIC freetype harfbuzz jpeg webp webpdemux z
+    MONOLIBTIC archive freetype harfbuzz jpeg webp webpdemux z
     STATIC mupdf mupdf-third aes
     LIBRARIES ${LIBRARIES}
 )

--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -81,6 +81,9 @@ declare_dependency(giflib::gif MONOLIBTIC gif)
 # harfbuzz
 declare_dependency(harfbuzz::harfbuzz INCLUDES freetype2 harfbuzz MONOLIBTIC harfbuzz)
 
+# libarchive
+declare_dependency(libarchive::libarchive MONOLIBTIC archive)
+
 # leptonica
 declare_dependency(leptonica::leptonica INCLUDES leptonica MONOLIBTIC leptonica)
 

--- a/thirdparty/libarchive/CMakeLists.txt
+++ b/thirdparty/libarchive/CMakeLists.txt
@@ -1,0 +1,54 @@
+if(ANDROID)
+    list(APPEND PATCH_FILES android.patch)
+    list(APPEND PATCH_CMD COMMAND mv contrib/android/include/android_lf.h libarchive/)
+endif()
+
+list(APPEND CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DBUILD_SHARED_LIBS=$<NOT:$<BOOL:${MONOLIBTIC}>>
+    # Project options.
+    -DENABLE_ACL=FALSE
+    -DENABLE_BZip2=FALSE
+    -DENABLE_CAT=FALSE
+    -DENABLE_CNG=FALSE
+    -DENABLE_CPIO=FALSE
+    -DENABLE_EXPAT=FALSE
+    -DENABLE_ICONV=FALSE
+    -DENABLE_LIBB2=FALSE
+    -DENABLE_LIBXML2=FALSE
+    -DENABLE_LZ4=FALSE
+    -DENABLE_LZMA=FALSE
+    -DENABLE_OPENSSL=FALSE
+    -DENABLE_PCRE2POSIX=FALSE
+    -DENABLE_PCREPOSIX=FALSE
+    -DENABLE_TAR=FALSE
+    -DENABLE_TEST=FALSE
+    -DENABLE_UNZIP=FALSE
+    -DENABLE_WERROR=FALSE
+    -DENABLE_XATTR=FALSE
+)
+# Avoid pulling > GLIBC_2.4 symbols on crappy platforms.
+if(LEGACY OR POCKETBOOK)
+    list(APPEND CMAKE_ARGS
+        -DHAVE_FUTIMENS=FALSE
+        -DHAVE_UTIMENSAT=FALSE
+    )
+endif()
+
+list(APPEND BUILD_CMD COMMAND ninja)
+
+list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
+
+if(NOT MONOLIBTIC)
+    append_shared_lib_install_commands(INSTALL_CMD archive VERSION 13)
+endif()
+
+external_project(
+    DOWNLOAD URL e378aeb163d8c81745665dddd81116ef
+    https://github.com/libarchive/libarchive/releases/download/v3.7.9/libarchive-3.7.9.tar.xz
+    CMAKE_ARGS ${CMAKE_ARGS}
+    PATCH_FILES ${PATCH_FILES}
+    PATCH_COMMAND ${PATCH_CMD}
+    BUILD_COMMAND ${BUILD_CMD}
+    INSTALL_COMMAND ${INSTALL_CMD}
+)

--- a/thirdparty/libarchive/android.patch
+++ b/thirdparty/libarchive/android.patch
@@ -1,0 +1,11 @@
+--- i/libarchive/archive_read_disk_posix.c
++++ w/libarchive/archive_read_disk_posix.c
+@@ -1825,7 +1825,7 @@
+ 		/* pathconf(_PC_REX_*) operations are not supported. */
+ #if defined(HAVE_STATVFS)
+ 		set_statvfs_transfer_size(t->current_filesystem, &svfs);
+-#else
++#elif defined(HAVE_STRUCT_STATFS)
+ 		set_statfs_transfer_size(t->current_filesystem, &sfs);
+ #endif
+ 	}

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -57,6 +57,7 @@ string(APPEND XCFLAGS
     " -DFZ_ENABLE_JS=0"
     " -DFZ_PLOTTERS_CMYK=0"
     " -DHAVE_LIBAES=1"
+    " -DHAVE_LIBARCHIVE=1"
     " -DHAVE_WEBP=1"
 )
 if(ANDROID AND CHOST MATCHES "^armv7a-.*")
@@ -85,6 +86,10 @@ set(MAKE_CMD
     USE_SYSTEM_HARFBUZZ=yes
     SYS_HARFBUZZ_CFLAGS=-I${STAGING_DIR}/include/harfbuzz
     SYS_HARFBUZZ_LIBS=
+    # - libarchive
+    USE_SYSTEM_LIBARCHIVE=yes
+    SYS_LIBARCHIVE_CFLAGS=-I${STAGING_DIR}/include
+    SYS_LIBARCHIVE_LIBS=
     # - libjpeg
     USE_SYSTEM_LIBJPEG=yes
     SYS_LIBJPEG_LIBS=


### PR DESCRIPTION
- add libarchive 3.7.9:
  - compiled with zlib+zstd support
  - only the library for now (we could look at replacing `tar` with `bsdtar`)
- re-implement ZipWriter using libarchive
- enable MuPDF libarchive support

Code size increase:
|               |                   |
|:-             |:-                 |
| emulator      | +735.9 KB (+2.7%) |
| kindlepw2     | +458.0 KB (+2.5%) |
| android-arm   | +262.4 KB (+1.8%) |
| android-arm64 | +349.8 KB (+1.8%) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2083)
<!-- Reviewable:end -->
