### PR TITLE
ci/macos: improve build directory cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,8 +115,6 @@ jobs:
 
       # }}}
 
-      # Restore / setup caches. {{{
-
       - name: Generate cache key
         run: make TARGET= cache-key
 
@@ -126,6 +124,8 @@ jobs:
         with:
           path: build
           key: ${{ env.CACHE_KEY }}-build-${{ hashFiles('cache-key') }}
+
+      # Restore / setup build cache. {{{
 
       - name: Restore build cache
         id: ccache-restore
@@ -168,7 +168,7 @@ jobs:
 
       # }}}
 
-      # Clean / save caches. {{{
+      # Clean / save build cache. {{{
 
       - name: Clean caches
         if: contains('failure success', steps.build.conclusion) && !cancelled()
@@ -186,13 +186,6 @@ jobs:
           path: /Users/runner/Library/Caches/ccache
           key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
 
-      - name: Save build directory
-        uses: actions/cache/save@v4
-        if: steps.build-restore.outputs.cache-hit != 'true'
-        with:
-          path: build
-          key: ${{ steps.build-restore.outputs.cache-primary-key }}
-
       # }}}
 
       # Dump & check binaries. {{{
@@ -204,6 +197,13 @@ jobs:
         run: make bincheck
 
       # }}}
+
+      - name: Save build directory
+        uses: actions/cache/save@v4
+        if: steps.build-restore.outputs.cache-hit != 'true'
+        with:
+          path: build
+          key: ${{ steps.build-restore.outputs.cache-primary-key }}
 
       - name: Test
         run: ./utils/fake_tty.py make --assume-old=all test


### PR DESCRIPTION
Save it **after** checking the binaries, to ensure a directory with broken shared dependencies is not saved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2168)
<!-- Reviewable:end -->
