### PR TITLE
make: explicitly disable executable stack

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -652,6 +652,11 @@ ifndef DARWIN
   ifneq ($(TARGET), android)
     LDFLAGS += -Wl,@$(abspath $(KOR_BASE)/origin.ldflags)
   endif
+  # No code we build should need an executable stack, so disable
+  # it explicitly to avoid issues on some systems (e.g. Gentoo).
+  ifndef ANDROID
+    LDFLAGS += -Wl,-z,noexecstack
+  endif
   # In monolibtic mode on Android, we can statically link the STL.
   ifeq ($(TARGET), android)
     LDFLAGS += $(if $(MONOLIBTIC),-static-libstdc++)


### PR DESCRIPTION
To prevent a possible issue on Gentoo (cf. https://github.com/koreader/koreader-base/pull/2343#issuecomment-4299401787), and since no code we build should need it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2346)
<!-- Reviewable:end -->
