### PR TITLE
ci/macos: update jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,25 +18,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - image: '13'
+          - image: '15'
             platform: 'x86-64'
-            xcode_version: '15.2'
+            xcode_version: '16.4'
             deployment_target: '10.15'
             jobs: 5
-          - image: '14'
-            platform: 'ARM64'
-            xcode_version: '15.4'
-            deployment_target: '11.0'
-            jobs: 4
           - image: '15'
             platform: 'ARM64'
-            xcode_version: '16.0'
-            deployment_target: '14.6.1'
+            xcode_version: '16.4'
+            deployment_target: '11.0'
             jobs: 4
 
     name: "macOS ${{ matrix.image }} ${{ matrix.platform }} 🔨${{ matrix.xcode_version }} 🎯${{ matrix.deployment_target }}"
 
-    runs-on: "macos-${{ matrix.image }}"
+    runs-on: "macos-${{ matrix.image }}${{ matrix.platform == 'x86-64' && '-intel' || '' }}"
 
     env:
       # Bump first number to reset all caches.


### PR DESCRIPTION
- switch x86-64 to macOS 15, since the macOS 13 runner images will be retired by December 4th
- keep only one ARM64 job, using the default XCode version and targeting the oldest possible macOS version for ARM64

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2194)
<!-- Reviewable:end -->
