### PR TITLE
minizip: update to aa4758b and use its `crypt.h` header

### DIFF
--- a/thirdparty/minizip/CMakeLists.txt
+++ b/thirdparty/minizip/CMakeLists.txt
@@ -4,12 +4,14 @@ list(APPEND BUILD_CMD COMMAND ninja)
 
 list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
+append_install_commands(INSTALL_CMD ${SOURCE_DIR}/crypt.h DESTINATION ${STAGING_DIR}/include/contrib/minizip)
+
 external_project(
     # NOTE: 53a657318af1fccc4bac7ed230729302b2391d1d is the tip
     # of the 1.2 branch. The fcrypt API we need is gone in master.
     # FIXME: Even then, something in said branch seems to upset MuPDF
     # with our custom patch as-is, so keep using the current code...
-    DOWNLOAD GIT 0b46a2b4ca317b80bc53594688883f7188ac4d08
+    DOWNLOAD GIT aa4758baea16e9dc03583340e62b370ea1140df9
     https://github.com/nmoinvaz/minizip
     PATCH_OVERLAY overlay
     CMAKE_ARGS ${CMAKE_ARGS}

--- a/thirdparty/mupdf/encrypted_zip.patch
+++ b/thirdparty/mupdf/encrypted_zip.patch
@@ -50,19 +50,13 @@ diff --git a/source/fitz/unzip.c b/source/fitz/unzip.c
 index 35d14fb1c..249ab0174 100644
 --- a/source/fitz/unzip.c
 +++ b/source/fitz/unzip.c
-@@ -43,10 +43,33 @@
+@@ -43,10 +43,27 @@
  
  #define ZIP_ENCRYPTED_FLAG 0x1
  
 +#ifdef HAVE_LIBAES
-+/*
-+ * Note that the original crypt.h in minizip uses unsigned long pointer to
-+ * pcrc_32_tab it will cause problem on x86_64 machine. While the crypt.h
-+ * in zlib-1.2.8 contrib minizip uses z_crc_t pointer which is determined
-+ * to unsigned int pointer on 64 bit machine.
-+ */
-+#include "contrib/minizip/crypt.h"  // from zlib-1.2.8
-+#include "aes/fileenc.h"            // from minizip-g0b46a2b
++#include "contrib/minizip/crypt.h"
++#include "aes/fileenc.h"
 +#define AES_METHOD          (99)
 +#define AES_PWVERIFYSIZE    (2)
 +#define AES_MAXSALTLENGTH   (16)
@@ -92,8 +86,8 @@ index 35d14fb1c..249ab0174 100644
 +#ifdef HAVE_LIBAES
 +	int crypted;
 +	char password[128];
-+	unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-+	const z_crc_t *pcrc_32_tab;
++	uint32_t keys[3];     /* keys defining the pseudo-random sequence */
++	const uint32_t *pcrc_32_tab;
 +	unsigned long aes_encryption_mode;
 +	unsigned long aes_compression_method;
 +	unsigned long aes_version;
@@ -118,15 +112,16 @@ index 35d14fb1c..249ab0174 100644
  			zip->count++;
  		}
  	}
-@@ -435,6 +478,12 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
+@@ -435,6 +478,13 @@ static int read_zip_entry_header(fz_context *ctx, fz_zip_archive *zip, zip_entry
  	fz_stream *file = zip->super.file;
  	uint32_t sig;
  	int general, method, namelength, extralength;
-+	int crc32, modtime;
++	uint32_t crc32;
++	uint16_t modtime;
 +#ifdef HAVE_LIBAES
 +	int i, headerid, datasize, chk;
 +	unsigned char source[12];
-+	unsigned char crcbyte;
++	uint8_t crcbyte;
 +#endif
  
  	fz_seek(ctx, file, ent->offset, 0);
@@ -187,7 +182,7 @@ index 35d14fb1c..249ab0174 100644
 +			}
 +		} else {
 +			fz_seek(ctx, file, extralength, 1);
-+			zip->pcrc_32_tab = (const z_crc_t*)get_crc_table();
++			zip->pcrc_32_tab = (const uint32_t*)get_crc_table();
 +			init_keys(zip->password, zip->keys, zip->pcrc_32_tab);
 +			fz_read(ctx, file, source, 12);
 +			for (i = 0; i < 12; i++) {

--- a/thirdparty/zlib/CMakeLists.txt
+++ b/thirdparty/zlib/CMakeLists.txt
@@ -11,7 +11,6 @@ list(APPEND BUILD_CMD COMMAND ninja)
 
 list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
-append_install_commands(INSTALL_CMD ${SOURCE_DIR}/contrib/minizip/crypt.h DESTINATION ${STAGING_DIR}/include/contrib/minizip)
 if(NOT MONOLIBTIC)
     append_shared_lib_install_commands(INSTALL_CMD z VERSION 1)
 endif()


### PR DESCRIPTION
So we don't have to use the `crypt.h` provided by zlib, and possibly switch to zlib-ng (which does not include it).

Changelog: https://github.com/nmoinvaz/minizip/compare/0b46a2b...aa4758b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2341)
<!-- Reviewable:end -->
