### PR TITLE
cmake: don't mark generated FFI decls as by-products

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -527,7 +527,6 @@ function(ffi_target NAME OUTPUT INPUT)
     get_filename_component(INPUT_PATH ${INPUT} ABSOLUTE BASE_DIR ${BASE_DIR})
     add_custom_target(
         ${OUTPUT}
-        BYPRODUCTS ${BASE_DIR}/ffi/${OUTPUT}
         DEPENDS ${_DEPENDS}
         COMMAND ${STAGING_DIR}/bin/ffi-cdecl -o ffi/${OUTPUT} ${_ARGS} ${INPUT}
         COMMENT "Generating 'ffi/${OUTPUT}'"


### PR DESCRIPTION
Otherwise they get deleted when invoking `ninja clean`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2166)
<!-- Reviewable:end -->
