### PR TITLE
android: small cleanup

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -881,7 +881,6 @@ set(CMAKE_SYSTEM_NAME $(if $(DARWIN),Darwin,$(if $(WIN32),Windows,Linux)))
 
 # Magical value that inhibits all of CMake's own NDK handling code. (Or shit goes boom.)
 $(if $(ANDROID),set(CMAKE_SYSTEM_VERSION 1))
-$(if $(ANDROID),set(ANDROID_STL c++_shared))
 # Also disable versioning of shared objects.
 $(if $(ANDROID),set(CMAKE_PLATFORM_NO_VERSIONED_SONAME TRUE))
 


### PR DESCRIPTION
Since we're not using CMake's NDK support, setting `ANDROID_STL` is not necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2099)
<!-- Reviewable:end -->
