### PR TITLE
harfbuzz: update to 14.1.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND PATCH_CMD COMMAND ${ISED} "/^#line/d"
 list(APPEND CFG_CMD COMMAND
     ${MESON_SETUP} --default-library=$<IF:$<BOOL:${MONOLIBTIC}>,static,shared>
     -Dfreetype=enabled
+    -Dgpu=disabled
     -Draster=disabled
     -Dsubset=disabled
     -Dtests=disabled
@@ -63,8 +64,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL de595664aa7213f408d417ea16e8a6be
-    https://github.com/harfbuzz/harfbuzz/releases/download/13.2.1/harfbuzz-13.2.1.tar.xz
+    DOWNLOAD URL da27771546eb196b8bec6703d81b12b7
+    https://github.com/harfbuzz/harfbuzz/releases/download/14.1.0/harfbuzz-14.1.0.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}

--- a/thirdparty/harfbuzz/android.patch
+++ b/thirdparty/harfbuzz/android.patch
@@ -17,10 +17,10 @@ index e1ccd5b94..e62b8fb9f 100644
      fprintf (stderr, "harfbuzz ");
      vfprintf (stderr, fmt, ap);
 diff --git a/src/hb.hh b/src/hb.hh
-index 2ebae65f2..169461d8b 100644
+index 4a21ca90b..e3dd1f885 100644
 --- a/src/hb.hh
 +++ b/src/hb.hh
-@@ -493,6 +493,10 @@ static int HB_UNUSED _hb_errno = 0;
+@@ -494,6 +494,10 @@ static int HB_UNUSED _hb_errno = 0;
  #define HB_NO_SETLOCALE 1
  #endif
  


### PR DESCRIPTION
- https://github.com/harfbuzz/harfbuzz/releases/tag/14.1.0
- https://github.com/harfbuzz/harfbuzz/releases/tag/14.0.0

Code size change:
- `android-arm`: +23.3 KB
- `android-arm64`: +15.0 KB
- `kindlepw2`: +14.1 KB
- `linux`: +11.7 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2339)
<!-- Reviewable:end -->
