### PR TITLE
tar: don't build it for the emulator target

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -388,7 +388,7 @@ declare_project(thirdparty/sdl2 ${EXCLUDE_FROM_ALL})
 declare_project(thirdparty/sqlite)
 
 # tar
-if(NOT ANDROID AND NOT APPLE AND NOT WIN32)
+if(NOT (ANDROID OR APPLE OR EMULATE_READER OR WIN32))
     set(EXCLUDE_FROM_ALL)
 else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)


### PR DESCRIPTION
No need for it now that libarchive is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2095)
<!-- Reviewable:end -->
