### PR TITLE
cmake: bump minimum required version to 3.17.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(koreader LANGUAGES C CXX)
 
 include(${CMAKE_KOVARS})

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -796,7 +796,7 @@ endif
 # Native & cross definitions.
 define cmake_toolchain
 
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 
 # CMake Cross ToolChain config file. Adapted from Debian's dpkg-cross ;).
 # c.f., https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-toolchain

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(koreader-base LANGUAGES C CXX)
 
 include(CheckFunctionExists)

--- a/thirdparty/czmq/cmake_tweaks.patch
+++ b/thirdparty/czmq/cmake_tweaks.patch
@@ -5,7 +5,7 @@
  # Project setup
  ########################################################################
 -cmake_minimum_required(VERSION 2.8.12)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  project(czmq)
  enable_language(C)
  enable_testing()

--- a/thirdparty/giflib/overlay/CMakeLists.txt
+++ b/thirdparty/giflib/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(giflib LANGUAGES C)
 
 add_library(gif)

--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(koreader LANGUAGES C CXX)
 
 include(${CMAKE_KOVARS})

--- a/thirdparty/leptonica/cmake_tweaks.patch
+++ b/thirdparty/leptonica/cmake_tweaks.patch
@@ -6,7 +6,7 @@
  
 -cmake_minimum_required(VERSION 3.5)
 -cmake_policy(SET CMP0054 NEW)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  
  # In-source builds are disabled.
  if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")

--- a/thirdparty/libressl/cmake_tweaks.patch
+++ b/thirdparty/libressl/cmake_tweaks.patch
@@ -2,7 +2,7 @@
 +++ w/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required (VERSION 3.16.4)
-+cmake_minimum_required (VERSION 3.16.3)
++cmake_minimum_required (VERSION 3.17.5)
  if(MSVC)
  	cmake_policy(SET CMP0091 NEW)
  endif()

--- a/thirdparty/libzmq/cmake_tweaks.patch
+++ b/thirdparty/libzmq/cmake_tweaks.patch
@@ -5,10 +5,10 @@
  
  if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
 -  cmake_minimum_required(VERSION 3.0.2)
-+  cmake_minimum_required(VERSION 3.16.3)
++  cmake_minimum_required(VERSION 3.17.5)
  else()
 -  cmake_minimum_required(VERSION 2.8.12)
-+  cmake_minimum_required(VERSION 3.16.3)
++  cmake_minimum_required(VERSION 3.17.5)
  endif()
  
  include(CheckIncludeFiles)

--- a/thirdparty/lodepng/overlay/CMakeLists.txt
+++ b/thirdparty/lodepng/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(lodepng LANGUAGES C)
 
 file(WRITE lodepng.c "#include \"lodepng.cpp\"\n")

--- a/thirdparty/lpeg/overlay/CMakeLists.txt
+++ b/thirdparty/lpeg/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(lpeg LANGUAGES C)
 
 find_package(PkgConfig REQUIRED)

--- a/thirdparty/lua-rapidjson/cmake_tweaks.patch
+++ b/thirdparty/lua-rapidjson/cmake_tweaks.patch
@@ -2,7 +2,7 @@
 +++ w/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
-+cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.17.5 FATAL_ERROR)
  
  project(lua-rapidjson)
  

--- a/thirdparty/luasec/overlay/CMakeLists.txt
+++ b/thirdparty/luasec/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(luasec LANGUAGES C)
 
 find_package(OpenSSL REQUIRED)

--- a/thirdparty/luasocket/overlay/CMakeLists.txt
+++ b/thirdparty/luasocket/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(luasocket LANGUAGES C)
 
 find_package(PkgConfig REQUIRED)

--- a/thirdparty/lunasvg/cmake_tweaks.patch
+++ b/thirdparty/lunasvg/cmake_tweaks.patch
@@ -2,7 +2,7 @@
 +++ w/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.3)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  
  project(lunasvg VERSION 2.3.8 LANGUAGES CXX C)
  

--- a/thirdparty/md4c/cmake_tweaks.patch
+++ b/thirdparty/md4c/cmake_tweaks.patch
@@ -3,7 +3,7 @@
 @@ -1,5 +1,5 @@
  
 -cmake_minimum_required(VERSION 3.5)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  project(MD4C C)
  
  set(MD_VERSION_MAJOR 0)

--- a/thirdparty/minizip/overlay/CMakeLists.txt
+++ b/thirdparty/minizip/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(minizip LANGUAGES C)
 
 file(GLOB AES_SRC aes/*.c)

--- a/thirdparty/popen-noshell/overlay/CMakeLists.txt
+++ b/thirdparty/popen-noshell/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(popen-noshell LANGUAGES C)
 
 add_library(popen_noshell STATIC popen_noshell.c)

--- a/thirdparty/sdl2/appimage.patch
+++ b/thirdparty/sdl2/appimage.patch
@@ -1,7 +1,7 @@
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
 @@ -8,6 +8,13 @@
- cmake_minimum_required(VERSION 3.16.3)
+ cmake_minimum_required(VERSION 3.17.5)
  project(SDL2 C CXX)
  
 +execute_process(COMMAND pkg-config --variable pc_path pkg-config RESULT_VARIABLE RET OUTPUT_VARIABLE OUT OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/thirdparty/sdl2/cmake_tweaks.patch
+++ b/thirdparty/sdl2/cmake_tweaks.patch
@@ -5,7 +5,7 @@
  set(CMAKE_POLICY_DEFAULT_CMP0091 NEW)
  
 -cmake_minimum_required(VERSION 3.0.0...3.10)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  project(SDL2 C)
  
  if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)

--- a/thirdparty/sqlite/overlay/CMakeLists.txt
+++ b/thirdparty/sqlite/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(sqlite LANGUAGES C)
 
 include(CheckIncludeFile)

--- a/thirdparty/tesseract/cmake_tweaks.patch
+++ b/thirdparty/tesseract/cmake_tweaks.patch
@@ -5,7 +5,7 @@
  # ##############################################################################
  
 -cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-+cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
++cmake_minimum_required(VERSION 3.17.5 FATAL_ERROR)
  
  # In-source builds are disabled.
  if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_BINARY_DIR}")

--- a/thirdparty/turbo/overlay/CMakeLists.txt
+++ b/thirdparty/turbo/overlay/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16.3)
+cmake_minimum_required(VERSION 3.17.5)
 project(turbo LANGUAGES C)
 
 find_package(OpenSSL REQUIRED)

--- a/thirdparty/zsync2/cmake_tweaks.patch
+++ b/thirdparty/zsync2/cmake_tweaks.patch
@@ -2,7 +2,7 @@
 +++ w/CMakeLists.txt
 @@ -1,4 +1,4 @@
 -cmake_minimum_required(VERSION 3.2)
-+cmake_minimum_required(VERSION 3.16.3)
++cmake_minimum_required(VERSION 3.17.5)
  
  project(zsync2)
  


### PR DESCRIPTION
We need at least 3.17 for libarchive, and Ubuntu 22.04 provides 3.22.1. Additionally, CMake support for versions <3.17 is deprecated since Meson 0.62.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2085)
<!-- Reviewable:end -->
