### PR TITLE
ci/circle: increase default ccache cache size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
         type: executor
       ccache_maxsize:
         type: string
-        default: "128M"
+        default: "256M"
       check_ffi_cdecls:
         type: boolean
         default: false


### PR DESCRIPTION
128M is to low (a cold cache kobo release build uses 195M).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2159)
<!-- Reviewable:end -->
