### PR TITLE
libressl: update to 4.2.0

### DIFF
--- a/thirdparty/libressl/CMakeLists.txt
+++ b/thirdparty/libressl/CMakeLists.txt
@@ -17,14 +17,14 @@ list(APPEND BUILD_CMD COMMAND ninja)
 list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
 if(NOT MONOLIBTIC)
-    append_shared_lib_install_commands(INSTALL_CMD crypto VERSION 56)
-    append_shared_lib_install_commands(INSTALL_CMD ssl VERSION 59)
+    append_shared_lib_install_commands(INSTALL_CMD crypto VERSION 57)
+    append_shared_lib_install_commands(INSTALL_CMD ssl VERSION 60)
 endif()
 
 external_project(
-    DOWNLOAD URL b9488f503f90d05aae5369054ed1ae71
-    https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.1.1.tar.gz
-    https://cloudflare.cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.1.1.tar.gz
+    DOWNLOAD URL 985a9e1ac27d542857d666cdae2582b9
+    https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.2.0.tar.gz
+    https://cloudflare.cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.2.0.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/libressl/android.patch
+++ b/thirdparty/libressl/android.patch
@@ -1,6 +1,6 @@
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -82,7 +82,6 @@
+@@ -98,7 +98,6 @@
  	add_definitions(-D_BSD_SOURCE)
  	add_definitions(-D_POSIX_SOURCE)
  	add_definitions(-D_GNU_SOURCE)

--- a/thirdparty/libressl/cmake_tweaks.patch
+++ b/thirdparty/libressl/cmake_tweaks.patch
@@ -1,12 +1,15 @@
 --- i/CMakeLists.txt
 +++ w/CMakeLists.txt
-@@ -1,4 +1,4 @@
+@@ -13,7 +13,7 @@
+ # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ 
 -cmake_minimum_required (VERSION 3.16.4)
 +cmake_minimum_required (VERSION 3.17.5)
+ 
  if(MSVC)
  	cmake_policy(SET CMP0091 NEW)
- endif()
-@@ -532,8 +532,8 @@
+@@ -569,8 +569,8 @@
  		# Create pkgconfig files.
  		set(prefix      ${CMAKE_INSTALL_PREFIX})
  		set(exec_prefix \${prefix})


### PR DESCRIPTION
https://github.com/libressl/portable/releases/tag/v4.2.0

Code size changes:
- android-arm: -11.4 KB
- android-arm64: -12.2 KB
- emulator: -17.8 KB
- kindlepw2: +7.7 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2200)
<!-- Reviewable:end -->
