### PR TITLE
fix: SDL3 HiDPI return value check

### DIFF
--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -132,7 +132,7 @@ function S.open(w, h, x, y)
     S.renderer = SDL.SDL_CreateRenderer(S.screen, nil)
     local output_w = ffi.new("int[1]", 0)
     local output_h = ffi.new("int[1]", 0)
-    if SDL.SDL_GetCurrentRenderOutputSize(S.renderer, output_w, output_h) == 0 and tonumber(output_w[0]) ~= w then
+    if SDL.SDL_GetCurrentRenderOutputSize(S.renderer, output_w, output_h) and tonumber(output_w[0]) ~= w then
         -- This is a workaround to obtain a simulacrum of real pixels in scenarios that marketing likes to refer to as "HiDPI".
         -- The utterly deranged idea is to render things at 2x or 3x, so it can subsequently be scaled down in order to assure everything will always be at least a little bit blurry unless you happen to use exactly 2x or 3x, instead of the traditional methods of just rendering at the desired DPI that have worked perfectly fine in Windows and X11 for decades.
         -- Contrary to claims by the blind that macOS is sharp, it's not.

--- a/ffi/framebuffer_SDL3.lua
+++ b/ffi/framebuffer_SDL3.lua
@@ -37,7 +37,7 @@ function framebuffer:resize(w, h)
     SDL.win_w = w or tonumber(output_w[0])
     SDL.win_h = h or tonumber(output_h[0])
 
-    if SDL.SDL.SDL_GetCurrentRenderOutputSize(SDL.renderer, output_w, output_h) == 0 then
+    if SDL.SDL.SDL_GetCurrentRenderOutputSize(SDL.renderer, output_w, output_h) then
         -- This is a workaround to obtain a simulacrum of real pixels in scenarios that marketing likes to refer to as "HiDPI".
         -- The utterly deranged idea is to render things at 2x or 3x, so it can subsequently be scaled down in order to assure everything will always be at least a little bit blurry unless you happen to use exactly 2x or 3x, instead of the traditional methods of just rendering at the desired DPI that have worked perfectly fine in Windows and X11 for decades.
         -- Contrary to claims by the blind that macOS is sharp, it's not.


### PR DESCRIPTION
SDL3's SDL_GetCurrentRenderOutputSize returns bool (true=success), not int (0=success) like SDL2's SDL_GetRendererOutputSize. The == 0 check skips the HiDPI codepath on success, causing blurry rendering on HiDPI displays like macos Retina.

Close #2284.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2285)
<!-- Reviewable:end -->
