### PR TITLE
czmq: backport 2 upstream bugfixes

### DIFF
--- a/thirdparty/czmq/CMakeLists.txt
+++ b/thirdparty/czmq/CMakeLists.txt
@@ -1,4 +1,8 @@
-list(APPEND PATCH_FILES cmake_tweaks.patch)
+list(APPEND PATCH_FILES
+    cmake_tweaks.patch
+    # Fix 2 bugs in prefix handling.
+    fix_prefix_handling.patch
+)
 if(ANDROID)
     list(APPEND PATCH_FILES android.patch)
 endif()

--- a/thirdparty/czmq/fix_prefix_handling.patch
+++ b/thirdparty/czmq/fix_prefix_handling.patch
@@ -1,0 +1,13 @@
+--- a/src/zsys.c
++++ b/src/zsys.c
+@@ -334,9 +334,7 @@
+         zsys_set_thread_name_prefix (s_thread_name_prefix);
+ 
+     if (getenv ("ZSYS_THREAD_NAME_PREFIX_STR"))
+-        zsys_set_thread_name_prefix_str (getenv ("ZSYS_THREAD_NAME_PREFIX"));
+-    else
+-        zsys_set_thread_name_prefix_str (s_thread_name_prefix_str);
++        zsys_set_thread_name_prefix_str (getenv ("ZSYS_THREAD_NAME_PREFIX_STR"));
+ 
+     return s_process_ctx;
+ }


### PR DESCRIPTION
Cf. https://github.com/koreader/koreader/issues/14070.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2135)
<!-- Reviewable:end -->
