### PR TITLE
make: align `KODEBUG` default with kodev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ executors:
     <<: *BASE_EXE
     environment: &EMU_ENV_LST
       EMULATE_READER: "1"
+      KODEBUG: ""
       CC: "gcc"
 
   emu_gcc_ninja_debug:
@@ -38,6 +39,7 @@ executors:
       - image: koreader/kobase-clang:0.4.1-22.04
     environment:
       <<: *EMU_ENV_LST
+      KODEBUG: ""
       USE_CLANG: "1"
 
   # }}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       # Bump first number to reset all caches.
       CACHE_KEY: "1-macOS-${{ matrix.image }}-${{ matrix.platform }}-XC${{ matrix.xcode_version }}-DT${{ matrix.deployment_target }}"
       CLICOLOR_FORCE: '1'
+      KODEBUG: ""
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
       MAKEFLAGS: 'OUTPUT_DIR=build'
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -253,6 +253,7 @@ else ifeq ($(TARGET), cervantes)
 else ifndef TARGET
 	# if TARGET is not defined we will build an emulator on current machine
 	EMULATE_READER=1
+	KODEBUG ?= 1
 	SDL=1
 else
   $(error Invalid TARGET: "$(TARGET)")


### PR DESCRIPTION
Default to 1 when building an emulator for the current machine, so `make …` commands build for the same configuration as kodev's default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2118)
<!-- Reviewable:end -->
