### PR TITLE
libarchive: ignore locale and force UTF-8

### DIFF
--- a/thirdparty/libarchive/CMakeLists.txt
+++ b/thirdparty/libarchive/CMakeLists.txt
@@ -1,3 +1,4 @@
+list(APPEND PATCH_FILES ignore_locale_and_use_utf8.patch)
 if(ANDROID)
     list(APPEND PATCH_FILES android.patch)
     list(APPEND PATCH_CMD COMMAND mv contrib/android/include/android_lf.h libarchive/)

--- a/thirdparty/libarchive/ignore_locale_and_use_utf8.patch
+++ b/thirdparty/libarchive/ignore_locale_and_use_utf8.patch
@@ -1,0 +1,20 @@
+--- a/libarchive/archive_string.c
++++ b/libarchive/archive_string.c
+@@ -445,6 +445,7 @@
+ default_iconv_charset(const char *charset) {
+ 	if (charset != NULL && charset[0] != '\0')
+ 		return charset;
++#if 0
+ #if HAVE_LOCALE_CHARSET && !defined(__APPLE__)
+ 	/* locale_charset() is broken on Mac OS */
+ 	return locale_charset();
+@@ -453,6 +454,9 @@
+ #else
+ 	return "";
+ #endif
++#else
++	return "UTF-8";
++#endif
+ }
+ 
+ #if defined(_WIN32) && !defined(__CYGWIN__)


### PR DESCRIPTION
We don't use `setlocale` anyway, so libarchive's encoding would default to ASCII.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2201)
<!-- Reviewable:end -->
