### PR TITLE
android: statically link the STL when using monolibtic mode

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -209,6 +209,7 @@ else ifeq ($(TARGET), macos)
 	EMULATE_READER=1
 else ifeq ($(TARGET), android)
 	ANDROID=1
+	MONOLIBTIC?=1
 	export PATH:=$(ANDROID_TOOLCHAIN)/bin:$(PATH)
 	ifeq ($(ANDROID_ARCH), x86)
 		CHOST?=i686-linux-android$(NDKABI)
@@ -649,6 +650,10 @@ ifndef DARWIN
   ifneq ($(TARGET), android)
     LDFLAGS += -Wl,@$(abspath $(KOR_BASE)/origin.ldflags)
   endif
+  # In monolibtic mode on Android, we can statically link the STL.
+  ifeq ($(TARGET), android)
+    LDFLAGS += $(if $(MONOLIBTIC),-static-libstdc++)
+  endif
 else
   LDFLAGS := -Wl,-rpath,@executable_path/libs,-rpath,@executable_path/../koreader/libs
 endif
@@ -770,8 +775,6 @@ DYNLIB_LDFLAGS = -shared
 ifdef DARWIN
 	DYNLIB_LDFLAGS += -dynamiclib -undefined dynamic_lookup
 endif
-
-MONOLIBTIC ?= $(ANDROID)
 
 # CMake toolchain file. {{{
 

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -135,7 +135,7 @@ check_libc_fn_exists(ngettext libintl.h HAS_GETTEXT)
 # We don't want to rely on `-static-libstdc++`, as it risks breaking the ODR. (Also, it was a pain to deal with because
 # of libtool, c.f., https://www.gnu.org/software/libtool/manual/html_node/Stripped-link-flags.html#Stripped-link-flags).
 #
-if(NOT (APPLE OR EMULATE_READER OR SDL))
+if(NOT ((ANDROID AND MONOLIBTIC) OR APPLE OR EMULATE_READER OR SDL))
     if(ANDROID)
         set(STL_NAME libc++_shared.so)
     else()

--- a/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
+++ b/thirdparty/cmake_modules/koreader_thirdparty_libs.cmake
@@ -66,7 +66,10 @@ endif()
 declare_dependency(czmq::czmq MONOLIBTIC czmq zmq LIBRARIES ${LIBRARIES})
 
 # djvulibre
-set(LIBRARIES m pthread stdc++)
+set(LIBRARIES m pthread)
+if(NOT (ANDROID AND MONOLIBTIC))
+    list(APPEND LIBRARIES stdc++)
+endif()
 if(APPLE)
     list(APPEND LIBRARIES "-framework CoreFoundation")
 endif()


### PR DESCRIPTION
Since in monolibtic mode we only have the one C++ library, we can statically link the STL. Ditto for our only executable (sdcv).

This fix another potential dynamic linker issue on some devices (cf. koreader/koreader#13821).

This also net us a small code size reduction:

| Target: component       | Difference          |
|:------------------------|--------------------:|
| android-arm: koreader   |  -455.2 KB ( -3.0%) |
| android-arm: sdcv       |  -463.1 KB (-24.9%) |
| android-arm64: koreader |  -652.3 KB ( -3.1%) |
| android-arm64: sdcv     |  -689.3 KB (-28.7%) |

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2100)
<!-- Reviewable:end -->
