### PR TITLE
reduce ccache misses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ $(BASE_PREFIX)uninstall:
 
 setup $(BUILD_ENTRYPOINT): $(CMAKE_KOVARS) $(CMAKE_TCF) $(MESON_CROSS_TOOLCHAIN) $(MESON_HOST_TOOLCHAIN)
 	$(strip $(build_info))
-	$(CMAKE) $(CMAKE_FLAGS) -S $(KOR_BASE)/cmake -B $(CMAKE_DIR)
+	$(if $(CCACHE),env CCACHE_DISABLE=1 )$(CMAKE) $(CMAKE_FLAGS) -S $(KOR_BASE)/cmake -B $(CMAKE_DIR)
 
 define write_file
 $(if $(DRY_RUN),: write $1,$(file >$1,$2))

--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -99,20 +99,20 @@ extract_archive() { (
     # Of course `cmake -E tar` does not support `--strip-components=n`,
     # so we need to use a temporary directory and move things around…
     rm -rf "${sourcedir}" "${sourcedir}.tmp" || return 1
-    case "${archive}" in
-        *.src.rock)
-            # Luarocks source rock, there's no need to extract it.
-            return 0
-            ;;
-    esac
     mkdir "${sourcedir}.tmp" || return 1
     oldpwd="${PWD}"
     cd "${sourcedir}.tmp"
     '@CMAKE_COMMAND@' -E tar xf "${archive}"
-    root="$(echo *)"
+    case "${archive}" in
+        # Luarocks source rock, no root dir.
+        *.src.rock) root='' ;;
+        *) root="$(echo *)" ;;
+    esac
     cd "${oldpwd}"
     mv "${sourcedir}.tmp/${root}" "${sourcedir}"
-    rmdir "${sourcedir}.tmp"
+    if [ -d "${sourcedir}.tmp" ]; then
+        rmdir "${sourcedir}.tmp"
+    fi
 ); }
 
 apply_patches() { (

--- a/thirdparty/spec/lua_cliargs/CMakeLists.txt
+++ b/thirdparty/spec/lua_cliargs/CMakeLists.txt
@@ -1,4 +1,5 @@
 spec_rock(
-    https://luarocks.org/manifests/lunarmodules/lua_cliargs-3.0-2.src.rock
-    cca85e869fac1b42252692693aed0333
+    https://github.com/lunarmodules/lua_cliargs/archive/refs/tags/v3.0.2.tar.gz
+    a5d712064c5c08beb69d816e1a7b8378
+    ROCKSPEC rockspecs/lua_cliargs-3.0.2-1.rockspec
 )


### PR DESCRIPTION
- disable ccache during cmake's configure phase: shifting source paths (temporary directories) prevent cache hits anyway
- tweak luarocks builds to always use `luarocks make` even for source rocks, to ensure stable source paths (unlike a build with `luarocks build`, which involves a temporary directory)