### PR TITLE
sdl2: enable libdecor support when building an AppImage

### DIFF
--- a/thirdparty/sdl2/CMakeLists.txt
+++ b/thirdparty/sdl2/CMakeLists.txt
@@ -29,8 +29,6 @@ if(APPIMAGE)
         -DSDL_DIRECTFB=OFF
         -DSDL_KMSDRM=OFF
         -DSDL_RPI=OFF
-        # No libdecor-0-dev package in Ubuntu Focal.
-        -DSDL_WAYLAND_LIBDECOR=OFF
     )
 endif()
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2170)
<!-- Reviewable:end -->
