### PR TITLE
dropbear: fix `_GNU_SOURCE` compilation warnings

### DIFF
--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -42,6 +42,7 @@ list(APPEND PATCH_FILES
     nopasswd-hack.patch
     pubkey-hack.patch
     reduce_build_verbosity.patch
+    fix__GNU_SOURCE_warnings.patch
 )
 
 if(ANDROID)

--- a/thirdparty/dropbear/fix__GNU_SOURCE_warnings.patch
+++ b/thirdparty/dropbear/fix__GNU_SOURCE_warnings.patch
@@ -1,0 +1,36 @@
+--- a/src/config.h.in
++++ b/src/config.h.in
+@@ -447,7 +447,9 @@
+ #undef _FILE_OFFSET_BITS
+ 
+ /* Use GNU extensions if glibc */
++#ifndef _GNU_SOURCE
+ #undef _GNU_SOURCE
++#endif
+ 
+ /* Define for large files, on AIX-style hosts. */
+ #undef _LARGE_FILES
+--- a/src/dbutil.c
++++ b/src/dbutil.c
+@@ -51,7 +51,9 @@
+ #include "config.h"
+ 
+ #ifdef __linux__
++#ifndef _GNU_SOURCE
+ #define _GNU_SOURCE
++#endif
+ /* To call clock_gettime() directly */
+ #include <sys/syscall.h>
+ #endif /* __linux */
+--- a/src/scpmisc.c
++++ b/src/scpmisc.c
+@@ -43,7 +43,9 @@
+ 
+ /*RCSID("OpenBSD: xmalloc.c,v 1.16 2001/07/23 18:21:46 stevesk Exp ");*/
+ 
++#ifndef _GNU_SOURCE
+ #define _GNU_SOURCE
++#endif
+ #include "includes.h"
+ #include "scpmisc.h"
+ 


### PR DESCRIPTION
Some platforms (e.g. kindle-legacy & pocketbook) pass `-D_GNU_SOURCE` as compilation flag, resulting a in build log littered with such warnings:
```
In file included from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/src/options.h:11,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/src/dbmalloc.h:4,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/tommath_class.h:1322,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/tommath_class.h:1305,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/tommath_class.h:1305,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/tommath_class.h:1305,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/tommath_private.h:8,
                 from …/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/source/libtommath/bn_cutoffs.c:1:
…/build/arm-pocketbook-linux-gnueabi/thirdparty/dropbear/build/config.h:451:9: warning: "_GNU_SOURCE" redefined
  451 | #define _GNU_SOURCE /**/
      |         ^~~~~~~~~~~
<command-line>: note: this is the location of the previous definition
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2142)
<!-- Reviewable:end -->
