### PR TITLE
ffi/libarchive: fix cdecls

### DIFF
--- a/ffi-cdecl/libarchive_cdecl.c
+++ b/ffi-cdecl/libarchive_cdecl.c
@@ -1,19 +1,10 @@
-// FIXME: ffi-cdecl is not doing the right thing when using:
-//
-// typedef int64_t la_int64_t;
-// typedef ssize_t la_ssize_t;
-//
-#include <sys/types.h>
-#include <stdint.h>
-#define __LA_INT64_T_DEFINED
-#define la_int64_t int64_t
-#define __LA_SSIZE_T_DEFINED
-#define la_ssize_t ssize_t
-
 #include <archive.h>
 #include <archive_entry.h>
 
 #include "ffi-cdecl.h"
+
+cdecl_c99_type(la_int64_t, int64_t)
+cdecl_c99_type(la_ssize_t, ssize_t)
 
 cdecl_const(AE_IFREG)
 cdecl_const(AE_IFLNK)

--- a/ffi/libarchive_h.lua
+++ b/ffi/libarchive_h.lua
@@ -3,6 +3,8 @@
 local ffi = require("ffi")
 
 ffi.cdef[[
+typedef int64_t la_int64_t;
+typedef ssize_t la_ssize_t;
 static const int AE_IFREG = 32768;
 static const int AE_IFLNK = 40960;
 static const int AE_IFSOCK = 49152;
@@ -25,18 +27,18 @@ void archive_entry_free(struct archive_entry *);
 struct archive_entry *archive_entry_new(void);
 const char *archive_entry_pathname(struct archive_entry *);
 void archive_entry_set_filetype(struct archive_entry *, unsigned int);
-void archive_entry_set_gid(struct archive_entry *, int64_t);
+void archive_entry_set_gid(struct archive_entry *, la_int64_t);
 void archive_entry_set_mtime(struct archive_entry *, long int, long int);
 void archive_entry_set_pathname(struct archive_entry *, const char *);
 void archive_entry_set_perm(struct archive_entry *, unsigned int);
-void archive_entry_set_size(struct archive_entry *, int64_t);
-void archive_entry_set_uid(struct archive_entry *, int64_t);
-int64_t archive_entry_size(struct archive_entry *);
+void archive_entry_set_size(struct archive_entry *, la_int64_t);
+void archive_entry_set_uid(struct archive_entry *, la_int64_t);
+la_int64_t archive_entry_size(struct archive_entry *);
 const char *archive_error_string(struct archive *);
 int archive_free(struct archive *);
 int archive_read_close(struct archive *);
-ssize_t archive_read_data(struct archive *, void *, size_t);
-int archive_read_data_block(struct archive *, const void **, size_t *, int64_t *);
+la_ssize_t archive_read_data(struct archive *, void *, size_t);
+int archive_read_data_block(struct archive *, const void **, size_t *, la_int64_t *);
 int archive_read_extract2(struct archive *, struct archive_entry *, struct archive *);
 struct archive *archive_read_new(void);
 int archive_read_next_header2(struct archive *, struct archive_entry *);
@@ -49,7 +51,7 @@ int archive_read_disk_open(struct archive *, const char *);
 int archive_read_disk_set_behavior(struct archive *, int);
 int archive_write_add_filter_by_name(struct archive *, const char *);
 int archive_write_close(struct archive *);
-ssize_t archive_write_data(struct archive *, const void *, size_t);
+la_ssize_t archive_write_data(struct archive *, const void *, size_t);
 struct archive *archive_write_disk_new(void);
 int archive_write_disk_set_options(struct archive *, int);
 int archive_write_header(struct archive *, struct archive_entry *);


### PR DESCRIPTION
Use `cdecl_c99_type` to handle `la_int64_t` & `la_ssize_t` instead of messing around with defines.