### PR TITLE
mupdf: update to 1.26.1

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -34,7 +34,7 @@ local mupdf = {
 }
 -- this cannot get adapted by the cdecl file because it is a
 -- string constant. Must match the actual mupdf API:
-local FZ_VERSION = "1.25.6"
+local FZ_VERSION = "1.26.1"
 
 local document_mt = { __index = {} }
 local page_mt = { __index = {} }

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -90,7 +90,11 @@ struct fz_outline {
   float y;
   struct fz_outline *next;
   struct fz_outline *down;
-  int is_open;
+  unsigned int is_open : 1;
+  unsigned int flags : 7;
+  unsigned char r;
+  unsigned char g;
+  unsigned char b;
 };
 typedef struct {
   int abort;
@@ -111,7 +115,7 @@ int fz_authenticate_password(fz_context *, fz_document *, const char *);
 void fz_drop_document(fz_context *, fz_document *);
 int mupdf_count_pages(fz_context *, fz_document *);
 void *mupdf_layout_document(fz_context *, fz_document *, float, float, float);
-int fz_lookup_metadata(fz_context *, fz_document *, const char *, char *, int);
+int fz_lookup_metadata(fz_context *, fz_document *, const char *, char *, size_t);
 fz_page *mupdf_load_page(fz_context *, fz_document *, int);
 fz_rect *mupdf_fz_bound_page(fz_context *, fz_page *, fz_rect *);
 void fz_drop_page(fz_context *, fz_page *);
@@ -164,6 +168,7 @@ struct fz_stext_block {
     struct {
       fz_stext_line *first_line;
       fz_stext_line *last_line;
+      int flags;
     } t;
     struct {
       fz_matrix transform;
@@ -174,7 +179,7 @@ struct fz_stext_block {
       int index;
     } s;
     struct {
-      uint8_t stroked;
+      uint32_t flags;
       uint32_t argb;
     } v;
     struct {
@@ -188,6 +193,7 @@ struct fz_stext_block {
 typedef struct {
   int flags;
   float scale;
+  fz_rect clip;
 } fz_stext_options;
 typedef struct {
   struct fz_pool *pool;
@@ -299,6 +305,7 @@ typedef struct {
   int do_preserve_metadata;
   int do_use_objstms;
   int compression_effort;
+  int do_labels;
 } pdf_write_options;
 void *mupdf_pdf_save_document(fz_context *, pdf_document *, const char *, pdf_write_options *);
 fz_alloc_context *mupdf_get_my_alloc_context();

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -23,7 +23,9 @@ list(APPEND PATCH_FILES
     css_color_names.patch
 )
 
+# Remove unnecessary vendored thirdparty libraries.
 list(APPEND PATCH_CMD COMMAND rm -rf
+    thirdparty/brotli
     thirdparty/curl
     thirdparty/freeglut
     thirdparty/freetype
@@ -32,7 +34,9 @@ list(APPEND PATCH_CMD COMMAND rm -rf
     thirdparty/libjpeg
     thirdparty/mujs
     thirdparty/tesseract
+    thirdparty/zint
     thirdparty/zlib
+    thirdparty/zxing-cpp
 )
 
 string(TOLOWER ${CMAKE_BUILD_TYPE} MUPDF_BUILD_TYPE)
@@ -50,11 +54,8 @@ string(APPEND XCFLAGS
     " ${CFLAGS} -fvisibility=hidden"
     # Disable a couple of things to save a small bit of space:
     # - builtin fonts
-    # - color profile support
     # - CMYK plotter only 100 kB
-    # - javascript (for form data validation) close to 800 kB
     " -DNOBUILTINFONT"
-    " -DFZ_ENABLE_JS=0"
     " -DFZ_PLOTTERS_CMYK=0"
     " -DHAVE_LIBAES=1"
     " -DHAVE_LIBARCHIVE=1"
@@ -74,6 +75,12 @@ set(MAKE_CMD
     CXX=${CXX}
     LDFLAGS=
     XCFLAGS=${XCFLAGS}
+    USE_ARGUMENT_FILE=no
+    # Disable some features.
+    barcode=no
+    brotli=no
+    mujs=no
+    tesseract=no
     # Disable some vendored libraries:
     # - curl
     USE_SYSTEM_CURL=yes
@@ -93,9 +100,6 @@ set(MAKE_CMD
     # - libjpeg
     USE_SYSTEM_LIBJPEG=yes
     SYS_LIBJPEG_LIBS=
-    # - mujs
-    MUJS_CFLAGS=
-    MUJS_SRC=
     # - zlib
     USE_SYSTEM_ZLIB=yes
     SYS_ZLIB_CFLAGS=-I${STAGING_DIR}/include
@@ -115,8 +119,8 @@ list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
 
 external_project(
-    DOWNLOAD URL 60b6e4c02c04f8f0b8936519d24eebd7
-    https://mupdf.com/downloads/archive/mupdf-1.25.6-source.tar.lz
+    DOWNLOAD URL 8657714f4e599a9c576cb9a9df884c2a
+    https://mupdf.com/downloads/archive/mupdf-1.26.1-source.tar.lz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/mupdf/css_color_names.patch
+++ b/thirdparty/mupdf/css_color_names.patch
@@ -1,5 +1,5 @@
 diff --git a/source/html/css-apply.c b/source/html/css-apply.c
-index 93839ccc..858bd588 100644
+index 1d860f937..160d126f5 100644
 --- a/source/html/css-apply.c
 +++ b/source/html/css-apply.c
 @@ -48,24 +48,307 @@ static const char *border_style_kw[] = {

--- a/thirdparty/mupdf/encrypted_zip.patch
+++ b/thirdparty/mupdf/encrypted_zip.patch
@@ -1,5 +1,5 @@
 diff --git a/include/mupdf/fitz/archive.h b/include/mupdf/fitz/archive.h
-index b169a88e..e5fd4207 100644
+index b169a88e8..e5fd42076 100644
 --- a/include/mupdf/fitz/archive.h
 +++ b/include/mupdf/fitz/archive.h
 @@ -314,6 +314,9 @@ fz_archive *fz_open_zip_archive(fz_context *ctx, const char *path);
@@ -13,7 +13,7 @@ index b169a88e..e5fd4207 100644
  	fz_zip_writer offers methods for creating and writing zip files.
  	It can be seen as the reverse of the fz_archive zip
 diff --git a/source/cbz/mucbz.c b/source/cbz/mucbz.c
-index 6d1b1b24..e2f99530 100644
+index 6d1b1b242..e2f99530a 100644
 --- a/source/cbz/mucbz.c
 +++ b/source/cbz/mucbz.c
 @@ -266,6 +266,20 @@ cbz_load_page(fz_context *ctx, fz_document *doc_, int chapter, int number)
@@ -47,7 +47,7 @@ index 6d1b1b24..e2f99530 100644
  	fz_try(ctx)
  	{
 diff --git a/source/fitz/unzip.c b/source/fitz/unzip.c
-index 4b138ccc..a79db423 100644
+index 35d14fb1c..4b416ada4 100644
 --- a/source/fitz/unzip.c
 +++ b/source/fitz/unzip.c
 @@ -43,10 +43,33 @@
@@ -244,7 +244,7 @@ index 4b138ccc..a79db423 100644
 +				if (zip->aes_encryption_mode) {
 +					fcrypt_decrypt(ubuf->data, ent->usize, &zip->aes_ctx);
 +				} else {
-+					int i;
++					unsigned i;
 +					for(i = 0; i < ent->usize; ++i)
 +						ubuf->data[i] = zdecode(zip->keys, zip->pcrc_32_tab, ubuf->data[i]);
 +				}
@@ -262,7 +262,7 @@ index 4b138ccc..a79db423 100644
 +				if (zip->aes_encryption_mode) {
 +					fcrypt_decrypt(cbuf, ent->csize, &zip->aes_ctx);
 +				} else {
-+					int i;
++					unsigned i;
 +					for(i = 0; i < ent->csize; ++i) {
 +						cbuf[i] = zdecode(zip->keys, zip->pcrc_32_tab, cbuf[i]);
 +					}

--- a/thirdparty/mupdf/external_fonts.patch
+++ b/thirdparty/mupdf/external_fonts.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index 21f7cb46..0ec7fdb1 100644
+index 7b04ff5cd..d247334bd 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -250,6 +250,7 @@ generated/%.otf.c : %.otf $(HEXDUMP_SH) ; $(QUIET_GEN) $(MKTGTDIR) ; bash $(HEXD
+@@ -239,6 +239,7 @@ generated/%.otf.c : %.otf $(HEXDUMP_SH) ; $(QUIET_GEN) $(MKTGTDIR) ; bash $(HEXD
  generated/%.ttf.c : %.ttf $(HEXDUMP_SH) ; $(QUIET_GEN) $(MKTGTDIR) ; bash $(HEXDUMP_SH) > $@ $<
  generated/%.ttc.c : %.ttc $(HEXDUMP_SH) ; $(QUIET_GEN) $(MKTGTDIR) ; bash $(HEXDUMP_SH) > $@ $<
  
@@ -10,7 +10,7 @@ index 21f7cb46..0ec7fdb1 100644
  ifeq ($(HAVE_OBJCOPY),yes)
    MUPDF_OBJ += $(FONT_BIN:%=$(OUT)/%.o)
    $(OUT)/%.cff.o : %.cff ; $(OBJCOPY_CMD)
-@@ -261,6 +262,7 @@ else
+@@ -250,6 +251,7 @@ else
  endif
  
  generate: $(FONT_GEN)
@@ -19,10 +19,10 @@ index 21f7cb46..0ec7fdb1 100644
  # --- Generated ICC profiles ---
  
 diff --git a/include/mupdf/fitz/font.h b/include/mupdf/fitz/font.h
-index 0892735d..f496ed16 100644
+index 313a5d474..55ff86185 100644
 --- a/include/mupdf/fitz/font.h
 +++ b/include/mupdf/fitz/font.h
-@@ -832,4 +832,9 @@ fz_buffer *fz_subset_ttf_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, i
+@@ -855,4 +855,9 @@ fz_buffer *fz_subset_ttf_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, i
   */
  fz_buffer *fz_subset_cff_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, int num_gids, int symbolic, int cidfont);
  
@@ -33,7 +33,7 @@ index 0892735d..f496ed16 100644
 +
  #endif
 diff --git a/source/fitz/font.c b/source/fitz/font.c
-index b9de4396..edb316b2 100644
+index 88ac44d39..10fab7f8e 100644
 --- a/source/fitz/font.c
 +++ b/source/fitz/font.c
 @@ -556,6 +556,8 @@ fz_font *fz_load_fallback_font(fz_context *ctx, int script, int language, int se
@@ -54,7 +54,7 @@ index b9de4396..edb316b2 100644
  static const struct ft_error ft_errors[] =
  {
  #include FT_ERRORS_H
-@@ -902,13 +906,18 @@ find_base14_index(const char *name)
+@@ -909,13 +913,18 @@ find_base14_index(const char *name)
  fz_font *
  fz_new_base14_font(fz_context *ctx, const char *name)
  {
@@ -73,7 +73,7 @@ index b9de4396..edb316b2 100644
  		data = fz_lookup_base14_font(ctx, name, &size);
  		if (data)
  		{
-@@ -920,6 +929,16 @@ fz_new_base14_font(fz_context *ctx, const char *name)
+@@ -927,6 +936,16 @@ fz_new_base14_font(fz_context *ctx, const char *name)
  			fz_set_font_embedding(ctx, ctx->font->base14[x], 1);
  			return fz_keep_font(ctx, ctx->font->base14[x]);
  		}
@@ -90,7 +90,7 @@ index b9de4396..edb316b2 100644
  	}
  	fz_throw(ctx, FZ_ERROR_ARGUMENT, "cannot find builtin font with name '%s'", name);
  }
-@@ -2100,6 +2119,7 @@ fz_encode_character_with_fallback(fz_context *ctx, fz_font *user_font, int unico
+@@ -2108,6 +2127,7 @@ fz_encode_character_with_fallback(fz_context *ctx, fz_font *user_font, int unico
  	}
  #endif
  
@@ -98,7 +98,7 @@ index b9de4396..edb316b2 100644
  	font = fz_load_fallback_math_font(ctx);
  	if (font)
  	{
-@@ -2141,6 +2161,15 @@ fz_encode_character_with_fallback(fz_context *ctx, fz_font *user_font, int unico
+@@ -2149,6 +2169,15 @@ fz_encode_character_with_fallback(fz_context *ctx, fz_font *user_font, int unico
  	}
  
  	font = fz_load_fallback_boxes_font(ctx);
@@ -115,7 +115,7 @@ index b9de4396..edb316b2 100644
  	{
  		gid = fz_encode_character(ctx, font, unicode);
 diff --git a/source/fitz/noto.c b/source/fitz/noto.c
-index e15cf28d..81da9378 100644
+index 9b359df85..3e883a9b8 100644
 --- a/source/fitz/noto.c
 +++ b/source/fitz/noto.c
 @@ -23,8 +23,12 @@
@@ -131,9 +131,9 @@ index e15cf28d..81da9378 100644
  /*
  	Base 14 PDF fonts from URW.
  	Noto fonts from Google.
-@@ -540,3 +544,131 @@ fz_lookup_noto_stem_from_script(fz_context *ctx, int script, int language)
+@@ -555,3 +559,131 @@ fz_lookup_script_name(fz_context *ctx, int script, int language)
+ 	default: return fz_lookup_noto_stem_from_script(ctx, script, language);
  	}
- 	return NULL;
  }
 +
 +#else // NOBUILTINFONT
@@ -264,7 +264,7 @@ index e15cf28d..81da9378 100644
 +
 +#endif
 diff --git a/source/html/html-font.c b/source/html/html-font.c
-index 87511f9d..0f325748 100644
+index e41035dac..58319b369 100644
 --- a/source/html/html-font.c
 +++ b/source/html/html-font.c
 @@ -23,18 +23,63 @@
@@ -350,7 +350,7 @@ index 87511f9d..0f325748 100644
  	}
  	return set->fonts[idx];
  }
-@@ -128,7 +185,7 @@ fz_load_html_font(fz_context *ctx, fz_html_font_set *set,
+@@ -149,7 +206,7 @@ fz_load_html_font(fz_context *ctx, fz_html_font_set *set,
  		return best_font;
  
  	// Handle the "default" font aliases.
@@ -360,7 +360,7 @@ index 87511f9d..0f325748 100644
  
  	return NULL;
 diff --git a/source/pdf/pdf-font-add.c b/source/pdf/pdf-font-add.c
-index d05d6019..39e98209 100644
+index a6d7d2a68..588a73618 100644
 --- a/source/pdf/pdf-font-add.c
 +++ b/source/pdf/pdf-font-add.c
 @@ -73,12 +73,16 @@ static int is_postscript(fz_context *ctx, FT_Face face)
@@ -381,7 +381,7 @@ index d05d6019..39e98209 100644
  
  static pdf_obj*
 diff --git a/source/pdf/pdf-font.c b/source/pdf/pdf-font.c
-index 66a6d417..6a28bde4 100644
+index c1724fc94..f4d55284b 100644
 --- a/source/pdf/pdf-font.c
 +++ b/source/pdf/pdf-font.c
 @@ -93,6 +93,8 @@ static const char *base_font_names[][10] =

--- a/thirdparty/mupdf/free-html-doc-fonts-on-close.patch
+++ b/thirdparty/mupdf/free-html-doc-fonts-on-close.patch
@@ -1,5 +1,5 @@
 diff --git a/source/html/html-doc.c b/source/html/html-doc.c
-index 46e0860e..24b10dfb 100644
+index 4bfa1f325..5c0ea1637 100644
 --- a/source/html/html-doc.c
 +++ b/source/html/html-doc.c
 @@ -49,6 +49,11 @@ static void

--- a/thirdparty/mupdf/honor_cflags.patch
+++ b/thirdparty/mupdf/honor_cflags.patch
@@ -1,8 +1,8 @@
 diff --git a/Makerules b/Makerules
-index 006fed6f..00245b5d 100644
+index 0f8b2b9c6..3cbb051f8 100644
 --- a/Makerules
 +++ b/Makerules
-@@ -111,10 +111,10 @@ else
+@@ -128,10 +128,10 @@ else
  endif
  
  ifeq ($(build),debug)

--- a/thirdparty/mupdf/mupdf_cbz_chapter_support.patch
+++ b/thirdparty/mupdf/mupdf_cbz_chapter_support.patch
@@ -12,7 +12,7 @@ Date:   Sun Nov 13 22:10:06 2022 +0100
     a comic book archive.
 
 diff --git a/source/cbz/mucbz.c b/source/cbz/mucbz.c
-index e877490b..a096648a 100644
+index e877490bb..a096648ac 100644
 --- a/source/cbz/mucbz.c
 +++ b/source/cbz/mucbz.c
 @@ -290,6 +290,110 @@ cbz_lookup_metadata(fz_context *ctx, fz_document *doc_, const char *key, char *b

--- a/thirdparty/mupdf/no_arm_asm.patch
+++ b/thirdparty/mupdf/no_arm_asm.patch
@@ -1,8 +1,8 @@
 diff --git a/include/mupdf/fitz/system.h b/include/mupdf/fitz/system.h
-index c5c32469..07e2254b 100644
+index 3f2c13ccc..65fb15609 100644
 --- a/include/mupdf/fitz/system.h
 +++ b/include/mupdf/fitz/system.h
-@@ -77,11 +77,13 @@ typedef unsigned __int64 uint64_t;
+@@ -84,11 +84,13 @@ typedef unsigned __int64 uint64_t;
  */
  
  /* ARCH_ARM is only used for 32bit ARM stuff. */

--- a/thirdparty/mupdf/relink_on_xlibs_change.patch
+++ b/thirdparty/mupdf/relink_on_xlibs_change.patch
@@ -1,13 +1,13 @@
 diff --git a/Makefile b/Makefile
-index 0ec7fdb1..af4737da 100644
+index d247334bd..11c2918ea 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -102,7 +102,7 @@ $(OUT)/%.a :
- $(OUT)/%.exe: %.c
- 	$(LINK_CMD)
+@@ -293,7 +293,7 @@ generate: source/html/css-properties.h
+ # --- Library ---
  
--$(OUT)/%.$(SO)$(SO_VERSION):
-+$(OUT)/%.$(SO)$(SO_VERSION): $(XLIBS)
- ifeq ($(SO_VERSION_LINUX),yes)
- 	$(LINK_CMD) -Wl,-soname,$(notdir $@) $(LIB_LDFLAGS) $(THIRD_LIBS) $(LIBCRYPTO_LIBS)
- 	ln -sf $(notdir $@) $(patsubst %$(SO_VERSION), %, $@)
+ ifeq ($(shared),yes)
+-  $(OUT)/libmupdf.$(SO)$(SO_VERSION): $(MUPDF_OBJ) $(THIRD_OBJ)
++  $(OUT)/libmupdf.$(SO)$(SO_VERSION): $(MUPDF_OBJ) $(THIRD_OBJ) $(XLIBS)
+ 	$(LINK_SO_CMD) $(THIRD_LIBS) $(LIBCRYPTO_LIBS)
+   ifeq ($(OS),OpenBSD)
+     # should never create symlink

--- a/thirdparty/mupdf/visibility.patch
+++ b/thirdparty/mupdf/visibility.patch
@@ -1,5 +1,5 @@
 diff --git a/include/mupdf/fitz/buffer.h b/include/mupdf/fitz/buffer.h
-index 5ac949cf..ec6740b5 100644
+index 5ac949cf4..ec6740b51 100644
 --- a/include/mupdf/fitz/buffer.h
 +++ b/include/mupdf/fitz/buffer.h
 @@ -26,6 +26,8 @@
@@ -19,7 +19,7 @@ index 5ac949cf..ec6740b5 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/color.h b/include/mupdf/fitz/color.h
-index 0a7e985c..0dcf81e7 100644
+index 3cf4d9325..75fe11362 100644
 --- a/include/mupdf/fitz/color.h
 +++ b/include/mupdf/fitz/color.h
 @@ -27,6 +27,8 @@
@@ -31,7 +31,7 @@ index 0a7e985c..0dcf81e7 100644
  #if FZ_ENABLE_ICC
  /**
  	Opaque type for an ICC Profile.
-@@ -390,6 +392,8 @@ void fz_set_default_rgb(fz_context *ctx, fz_default_colorspaces *default_cs, fz_
+@@ -396,6 +398,8 @@ void fz_set_default_rgb(fz_context *ctx, fz_default_colorspaces *default_cs, fz_
  void fz_set_default_cmyk(fz_context *ctx, fz_default_colorspaces *default_cs, fz_colorspace *cs);
  void fz_set_default_output_intent(fz_context *ctx, fz_default_colorspaces *default_cs, fz_colorspace *cs);
  
@@ -41,7 +41,7 @@ index 0a7e985c..0dcf81e7 100644
  
  struct fz_colorspace
 diff --git a/include/mupdf/fitz/context.h b/include/mupdf/fitz/context.h
-index b98df08b..43909cd9 100644
+index 64245a719..d097441c8 100644
 --- a/include/mupdf/fitz/context.h
 +++ b/include/mupdf/fitz/context.h
 @@ -32,6 +32,8 @@
@@ -53,7 +53,7 @@ index b98df08b..43909cd9 100644
  typedef struct fz_font_context fz_font_context;
  typedef struct fz_colorspace_context fz_colorspace_context;
  typedef struct fz_style_context fz_style_context;
-@@ -780,6 +782,8 @@ int fz_do_try(fz_context *ctx);
+@@ -790,6 +792,8 @@ int fz_do_try(fz_context *ctx);
  int fz_do_always(fz_context *ctx);
  int (fz_do_catch)(fz_context *ctx);
  
@@ -62,7 +62,7 @@ index b98df08b..43909cd9 100644
  #ifndef FZ_JMPBUF_ALIGN
  #define FZ_JMPBUF_ALIGN 32
  #endif
-@@ -852,6 +856,7 @@ struct fz_context
+@@ -890,6 +894,7 @@ struct fz_context
  	fz_glyph_cache *glyph_cache;
  };
  
@@ -71,7 +71,7 @@ index b98df08b..43909cd9 100644
  
  /**
 diff --git a/include/mupdf/fitz/device.h b/include/mupdf/fitz/device.h
-index 70497a7d..08f8a562 100644
+index e2d05cf32..9bb4278df 100644
 --- a/include/mupdf/fitz/device.h
 +++ b/include/mupdf/fitz/device.h
 @@ -31,6 +31,8 @@
@@ -83,7 +83,7 @@ index 70497a7d..08f8a562 100644
  /**
  	The different format handlers (pdf, xps etc) interpret pages to
  	a device. These devices can then process the stream of calls
-@@ -651,4 +653,6 @@ fz_draw_options *fz_parse_draw_options(fz_context *ctx, fz_draw_options *options
+@@ -648,4 +650,6 @@ fz_draw_options *fz_parse_draw_options(fz_context *ctx, fz_draw_options *options
  */
  fz_device *fz_new_draw_device_with_options(fz_context *ctx, const fz_draw_options *options, fz_rect mediabox, fz_pixmap **pixmap);
  
@@ -91,7 +91,7 @@ index 70497a7d..08f8a562 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/document.h b/include/mupdf/fitz/document.h
-index 3581e366..4bfc1cb6 100644
+index 58034afa8..46c78d42a 100644
 --- a/include/mupdf/fitz/document.h
 +++ b/include/mupdf/fitz/document.h
 @@ -34,6 +34,8 @@
@@ -113,7 +113,7 @@ index 3581e366..4bfc1cb6 100644
  
  /**
 diff --git a/include/mupdf/fitz/export.h b/include/mupdf/fitz/export.h
-index 853e2d5a..a36eb3f2 100644
+index 853e2d5a4..a36eb3f24 100644
 --- a/include/mupdf/fitz/export.h
 +++ b/include/mupdf/fitz/export.h
 @@ -45,8 +45,11 @@
@@ -131,7 +131,7 @@ index 853e2d5a..a36eb3f2 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/font.h b/include/mupdf/fitz/font.h
-index f496ed16..a7705025 100644
+index 55ff86185..a29181f82 100644
 --- a/include/mupdf/fitz/font.h
 +++ b/include/mupdf/fitz/font.h
 @@ -29,6 +29,8 @@
@@ -143,7 +143,7 @@ index f496ed16..a7705025 100644
  /* forward declaration for circular dependency */
  struct fz_device;
  
-@@ -705,6 +707,8 @@ float fz_font_descender(fz_context *ctx, fz_font *font);
+@@ -706,6 +708,8 @@ float fz_font_descender(fz_context *ctx, fz_font *font);
  */
  void fz_font_digest(fz_context *ctx, fz_font *font, unsigned char digest[16]);
  
@@ -152,7 +152,7 @@ index f496ed16..a7705025 100644
  /* Implementation details: subject to change. */
  
  void fz_decouple_type3_font(fz_context *ctx, fz_font *font, void *t3doc);
-@@ -835,6 +839,7 @@ fz_buffer *fz_subset_cff_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, i
+@@ -858,6 +862,7 @@ fz_buffer *fz_subset_cff_for_gids(fz_context *ctx, fz_buffer *orig, int *gids, i
  char *get_font_file(const char *name);
  char *fz_lookup_base14_font_from_file(fz_context *ctx, const char *name);
  char *fz_lookup_cjk_font_from_file(fz_context *ctx, int registry, int serif, int wmode);
@@ -161,7 +161,7 @@ index f496ed16..a7705025 100644
  
  #endif
 diff --git a/include/mupdf/fitz/geometry.h b/include/mupdf/fitz/geometry.h
-index 5ab4aee3..e4c817dc 100644
+index d280a0404..4d6f2c215 100644
 --- a/include/mupdf/fitz/geometry.h
 +++ b/include/mupdf/fitz/geometry.h
 @@ -32,6 +32,8 @@
@@ -173,7 +173,7 @@ index 5ab4aee3..e4c817dc 100644
  /**
  	Multiply scaled two integers in the 0..255 range
  */
-@@ -844,4 +846,6 @@ int fz_is_quad_inside_quad(fz_quad needle, fz_quad haystack);
+@@ -874,4 +876,6 @@ int fz_is_quad_inside_quad(fz_quad needle, fz_quad haystack);
  */
  int fz_is_quad_intersecting_quad(fz_quad a, fz_quad b);
  
@@ -181,7 +181,7 @@ index 5ab4aee3..e4c817dc 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/image.h b/include/mupdf/fitz/image.h
-index eb7563ef..c29dd2f6 100644
+index e3e501cee..c61464b1a 100644
 --- a/include/mupdf/fitz/image.h
 +++ b/include/mupdf/fitz/image.h
 @@ -32,6 +32,8 @@
@@ -193,7 +193,7 @@ index eb7563ef..c29dd2f6 100644
  /**
  	Images are storable objects from which we can obtain fz_pixmaps.
  	These may be implemented as simple wrappers around a pixmap, or
-@@ -414,6 +416,8 @@ void fz_set_compressed_image_buffer(fz_context *ctx, fz_compressed_image *cimg,
+@@ -416,6 +418,8 @@ void fz_set_compressed_image_buffer(fz_context *ctx, fz_compressed_image *cimg,
  fz_pixmap *fz_pixmap_image_tile(fz_context *ctx, fz_pixmap_image *cimg);
  void fz_set_pixmap_image_tile(fz_context *ctx, fz_pixmap_image *cimg, fz_pixmap *pix);
  
@@ -203,7 +203,7 @@ index eb7563ef..c29dd2f6 100644
  
  /**
 diff --git a/include/mupdf/fitz/link.h b/include/mupdf/fitz/link.h
-index 1a20a22f..53d392fb 100644
+index 1a20a22f5..53d392fbe 100644
 --- a/include/mupdf/fitz/link.h
 +++ b/include/mupdf/fitz/link.h
 @@ -28,6 +28,8 @@
@@ -223,7 +223,7 @@ index 1a20a22f..53d392fb 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/outline.h b/include/mupdf/fitz/outline.h
-index d9bf83e3..d5b3fc65 100644
+index c508e8f51..679f81407 100644
 --- a/include/mupdf/fitz/outline.h
 +++ b/include/mupdf/fitz/outline.h
 @@ -29,6 +29,8 @@
@@ -235,7 +235,7 @@ index d9bf83e3..d5b3fc65 100644
  /* Outline */
  
  typedef struct {
-@@ -159,6 +161,7 @@ void fz_drop_outline(fz_context *ctx, fz_outline *outline);
+@@ -177,6 +179,7 @@ void fz_drop_outline(fz_context *ctx, fz_outline *outline);
  fz_outline *
  fz_load_outline_from_iterator(fz_context *ctx, fz_outline_iterator *iter);
  
@@ -244,7 +244,7 @@ index d9bf83e3..d5b3fc65 100644
  /**
  	Implementation details.
 diff --git a/include/mupdf/fitz/pixmap.h b/include/mupdf/fitz/pixmap.h
-index 42272076..3d0fa58f 100644
+index 0185d0630..4c7072602 100644
 --- a/include/mupdf/fitz/pixmap.h
 +++ b/include/mupdf/fitz/pixmap.h
 @@ -29,6 +29,8 @@
@@ -274,7 +274,7 @@ index 42272076..3d0fa58f 100644
  
  /*
 diff --git a/include/mupdf/fitz/stream.h b/include/mupdf/fitz/stream.h
-index 13d1c779..ae848372 100644
+index 13d1c7793..ae8483729 100644
 --- a/include/mupdf/fitz/stream.h
 +++ b/include/mupdf/fitz/stream.h
 @@ -27,6 +27,8 @@
@@ -296,7 +296,7 @@ index 13d1c779..ae848372 100644
  
  /**
 diff --git a/include/mupdf/fitz/string-util.h b/include/mupdf/fitz/string-util.h
-index 2c8d78a1..97e1ca4f 100644
+index f46331dd9..64a41c173 100644
 --- a/include/mupdf/fitz/string-util.h
 +++ b/include/mupdf/fitz/string-util.h
 @@ -26,6 +26,8 @@
@@ -308,7 +308,7 @@ index 2c8d78a1..97e1ca4f 100644
  /* The Unicode character used to incoming character whose value is
   * unknown or unrepresentable. */
  #define FZ_REPLACEMENT_CHARACTER 0xFFFD
-@@ -283,4 +285,6 @@ const char *fz_parse_page_range(fz_context *ctx, const char *s, int *a, int *b,
+@@ -332,4 +334,6 @@ const char *fz_parse_page_range(fz_context *ctx, const char *s, int *a, int *b,
  int fz_tolower(int c);
  int fz_toupper(int c);
  
@@ -316,7 +316,7 @@ index 2c8d78a1..97e1ca4f 100644
 +
  #endif
 diff --git a/include/mupdf/fitz/structured-text.h b/include/mupdf/fitz/structured-text.h
-index d9a6aa72..1a3b202d 100644
+index c45badca4..d471af2a8 100644
 --- a/include/mupdf/fitz/structured-text.h
 +++ b/include/mupdf/fitz/structured-text.h
 @@ -33,6 +33,8 @@
@@ -328,7 +328,7 @@ index d9a6aa72..1a3b202d 100644
  /**
  	Simple text layout (for use with annotation editing primarily).
  */
-@@ -633,5 +635,6 @@ fz_device *fz_new_ocr_device(fz_context *ctx, fz_device *target, fz_matrix ctm,
+@@ -732,5 +734,6 @@ fz_device *fz_new_ocr_device(fz_context *ctx, fz_device *target, fz_matrix ctm,
  
  fz_document *fz_open_reflowed_document(fz_context *ctx, fz_document *underdoc, const fz_stext_options *opts);
  
@@ -336,7 +336,7 @@ index d9a6aa72..1a3b202d 100644
  
  #endif
 diff --git a/include/mupdf/fitz/util.h b/include/mupdf/fitz/util.h
-index 78326f72..84e9d47f 100644
+index 78326f724..84e9d47fe 100644
 --- a/include/mupdf/fitz/util.h
 +++ b/include/mupdf/fitz/util.h
 @@ -34,6 +34,8 @@
@@ -356,7 +356,7 @@ index 78326f72..84e9d47f 100644
 +
  #endif
 diff --git a/include/mupdf/pdf/annot.h b/include/mupdf/pdf/annot.h
-index 8d22daf6..b447ff95 100644
+index 23af8ccb9..3a70a47bb 100644
 --- a/include/mupdf/pdf/annot.h
 +++ b/include/mupdf/pdf/annot.h
 @@ -29,6 +29,8 @@
@@ -368,7 +368,7 @@ index 8d22daf6..b447ff95 100644
  typedef struct pdf_annot pdf_annot;
  
  enum pdf_annot_type
-@@ -1006,4 +1008,6 @@ void pdf_set_annot_hidden_for_editing(fz_context *ctx, pdf_annot *annot, int hid
+@@ -1022,4 +1024,6 @@ void pdf_set_annot_hidden_for_editing(fz_context *ctx, pdf_annot *annot, int hid
   */
  int pdf_apply_redaction(fz_context *ctx, pdf_annot *annot, pdf_redact_options *opts);
  
@@ -376,7 +376,7 @@ index 8d22daf6..b447ff95 100644
 +
  #endif
 diff --git a/include/mupdf/pdf/document.h b/include/mupdf/pdf/document.h
-index 655208da..fd5cc8d2 100644
+index 04a5e1806..6fe04ee6f 100644
 --- a/include/mupdf/pdf/document.h
 +++ b/include/mupdf/pdf/document.h
 @@ -30,6 +30,8 @@
@@ -388,9 +388,9 @@ index 655208da..fd5cc8d2 100644
  typedef struct pdf_xref pdf_xref;
  typedef struct pdf_ocg_descriptor pdf_ocg_descriptor;
  
-@@ -870,4 +872,6 @@ int pdf_count_page_associated_files(fz_context *ctx, pdf_page *page);
- */
- pdf_obj *pdf_page_associated_file(fz_context *ctx, pdf_page *page, int idx);
+@@ -899,4 +901,6 @@ void pdf_drop_object_labels(fz_context *ctx, pdf_object_labels *g);
+ typedef void (pdf_label_object_fn)(fz_context *ctx, void *arg, const char *label);
+ void pdf_label_object(fz_context *ctx, pdf_object_labels *g, int num, pdf_label_object_fn *callback, void *arg);
  
 +FZ_EXPORTS_STOP
 +

--- a/thirdparty/mupdf/webp-upstream-697749.patch
+++ b/thirdparty/mupdf/webp-upstream-697749.patch
@@ -1,8 +1,8 @@
 diff --git a/include/mupdf/fitz/compressed-buffer.h b/include/mupdf/fitz/compressed-buffer.h
-index 80458f11..64202fd6 100644
+index 326d524dd..296079618 100644
 --- a/include/mupdf/fitz/compressed-buffer.h
 +++ b/include/mupdf/fitz/compressed-buffer.h
-@@ -125,10 +125,10 @@ fz_stream *fz_open_image_decomp_stream_from_buffer(fz_context *ctx, fz_compresse
+@@ -133,10 +133,10 @@ fz_stream *fz_open_image_decomp_stream_from_buffer(fz_context *ctx, fz_compresse
  fz_stream *fz_open_image_decomp_stream(fz_context *ctx, fz_stream *, fz_compression_params *, int *l2factor);
  
  /**
@@ -15,7 +15,7 @@ index 80458f11..64202fd6 100644
  
  /**
  	Map from FZ_IMAGE_* value to string.
-@@ -167,6 +167,7 @@ enum
+@@ -176,6 +176,7 @@ enum
  	FZ_IMAGE_PNM,
  	FZ_IMAGE_TIFF,
  	FZ_IMAGE_PSD,
@@ -24,7 +24,7 @@ index 80458f11..64202fd6 100644
  
  /**
 diff --git a/scripts/wrap/make_cppyy.py b/scripts/wrap/make_cppyy.py
-index 89be2fec..91396c33 100644
+index a37456d81..69604a377 100644
 --- a/scripts/wrap/make_cppyy.py
 +++ b/scripts/wrap/make_cppyy.py
 @@ -763,7 +763,7 @@ def make_cppyy(
@@ -37,7 +37,7 @@ index 89be2fec..91396c33 100644
              cppyy.cppdef(f'''
                      namespace mupdf
 diff --git a/source/cbz/mucbz.c b/source/cbz/mucbz.c
-index e2f99530..e877490b 100644
+index e2f99530a..e877490bb 100644
 --- a/source/cbz/mucbz.c
 +++ b/source/cbz/mucbz.c
 @@ -49,6 +49,7 @@ static const char *cbz_ext_list[] = {
@@ -49,7 +49,7 @@ index e2f99530..e877490b 100644
  };
  
 diff --git a/source/cbz/muimg.c b/source/cbz/muimg.c
-index 69d1f990..78c07017 100644
+index 69d1f990f..78c07017d 100644
 --- a/source/cbz/muimg.c
 +++ b/source/cbz/muimg.c
 @@ -191,7 +191,7 @@ img_open_document(fz_context *ctx, const fz_document_handler *handler, fz_stream
@@ -83,7 +83,7 @@ index 69d1f990..78c07017 100644
  
  	fmt = fz_recognize_image_format(ctx, data);
 diff --git a/source/fitz/image-imp.h b/source/fitz/image-imp.h
-index 06db2afc..ee6db1c5 100644
+index 06db2afc7..ee6db1c54 100644
 --- a/source/fitz/image-imp.h
 +++ b/source/fitz/image-imp.h
 @@ -32,6 +32,7 @@ fz_pixmap *fz_load_gif(fz_context *ctx, const unsigned char *data, size_t size);
@@ -102,7 +102,7 @@ index 06db2afc..ee6db1c5 100644
  
  #endif
 diff --git a/source/fitz/image.c b/source/fitz/image.c
-index e898aa42..915ddf28 100644
+index c5531c097..cb720bfd9 100644
 --- a/source/fitz/image.c
 +++ b/source/fitz/image.c
 @@ -794,6 +794,9 @@ compressed_image_get_pixmap(fz_context *ctx, fz_image *image_, fz_irect *subarea
@@ -115,7 +115,7 @@ index e898aa42..915ddf28 100644
  	case FZ_IMAGE_TIFF:
  		tile = fz_load_tiff(ctx, image->buffer->buffer->data, image->buffer->buffer->len);
  		break;
-@@ -1295,7 +1298,7 @@ fz_lookup_image_type(const char *type)
+@@ -1299,7 +1302,7 @@ fz_lookup_image_type(const char *type)
  }
  
  int
@@ -124,7 +124,7 @@ index e898aa42..915ddf28 100644
  {
  	if (p[0] == 'P' && p[1] >= '1' && p[1] <= '7')
  		return FZ_IMAGE_PNM;
-@@ -1328,6 +1331,9 @@ fz_recognize_image_format(fz_context *ctx, unsigned char p[8])
+@@ -1332,6 +1335,9 @@ fz_recognize_image_format(fz_context *ctx, unsigned char p[8])
  		return FZ_IMAGE_JBIG2;
  	if (p[0] == '8' && p[1] == 'B' && p[2] == 'P' && p[3] == 'S')
  		return FZ_IMAGE_PSD;
@@ -134,7 +134,7 @@ index e898aa42..915ddf28 100644
  	return FZ_IMAGE_UNKNOWN;
  }
  
-@@ -1344,7 +1350,7 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
+@@ -1348,7 +1354,7 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
  	int bpc;
  	uint8_t orientation = 0;
  
@@ -143,7 +143,7 @@ index e898aa42..915ddf28 100644
  		fz_throw(ctx, FZ_ERROR_FORMAT, "unknown image file format");
  
  	type = fz_recognize_image_format(ctx, buf);
-@@ -1382,6 +1388,9 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
+@@ -1386,6 +1392,9 @@ fz_new_image_from_buffer(fz_context *ctx, fz_buffer *buffer)
  		fz_load_jbig2_info(ctx, buf, len, &w, &h, &xres, &yres, &cspace);
  		bpc = 1;
  		break;
@@ -155,7 +155,7 @@ index e898aa42..915ddf28 100644
  	}
 diff --git a/source/fitz/load-webp.c b/source/fitz/load-webp.c
 new file mode 100644
-index 00000000..1ab554da
+index 000000000..1ab554dae
 --- /dev/null
 +++ b/source/fitz/load-webp.c
 @@ -0,0 +1,280 @@
@@ -440,10 +440,10 @@ index 00000000..1ab554da
 +
 +#endif /* HAVE_WEBP */
 diff --git a/source/html/mobi.c b/source/html/mobi.c
-index e0a076d1..e586eddb 100644
+index 4edb1f4aa..23b9e24dd 100644
 --- a/source/html/mobi.c
 +++ b/source/html/mobi.c
-@@ -318,7 +318,7 @@ fz_extract_html_from_mobi(fz_context *ctx, fz_buffer *mobi)
+@@ -317,7 +317,7 @@ fz_extract_html_from_mobi(fz_context *ctx, fz_buffer *mobi)
  		for (i = extra; i < n; ++i)
  		{
  			uint32_t size = offsets[i+1] - offsets[i];


### PR DESCRIPTION
https://www.mupdf.com/releases/history

There's small code size increase:
- android-arm: +40.5 KB
- android-arm64: +51.0 KB
- emulator: +57.9 KB
- kindlepw2: +35.6 KB