### PR TITLE
make: use clang on macOS

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -201,6 +201,7 @@ else ifeq ($(TARGET), macos)
 	SDL=1
 	MACOS=1
 	EMULATE_READER=1
+	USE_CLANG=1
 else ifeq ($(TARGET), android)
 	ANDROID=1
 	MONOLIBTIC?=1
@@ -270,6 +271,7 @@ ifneq (,$(findstring darwin,$(MAKE_HOST)))
       DARWIN_AARCH64=1
     endif
     export MACOSX_DEPLOYMENT_TARGET := $(or $(MACOSX_DEPLOYMENT_TARGET),$(shell sw_vers -productVersion))
+    USE_CLANG=1
   endif
 endif
 


### PR DESCRIPTION
When compiling the emulator or for the `macos` target: while gcc is already an alias for clang, this might prevent the build system from picking another GCC install (e.g. from homebrew).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2140)
<!-- Reviewable:end -->
