### PR TITLE
ci/macos: speedup builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,14 +22,17 @@ jobs:
             platform: 'x86-64'
             xcode_version: '15.2'
             deployment_target: '10.15'
+            jobs: 4
           - image: '14'
             platform: 'ARM64'
             xcode_version: '15.4'
             deployment_target: '11.0'
+            jobs: 3
           - image: '15'
             platform: 'ARM64'
             xcode_version: '16.0'
             deployment_target: '14.6.1'
+            jobs: 3
 
     name: "macOS ${{ matrix.image }} ${{ matrix.platform }} 🔨${{ matrix.xcode_version }} 🎯${{ matrix.deployment_target }}"
 
@@ -41,7 +44,7 @@ jobs:
       CLICOLOR_FORCE: '1'
       KODEBUG: ""
       MACOSX_DEPLOYMENT_TARGET: ${{ matrix.deployment_target }}
-      MAKEFLAGS: 'OUTPUT_DIR=build'
+      MAKEFLAGS: OUTPUT_DIR=build PARALLEL_LOAD= PARALLEL_JOBS=${{ matrix.jobs }}
 
     steps:
 


### PR DESCRIPTION
It looks like the make / ninja `-l` (cap jobs to load-average) option does not work well, resulting in slower builds, so disable its use and hard-code the maximum number of jobs to each runner's number of processors.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2185)
<!-- Reviewable:end -->
