### PR TITLE
tests: fix test runner handling of `--wrapper` option

### DIFF
--- a/test-runner/runtests
+++ b/test-runner/runtests
@@ -94,8 +94,8 @@ runtests_busted() {
         '') ;;
         gdb) cmd+=(gdb --args) ;;
         *)
-            # shellcheck disable=SC2206
-            cmd+=(${wrapper})
+            declare -a a="(${wrapper})"
+            cmd+=("${a[@]}")
             ;;
     esac
     cmd+=(./luajit -e 'require "busted.runner" {standalone = false}' /dev/null)


### PR DESCRIPTION
When using busted directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2195)
<!-- Reviewable:end -->
