### PR TITLE
libressl: update to 4.3.1

### DIFF
--- a/thirdparty/libressl/CMakeLists.txt
+++ b/thirdparty/libressl/CMakeLists.txt
@@ -22,9 +22,9 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 3eac6e95cd4ba1f03055181b950427da
-    https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.2.1.tar.gz
-    https://cloudflare.cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.2.1.tar.gz
+    DOWNLOAD URL 888de2b4f668651f1fe19d9e0340dd57
+    https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.3.1.tar.gz
+    https://cloudflare.cdn.openbsd.org/pub/OpenBSD/LibreSSL/libressl-4.3.1.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}

--- a/thirdparty/libressl/cmake_tweaks.patch
+++ b/thirdparty/libressl/cmake_tweaks.patch
@@ -9,14 +9,3 @@
  
  if(MSVC)
  	cmake_policy(SET CMP0091 NEW)
-@@ -569,8 +569,8 @@
- 		# Create pkgconfig files.
- 		set(prefix      ${CMAKE_INSTALL_PREFIX})
- 		set(exec_prefix \${prefix})
--		set(libdir      \${exec_prefix}/${CMAKE_INSTALL_LIBDIR})
--		set(includedir  \${prefix}/${CMAKE_INSTALL_INCLUDEDIR})
-+		set(libdir      \${exec_prefix}/lib)
-+		set(includedir  \${prefix}/include)
- 		if(PLATFORM_LIBS)
- 			string(REGEX REPLACE ";" " -l" PLATFORM_LDADD ";${PLATFORM_LIBS}")
- 		endif()


### PR DESCRIPTION
- https://github.com/libressl/portable/releases/tag/v4.3.1
- https://github.com/libressl/portable/releases/tag/v4.3.0

Code size change:
- `android-arm`  : + 8.3 KB
- `android-arm64`: +21.1 KB
- `kindlepw2`    : + 4.5 KB
- `linux`        : + 6.8 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2343)
<!-- Reviewable:end -->
