### PR TITLE
utils: improve `gen_linker_exports.sh` script

### DIFF
--- a/utils/gen_linker_exports.sh
+++ b/utils/gen_linker_exports.sh
@@ -43,7 +43,7 @@ if [[ ${debug} -eq 1 ]]; then
     echo "vsfmt: ${vsfmt}"
 fi
 
-out="$(sed -E -n -e 's,^[[:space:]]*cdecl_(func|var)\(([^)]+)\)[[:space:]]*(/[/*].*)?$,\2,p' "$@" | sort -u)"
+out="$(sed -E -n -e 's,^[[:space:]]*cdecl_(func|var)\(([^)]+)\)[[:space:]]*;?[[:space:]]*(/[/*].*)?$,\2,p' "$@" | sort -u)"
 read -r -d '' -a symbols <<<"${out}" || true
 
 if [[ ${debug} -eq 1 ]]; then


### PR DESCRIPTION
Allow a semi-colon after a call to `cdecl_func` or `cdecl_var` (to appease vim automatic-indent when editing).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2181)
<!-- Reviewable:end -->
