### PR TITLE
cmake: tweak download command line

### DIFF
--- a/thirdparty/cmake_modules/koenv.sh
+++ b/thirdparty/cmake_modules/koenv.sh
@@ -83,7 +83,7 @@ download_archive() { (
     for timeout in 0 2 4; do
         sleep ${timeout}
         for url in "$@"; do
-            if curl --fail --location --connect-timeout 10 --create-dirs --max-time 30 --retry 3 --output "${dest}" "${url}" && validate_md5 "${dest}" "${md5}"; then
+            if curl --fail --location --connect-timeout 15 --create-dirs --max-time 120 --output "${dest}" "${url}" && validate_md5 "${dest}" "${md5}"; then
                 return 0
             fi
         done


### PR DESCRIPTION
To work around MuPDF' slow server:
- increase connection timeout and maximum allowed total time
- drop curl builtin retries: we already manually retrying 2 times anyway (in case of possible incorrect checksum)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2217)
<!-- Reviewable:end -->
