### PR TITLE
fix 5c02afb9 regression

### DIFF
--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -257,7 +257,11 @@ checkout_git_repo() { (
 
 make() { (
     set +u
+    # Strip outer make overrides to avoid messing-up a thirdparty
+    # project build (e.g. fbink `INSTALL_DIR` makefile variable).
     unset MAKEOVERRIDES
+    MAKEFLAGS="${MAKEFLAGS%% -- *}"
+    export MAKEFLAGS
     exec '@MAKE@' "$@"
 ); }
 


### PR DESCRIPTION
When recursively calling make to build a thirdparty project, we do need to strip overridden variables from `MAKEFLAGS` too, otherwise those may mess-up the build (e.g. fbink `INSTALL_DIR` makefile variable).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2188)
<!-- Reviewable:end -->
