### PR TITLE
dropbear: statically link libcrypt when building for pocketbook

### DIFF
--- a/thirdparty/dropbear/CMakeLists.txt
+++ b/thirdparty/dropbear/CMakeLists.txt
@@ -65,8 +65,8 @@ list(APPEND CFG_CMD
 )
 list(APPEND CFG_CMD COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_CURRENT_BINARY_DIR}/localoptions.h localoptions.h)
 
-if(KINDLE)
-    # Some kindles don't have `libcrypt.so.1`, so link the static version.
+if(KINDLE OR POCKETBOOK)
+    # Some kindles / pocketbooks don't have `libcrypt.so.1`, so link the static version.
     find_compiler_lib_path(LIBCRYPT libcrypt.a)
     list(APPEND CFG_CMD COMMAND ${ISED} "/^dropbear:/{n$<SEMICOLON>s| -lcrypt | ${LIBCRYPT} |}" Makefile)
 endif()


### PR DESCRIPTION
Some pocketbook systems are missing `libcrypt.so.1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2243)
<!-- Reviewable:end -->
