### PR TITLE
Patch lua-spore to properly set filename in form-data

### DIFF
--- a/thirdparty/lua-Spore/CMakeLists.txt
+++ b/thirdparty/lua-Spore/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(BINARY_DIR ${SOURCE_DIR})
 
 list(APPEND PATCH_FILES content-type-detection.patch)
+list(APPEND PATCH_FILES form-data-filename.patch)
 
 append_install_commands(INSTALL_CMD src/Spore.lua DESTINATION common)
 append_tree_install_commands(INSTALL_CMD src/Spore common/Spore)

--- a/thirdparty/lua-Spore/form-data-filename.patch
+++ b/thirdparty/lua-Spore/form-data-filename.patch
@@ -1,0 +1,16 @@
+diff --git a/src/Spore/Request.lua b/src/Spore/Request.lua
+index eb983fb..44b4635 100644
+--- a/src/Spore/Request.lua
++++ b/src/Spore/Request.lua
+@@ -121,8 +121,9 @@ local function _form_data (data, debug_)
+     local p = {}
+     for k, v in pairs(data) do
+         if sub(v, 1, 1) == '@' then
+-            local fname = sub(v, 2)
+-            local content = slurp(fname, debug_)
++            local fullpath = sub(v, 2)
++            local fname = fullpath:match("([^/\\]+)$")
++            local content = slurp(fullpath, debug_)
+             p[#p+1] = 'content-disposition: form-data; name="' .. k .. '"; filename="' .. fname ..'"\r\n'
+                    .. 'content-type: application/octet-stream\r\n\r\n'
+                    .. content


### PR DESCRIPTION
During the development of a koreader plugin I encountered the following problem using the `lua-spore` library.

I have an `api.json` file like this

```json
"upload_file": {
      "path": "/api/v1/files/upload",
      "method": "POST",
      "required_params": [
        "file",
        "libraryId",
        "pathId"
      ],
      "expected_status": [
        200,
        201,
        400,
        414,
        500
      ]
      "form-data": {
        "file": ":file",
        "libraryId": ":libraryId",
        "pathId": ":pathId"
      },
}
```

When I invoke the `upload_file` method like this

```lua
client:upload_file({
  file = "@/absolute/path/to/file.txt",
  libraryId = "1",
  pathId = "1"
})
```

The request is succesfully sent but the server is unable to save the file locally because of a problem in the way the form-data is built.

Until now when you use an absolute path inside the `file` field the lua spore library would send a form-data with the filename set exactly to the absolute path you specified while instead it should just put the filename of the corresponding file.

This fix aims to resolve that problem and simply by getting the last part of the path I'm able to correctly set the `filename` field inside the form-data and correctly save the file on the backend.

So we move from something like this

```
Content-Disposition: form-data; name="file"; filename="/absolute/path/to/file.txt"\r\n'
```

to


```
Content-Disposition: form-data; name="file"; filename="file.txt"\r\n'
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2123)
<!-- Reviewable:end -->
