### PR TITLE
mupdf: fix `fz_default_color_params` export

### DIFF
--- a/ffi-cdecl/wrap-mupdf_cdecl.c
+++ b/ffi-cdecl/wrap-mupdf_cdecl.c
@@ -111,7 +111,7 @@ cdecl_func(fz_drop_stext_page)
 
 cdecl_type(fz_color_params)
 cdecl_type(fz_default_colorspaces)
-cdecl_const(fz_default_color_params)
+cdecl_var(fz_default_color_params)
 
 /* pixmaps */
 cdecl_func(fz_new_pixmap) // compat


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2256)
<!-- Reviewable:end -->
