### PR TITLE
make: do not use `-march=native` for CI emulator builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # Bump this to reset all caches.
     cache_epoch:
       type: integer
-      default: 4
+      default: 5
 
 # }}}
 
@@ -158,12 +158,12 @@ jobs:
       - restore_cache:
           name: Restore build directory
           keys:
-            - &CACHE_KEY_BUILD_DIR '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-build-{{ arch }}-{{ checksum "cache-key" }}'
+            - &CACHE_KEY_BUILD_DIR '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-build-{{ checksum "cache-key" }}'
       - restore_cache:
           name: Restore build cache
           keys:
-            - &CACHE_KEY_BUILD_CACHE '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-{{ checksum "cache-key" }}'
-            - '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ arch }}-'
+            - &CACHE_KEY_BUILD_CACHE '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-{{ checksum "cache-key" }}'
+            - '<< pipeline.parameters.cache_epoch >>-{{ .Environment.CIRCLE_JOB }}-ccache-'
       - run:
           name: Setup build cache
           command: |

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -611,7 +611,14 @@ else ifeq ($(TARGET), macos)
     TARGET_CFLAGS = -mtune=generic
   endif
 else ifdef EMULATE_READER
-  TARGET_CFLAGS = -march=native
+  ifdef CI
+    # Don't use `-march=native` on CI: different runner hardware
+    # will result in build cache misses and possibly crashes when
+    # running the testsuite with a restored build directory.
+    TARGET_CFLAGS = -mtune=generic
+  else
+    TARGET_CFLAGS = -march=native
+  endif
 endif
 
 # Some of our deps require C11 & C++17 (`if constexpr (…)`) support.


### PR DESCRIPTION
Avoid potential build cache mismatches due to different runner hardware.

I don't think I've seen the issue on Circle CI, but on Github Actions, I've definitively ended up with some weird build with 0% ccache hit rate, or worse, all the tests crashing with an illegal instruction exception after restoring a build directory from cache.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2330)
<!-- Reviewable:end -->
