### PR TITLE
Fix offs_x/offs_y typo in BB_add_blit_from fast path

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -1717,7 +1717,7 @@ void BB_add_blit_from(BlitBuffer * restrict dst, const BlitBuffer * restrict src
         // NOP
         return;
     } else if (alpha == 0xFF) {
-        return BB_blit_to(src, dst, dest_x, dest_y, offs_x, offs_x, w, h);
+        return BB_blit_to(src, dst, dest_x, dest_y, offs_x, offs_y, w, h);
     }
 
     const int dbb_type = GET_BB_TYPE(dst);


### PR DESCRIPTION
The `alpha == 0xFF` fast path in `BB_add_blit_from` passes `offs_x` as both the x and y source offset to `BB_blit_to`:


```c
return BB_blit_to(src, dst, dest_x, dest_y, offs_x, offs_x, w, h);
```

This causes out-of-bounds reads whenever `offs_x != offs_y`, which can lead to crashes or visual corruption.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2266)
<!-- Reviewable:end -->
