### PR TITLE
sdcv: ignore hidden filesystem entries

### DIFF
--- a/thirdparty/sdcv/CMakeLists.txt
+++ b/thirdparty/sdcv/CMakeLists.txt
@@ -6,6 +6,8 @@ list(APPEND PATCH_FILES
     sdcv-locale-hack.patch
     # Fix compilation with newer GLib.
     compat_with_newer_glib.patch
+    # Ignore hidden filesystem entries.
+    ignore_hidden.patch
 )
 
 string(APPEND GLIB2_INCLUDE_DIRS

--- a/thirdparty/sdcv/ignore_hidden.patch
+++ b/thirdparty/sdcv/ignore_hidden.patch
@@ -1,0 +1,13 @@
+--- a/src/utils.cpp
++++ b/src/utils.cpp
+@@ -64,6 +64,10 @@
+         const gchar *filename;
+ 
+         while ((filename = g_dir_read_name(dir)) != nullptr) {
++            if (filename[0] == '.') {
++                // Ignore hidden entries.
++                continue;
++            }
+             const std::string fullfilename(dirname + G_DIR_SEPARATOR_S + filename);
+             if (g_file_test(fullfilename.c_str(), G_FILE_TEST_IS_DIR))
+                 __for_each_file(fullfilename, suff, order_list, disable_list, f);


### PR DESCRIPTION
Including the dreaded `.DS_Store` and other macOS crap.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2138)
<!-- Reviewable:end -->
