### PR TITLE
blitbuffer: fix GCC 16 warning (-Wunused-but-set-variable)

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -3060,7 +3060,6 @@ void BB_paint_rounded_corner_noAA(BlitBuffer * restrict bb, unsigned int off_x, 
     // r2 ... radius of inner circle; might be zero
     const unsigned int r2 = r - bw;
 
-    int x2 = 0;
     int y2 = r2;
 
     int f2 = 1 - r2;
@@ -3085,7 +3084,6 @@ void BB_paint_rounded_corner_noAA(BlitBuffer * restrict bb, unsigned int off_x, 
                 ddF2_y += 2;
                 f2 += ddF2_y;
             }
-            ++x2;
             ddF2_x += 2;
             f2 += ddF2_x + 1;
         }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2348)
<!-- Reviewable:end -->
