### PR TITLE
fbink / fbdepth / libfbink_input: fix duplicate downloads

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -214,8 +214,10 @@ else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)
 endif()
 declare_project(thirdparty/fbink ${EXCLUDE_FROM_ALL})
+set(fbdepth_DOWNLOAD_DIR ${fbink_DOWNLOAD_DIR})
 set(fbdepth_CMAKE_SOURCE_DIR ${fbink_CMAKE_SOURCE_DIR})
 declare_project(thirdparty/libfbink_input ${EXCLUDE_FROM_ALL})
+set(libfbink_input_DOWNLOAD_DIR ${fbink_DOWNLOAD_DIR})
 set(libfbink_input_CMAKE_SOURCE_DIR ${fbink_CMAKE_SOURCE_DIR})
 
 # ffi-cdecl

--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -178,7 +178,7 @@ clone_git_repo() { (
     clone_depth=50
     mkdir -p "${repo%/*}"
     (
-        flock -n 9
+        flock 9
         # Try the clone 3 times in case there is an odd git clone issue.
         error=1
         for timeout in 0 2 4; do
@@ -244,7 +244,7 @@ checkout_git_repo() { (
     revision="$3"
     shift 3
     rm -rf "${tree}" || return 1
-    (flock -n 9 && cp -a "${repo}" "${tree}") 9>"${repo}.lock" || return 1
+    (flock 9 && cp -a "${repo}" "${tree}") 9>"${repo}.lock" || return 1
     # Same as above in `checkout_git_repo`.
     # shellcheck disable=SC2031
     export GIT_DIR="${tree}/.git"


### PR DESCRIPTION
The intent was always to use the same git clone.

Je devais pas avoir les yeux en face des trous quand j'ai codé cette portion… :P

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2093)
<!-- Reviewable:end -->
