### PR TITLE
mupdf: add annotation type and contents getters

### DIFF
--- a/ffi-cdecl/wrap-mupdf_cdecl.c
+++ b/ffi-cdecl/wrap-mupdf_cdecl.c
@@ -147,6 +147,8 @@ cdecl_type(pdf_page)
 cdecl_type(pdf_document)
 
 /* annotations */
+cdecl_func(mupdf_pdf_annot_type)
+cdecl_func(mupdf_pdf_annot_contents)
 cdecl_func(mupdf_pdf_create_annot)
 cdecl_func(mupdf_pdf_delete_annot)
 cdecl_func(mupdf_pdf_set_annot_quad_points)

--- a/ffi/mupdf.lua
+++ b/ffi/mupdf.lua
@@ -830,26 +830,35 @@ function page_mt.__index:updateMarkupAnnotation(annot, contents)
     if ok == nil then merror(self.ctx, "could not update markup annot contents") end
 end
 
-function page_mt.__index:getMarkupAnnotationBoxesFromPage()
-    local boxes = {}
+function page_mt.__index:getEmbeddedAnnotations()
+    local annotations = {}
     local annot = W.mupdf_pdf_first_annot(self.ctx, ffi.cast("pdf_page*", self.page))
     while annot ~= nil do
-        local annot_boxes = {}
-        local quadpoint = ffi.new("fz_quad[1]")
-        local point_count = W.mupdf_pdf_annot_quad_point_count(self.ctx, annot)
-        for i = 0, point_count - 1 do
-            W.mupdf_pdf_annot_quad_point(self.ctx, annot, i, quadpoint)
-            table.insert(annot_boxes, {
-                h = quadpoint[0].ll.y - quadpoint[0].ul.y + 1,
-                w = quadpoint[0].ur.x - quadpoint[0].ul.x + 1,
-                x = quadpoint[0].ul.x,
-                y = quadpoint[0].ul.y,
+        local annot_type = W.mupdf_pdf_annot_type(self.ctx, annot)
+        -- markup annotations: highlight=8, underline=9, squiggly=10, strikeout=11
+        if annot_type >= 8 and annot_type <= 11 then
+            local annot_boxes = {}
+            local quadpoint = ffi.new("fz_quad[1]")
+            local point_count = W.mupdf_pdf_annot_quad_point_count(self.ctx, annot)
+            for i = 0, point_count - 1 do
+                W.mupdf_pdf_annot_quad_point(self.ctx, annot, i, quadpoint)
+                table.insert(annot_boxes, {
+                    h = quadpoint[0].ll.y - quadpoint[0].ul.y + 1,
+                    w = quadpoint[0].ur.x - quadpoint[0].ul.x + 1,
+                    x = quadpoint[0].ul.x,
+                    y = quadpoint[0].ul.y,
+                })
+            end
+            local contents = W.mupdf_pdf_annot_contents(self.ctx, annot)
+            table.insert(annotations, {
+                boxes = annot_boxes,
+                type = annot_type,
+                contents = contents ~= nil and ffi.string(contents) or nil,
             })
         end
-        table.insert(boxes, annot_boxes)
         annot = W.mupdf_pdf_next_annot(self.ctx, annot)
     end
-    return next(boxes) and boxes
+    return next(annotations) and annotations
 end
 
 -- image loading via MuPDF:

--- a/ffi/mupdf_h.lua
+++ b/ffi/mupdf_h.lua
@@ -277,6 +277,8 @@ enum pdf_annot_type {
 typedef struct pdf_annot pdf_annot;
 typedef struct pdf_page pdf_page;
 typedef struct pdf_document pdf_document;
+int mupdf_pdf_annot_type(fz_context *, pdf_annot *);
+const char *mupdf_pdf_annot_contents(fz_context *, pdf_annot *);
 pdf_annot *mupdf_pdf_create_annot(fz_context *, pdf_page *, enum pdf_annot_type);
 void *mupdf_pdf_delete_annot(fz_context *, pdf_page *, pdf_annot *);
 void *mupdf_pdf_set_annot_quad_points(fz_context *, pdf_annot *, int, const fz_quad *);

--- a/wrap-mupdf.h
+++ b/wrap-mupdf.h
@@ -144,6 +144,12 @@ MUPDF_WRAP(mupdf_fz_page_number_from_location, int, -1,
 MUPDF_WRAP(mupdf_fz_location_from_page_number, void *, NULL,
     { *location = fz_location_from_page_number(ctx, doc, number); ret = (void*) -1; },
     fz_document *doc, fz_location *location, int number)
+MUPDF_WRAP(mupdf_pdf_annot_type, int, -1,
+     ret = pdf_annot_type(ctx, annot),
+     pdf_annot *annot)
+MUPDF_WRAP(mupdf_pdf_annot_contents, const char*, NULL,
+     ret = pdf_annot_contents(ctx, annot),
+     pdf_annot *annot)
 MUPDF_WRAP(mupdf_pdf_create_annot, pdf_annot*, NULL,
     ret = pdf_create_annot(ctx, page, type),
     pdf_page *page, enum pdf_annot_type type)


### PR DESCRIPTION
Expose `pdf_annot_type()` and `pdf_annot_contents()` from MuPDF as FFI-accessible getters.

koreader-base currently wraps **setter** functions for annotation properties (`pdf_set_annot_contents`, `pdf_create_annot` with type) but not the corresponding **getters**. This means code that imports embedded PDF annotations can read quadpoint coordinates but cannot read the annotation type (Highlight vs Underline vs StrikeOut) or the `/Contents` field (user notes).

### Changes

- **`wrap-mupdf.h`**: Add `mupdf_pdf_annot_type` and `mupdf_pdf_annot_contents` wrappers
- **`ffi-cdecl/wrap-mupdf_cdecl.c`**: Export the two new functions
- **`ffi/mupdf_h.lua`**: Add FFI declarations
- **`ffi/mupdf.lua`**: Add `getEmbeddedAnnotations()` -- returns type, quadpoint boxes, and contents for each markup annotation (Highlight, Underline, Squiggly, StrikeOut), filtering out Links, Popups, Widgets, etc.

### Context

Needed by koreader/koreader#15075 to fix the embedded annotation import feature.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2287)
<!-- Reviewable:end -->
