### PR TITLE
mupdf: update to 1.26.10

### DIFF
--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -34,7 +34,7 @@ local mupdf = {
 }
 -- this cannot get adapted by the cdecl file because it is a
 -- string constant. Must match the actual mupdf API:
-local FZ_VERSION = "1.26.8"
+local FZ_VERSION = "1.26.10"
 
 local document_mt = { __index = {} }
 local page_mt = { __index = {} }

--- a/thirdparty/mupdf/CMakeLists.txt
+++ b/thirdparty/mupdf/CMakeLists.txt
@@ -119,8 +119,8 @@ list(APPEND BUILD_CMD COMMAND ${MAKE_CMD} libs)
 list(APPEND INSTALL_CMD COMMAND ${MAKE_CMD} DESTDIR=${STAGING_DIR} prefix=/ install-libs)
 
 external_project(
-    DOWNLOAD URL 3ca2eb786616345538ed9af23ad8da17
-    https://mupdf.com/downloads/archive/mupdf-1.26.8-source.tar.lz
+    DOWNLOAD URL 25c5f8bcf419ad1466b8fbb31f59dd5b
+    https://mupdf.com/downloads/archive/mupdf-1.26.10-source.tar.lz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
https://mupdf.com/releases/history#:~:text=1.26.10

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2178)
<!-- Reviewable:end -->
