### PR TITLE
linux: build in monolibtic mode

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -598,6 +598,7 @@ else ifeq ($(TARGET), arm-generic)
 	ARM_ARCH:=$(ARMV6_GENERIC_ARCH)
 	ARM_ARCH+=-mfloat-abi=softfp
 else ifeq ($(TARGET), linux)
+	MONOLIBTIC = 1
 	ifeq ($(LINUX_ARCH), arm)
 		ARM_ARCH:=$(ARMV7_GENERIC_ARCH)
 		ARM_ARCH+=-mfloat-abi=hard


### PR DESCRIPTION
This will help improve isolation from system libraries (fixing flathub/rocks.koreader.KOReader#60 for example).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2232)
<!-- Reviewable:end -->
