### PR TITLE
cmake: improve luarocks-based thirdparty projects

### DIFF
--- a/thirdparty/cmake_modules/koreader_external_project.cmake
+++ b/thirdparty/cmake_modules/koreader_external_project.cmake
@@ -373,6 +373,8 @@ function(luarocks_external_project URL MD5)
     if(_SOURCE_SUBDIR)
         list(APPEND BUILD_CMD COMMAND cd ${_SOURCE_SUBDIR})
     endif()
+    # First things first: go back to a pristine source tree…
+    list(APPEND BUILD_CMD COMMAND clean_tree ${SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/source.list)
     list(APPEND BUILD_CMD COMMAND
         ${STAGING_DIR}/bin/luarocks
         --tree ${BINARY_DIR}/dist make ${_ROCKSPEC}


### PR DESCRIPTION
Ensure all luarocks build commands are run from a pristine source tree:
- shared modules are already fully rebuilt by luarocks anyway (not incrementally)
- this fix a potential issue if the luafilesystem build phase is triggered again: the luarocks build command will load the source tree previously built `lfs.so`, and segfault when the file is recreated while in use.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2220)
<!-- Reviewable:end -->
