### PR TITLE
feat/remarkable: refresh levels

### DIFF
--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -1152,6 +1152,26 @@ function framebuffer:init()
         self.waveform_flashnight = self.waveform_night
         self.night_is_reagl = false
 
+        self.wf_level_max = 3
+        local level = self:getWaveformLevel()
+        -- The best quality but much slower refresh.
+        if level == 0 then
+            self.waveform_fast = C.WAVEFORM_MODE_GC16
+            self.waveform_partial = C.WAVEFORM_MODE_GC16
+        -- Good quality for contents while still having decently fast "fast" refresh mode without losing any color.
+        elseif level == 1 then
+            self.waveform_fast = C.WAVEFORM_MODE_GL16
+            self.waveform_partial = C.WAVEFORM_MODE_GC16
+        -- Level 2 was the setting before levels were introduced, fast refresh mode loses color on color-enabled devices.
+        elseif level == 2 then
+            self.waveform_fast = C.WAVEFORM_MODE_DU
+            self.waveform_partial = C.WAVEFORM_MODE_GL16
+        -- Fastest refresh, but more ghosting and artifacts, and color is lost on color-enabled devices.
+        elseif level == 3 then
+            self.waveform_fast = C.WAVEFORM_MODE_DU
+            self.waveform_partial = C.WAVEFORM_MODE_DU
+        end
+
         -- Keep our data structures around
         self.update_data = ffi.new("struct mxcfb_update_data")
         -- NOTE: We update temp at runtime on rM


### PR DESCRIPTION
Current default refresh mode does leave some ghosting and artifacts on color devices especially when reading color documents. Also color quality depends on refresh mode. So add refresh levels to give users the option of quality vs speed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2209)
<!-- Reviewable:end -->
