### PR TITLE
ci/circle: speed up lint phase

### DIFF
--- a/.ci/lint_script.sh
+++ b/.ci/lint_script.sh
@@ -9,7 +9,7 @@ exit_code=0
 "${CI_DIR}/helper_shellchecks.sh" || exit_code=1
 
 echo -e "\n${ANSI_GREEN}Luacheck results${ANSI_RESET}"
-luacheck -q ffi spec || exit_code=1
+luacheck ${PARALLEL_JOBS:+-j "${PARALLEL_JOBS}"} -q ffi spec || exit_code=1
 
 echo -e "\n${ANSI_GREEN}CMakeLint results${ANSI_RESET}"
 mapfile -t cmake_files < <(git ls-files '*.cmake' '*/CMakeLists.txt')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ jobs:
     resource_class: small
     environment:
       BASH_ENV: "~/.bashrc"
+      PARALLEL_JOBS: "1"
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Honor `PARALLEL_JOBS` so the number of luacheck jobs is capped to 3 (we don't want to end-up using 36 jobs).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2193)
<!-- Reviewable:end -->
