### PR TITLE
lua-Spore: fix matching plain application/json

### DIFF
--- a/thirdparty/lua-Spore/detect-more-json-content-types.patch
+++ b/thirdparty/lua-Spore/detect-more-json-content-types.patch
@@ -16,7 +16,7 @@ index 225b25e..d3419b5 100644
  
 +local has_json_mime_type = function(header)
 +    local mime_type = match(header, '[^;]+')
-+    return match(mime_type, "^%s*application/[%w.]-%+json%s*$")
++    return match(mime_type, "^%s*application/[%w.]-%+?json%s*$")
 +end
 +
  function m.call (_args, req)


### PR DESCRIPTION
See https://github.com/koreader/koreader/issues/14972

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2267)
<!-- Reviewable:end -->
