### PR TITLE
harfbuzz: update to 12.3.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -63,8 +63,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL d9c0c102a1595e718fd5bbb0e4497594
-    https://github.com/harfbuzz/harfbuzz/releases/download/12.2.0/harfbuzz-12.2.0.tar.xz
+    DOWNLOAD URL 1a61090b530e820c685911ac198a04bc
+    https://github.com/harfbuzz/harfbuzz/releases/download/12.3.0/harfbuzz-12.3.0.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}


### PR DESCRIPTION
https://github.com/harfbuzz/harfbuzz/releases/tag/12.3.0

Code size change:
- android-arm: -1.1 KB
- android-arm64: -4.8 KB
- emulator: -18.8 KB
- kindlepw2: -8.2 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2244)
<!-- Reviewable:end -->
