### PR TITLE
cmake: fix meson projects `bindir` install directory

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -114,7 +114,7 @@ find_executable(MESON Meson meson --version REQUIRED)
 set(MESON_SETUP
     ${MESON} setup ${MESON_TOOLCHAINS}
     --auto-features=disabled
-    --bindir=
+    --bindir=bin
     --libdir=lib
     --prefix=${STAGING_DIR}
     --wrap-mode=nodownload


### PR DESCRIPTION
So executables end-up in the right staging tree sub-directory.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2110)
<!-- Reviewable:end -->
