### PR TITLE
libunibreak: update to 7.0

### DIFF
--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -1,3 +1,5 @@
+list(APPEND PATCH_FILES trim_the_fat.patch)
+
 list(APPEND CFG_CMD COMMAND env)
 append_autotools_vars(CFG_CMD)
 list(APPEND CFG_CMD
@@ -22,6 +24,7 @@ endif()
 external_project(
     DOWNLOAD URL ccc11ff950ef7aefa815035f3a20de57
     https://github.com/adah1972/libunibreak/releases/download/libunibreak_7_0/libunibreak-7.0.tar.gz
+    PATCH_FILES ${PATCH_FILES}
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}

--- a/thirdparty/libunibreak/CMakeLists.txt
+++ b/thirdparty/libunibreak/CMakeLists.txt
@@ -12,7 +12,7 @@ list(APPEND BUILD_CMD COMMAND make)
 list(APPEND INSTALL_CMD COMMAND make install)
 
 if(NOT MONOLIBTIC)
-    set(LIB_SPEC unibreak VERSION 6)
+    set(LIB_SPEC unibreak VERSION 7)
     if(APPLE)
         append_shared_lib_fix_commands(INSTALL_CMD ${LIB_SPEC} ID)
     endif()
@@ -20,8 +20,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 8df410d010e03de1a339a400a920335e
-    https://github.com/adah1972/libunibreak/releases/download/libunibreak_6_1/libunibreak-6.1.tar.gz
+    DOWNLOAD URL ccc11ff950ef7aefa815035f3a20de57
+    https://github.com/adah1972/libunibreak/releases/download/libunibreak_7_0/libunibreak-7.0.tar.gz
     CONFIGURE_COMMAND ${CFG_CMD}
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}

--- a/thirdparty/libunibreak/trim_the_fat.patch
+++ b/thirdparty/libunibreak/trim_the_fat.patch
@@ -1,0 +1,41 @@
+diff --git a/src/eastasianwidthdata.c b/src/eastasianwidthdata.c
+index 7915446..b2a301c 100644
+--- a/src/eastasianwidthdata.c
++++ b/src/eastasianwidthdata.c
+@@ -7,6 +7,8 @@
+ 
+ #include "eastasianwidthdef.h"
+ 
++#if 0
++
+ static const struct EastAsianWidthProperties eaw_prop[] = {
+     {0x0020, 0x007E, EAW_Na},
+     {0x00A1, 0x00A1, EAW_A},
+@@ -325,6 +327,8 @@ static const struct EastAsianWidthProperties eaw_prop[] = {
+     {0x100000, 0x10FFFD, EAW_A},
+ };
+ 
++#endif
++
+ bool ub_is_op_east_asian(utf32_t ch) {
+     return false
+         || (ch >= 0x2329 && ch <= 0x2768)
+diff --git a/src/eastasianwidthdef.c b/src/eastasianwidthdef.c
+index 60df5e2..49ae65f 100644
+--- a/src/eastasianwidthdef.c
++++ b/src/eastasianwidthdef.c
+@@ -25,6 +25,8 @@
+ #include "eastasianwidthdata.c"
+ #include "unibreakdef.h"
+ 
++#if 0
++
+ /**
+  * Gets the East Asian Width class of a character.
+  *
+@@ -42,3 +44,5 @@ enum EastAsianWidthClass ub_get_char_eaw_class(utf32_t ch)
+     }
+     return EAW_N;
+ }
++
++#endif


### PR DESCRIPTION
https://github.com/adah1972/libunibreak/releases/tag/libunibreak_7_0

Code size change:
- `android-arm`: -3.5 KB
- `android-arm64`: -3.6 KB
- `kindlepw2`: -3.1 KB
- `linux`: -2.2 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2337)
<!-- Reviewable:end -->
