### PR TITLE
sdl2: always compile on macOS

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -401,7 +401,7 @@ declare_project(thirdparty/proxy-libintl EXCLUDE_FROM_ALL)
 declare_project(thirdparty/sdcv DEPENDS glib zlib)
 
 # sdl2
-if(APPIMAGE OR MACOS)
+if(APPIMAGE OR APPLE)
     set(EXCLUDE_FROM_ALL)
 else()
     set(EXCLUDE_FROM_ALL EXCLUDE_FROM_ALL)


### PR DESCRIPTION
That's one less variable when trying to troubleshoot issues with the emulator/GA artifacts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2116)
<!-- Reviewable:end -->
