### PR TITLE
djvulibre: switch to cmake + fix release build with GCC 16

### DIFF
--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -9,39 +9,21 @@ if(ANDROID)
     list(APPEND PATCH_FILES android.patch)
 endif()
 
-list(APPEND PATCH_CMD COMMAND env NOCONFIGURE=1 ./autogen.sh)
-
-# fix build error due to -Werror under Fedora 26 (and potentially other systems)
-string(APPEND CFLAGS " -Wno-error")
-# Fix build error when compiling with -std=gnu++17: ISO
-# C++17 does not allow 'register' storage class specifier.
-string(APPEND CXXFLAGS " -Wno-register -Wno-error=register")
-# Fix symbols visibility.
-string(APPEND CFLAGS " -fvisibility=hidden")
-string(APPEND CXXFLAGS " -fvisibility=hidden -fvisibility-inlines-hidden")
-
-list(APPEND CFG_CMD COMMAND env)
-append_autotools_vars(CFG_CMD)
-list(APPEND CFG_CMD
-    ${SOURCE_DIR}/configure --host=${CHOST} --prefix=/
-    --disable-shared --enable-static
-    --disable-desktopfiles
-    --disable-largefile
-    --disable-xmltools
-    --with-jpeg=${STAGING_DIR}
-    --without-tiff
+list(APPEND CMAKE_ARGS
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DBUILD_SHARED_LIBS=FALSE
 )
 
-list(APPEND BUILD_CMD COMMAND make -C libdjvu)
+list(APPEND BUILD_CMD COMMAND ninja)
 
-list(APPEND INSTALL_CMD COMMAND make -C libdjvu DESTDIR=${STAGING_DIR} install)
+list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
 external_project(
     DOWNLOAD GIT fd7b8db8fffba96fd1f053797704355f2bfd7849
     https://gitlab.com/koreader/djvulibre.git
+    PATCH_OVERLAY overlay
     PATCH_FILES ${PATCH_FILES}
-    PATCH_COMMAND ${PATCH_CMD}
-    CONFIGURE_COMMAND ${CFG_CMD}
+    CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}
     INSTALL_COMMAND ${INSTALL_CMD}
 )

--- a/thirdparty/djvulibre/overlay/CMakeLists.txt
+++ b/thirdparty/djvulibre/overlay/CMakeLists.txt
@@ -1,0 +1,224 @@
+cmake_minimum_required(VERSION 3.17.5)
+project(djvulibre LANGUAGES C CXX)
+
+include(CMakePushCheckState)
+include(CheckCSourceCompiles)
+include(CheckCXXSourceCompiles)
+include(CheckIncludeFile)
+include(CheckIncludeFiles)
+include(CheckSymbolExists)
+include(CheckTypeSize)
+
+set(PACKAGE_VERSION 3.5.29)
+
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+set(HAVE_PTHREAD ${CMAKE_USE_PTHREADS_INIT})
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(JPeg libjpeg REQUIRED IMPORTED_TARGET)
+
+foreach(HDR
+        cpuid.h
+        dirent.h
+        iconv.h
+        inttypes.h
+        ndir.h
+        new.h
+        stdint.h
+        sys/dir.h
+        sys/mman.h
+        sys/ndir.h
+        sys/time.h
+        wchar.h
+    )
+    string(REGEX REPLACE "[./]" "_" VAR HAVE_${HDR})
+    string(TOUPPER ${VAR} VAR)
+    check_include_file(${HDR} ${VAR})
+endforeach()
+
+check_include_files("sys/time.h;time.h" TIME_WITH_SYS_TIME)
+
+set(SYM_CHECKS
+    getpwuid  "sys/types.h pwd.h"
+    iconv     "iconv.h"
+    mkstemp   "stdlib.h"
+    mmap      "sys/mman.h"
+    snprintf  "stdio.h"
+    strerror  "string.h"
+    vsnprintf "stdio.h"
+    wcrtomb   "wchar.h"
+)
+while(SYM_CHECKS)
+    list(POP_FRONT SYM_CHECKS SYM HEADERS)
+    string(TOUPPER HAVE_${SYM} VAR)
+    string(REPLACE " " ";" HEADERS ${HEADERS})
+    check_symbol_exists(${SYM} "${HEADERS}" ${VAR})
+endwhile()
+
+if(HAVE_WCHAR_H)
+    cmake_push_check_state()
+    set(CMAKE_EXTRA_INCLUDE_FILES "wchar.h")
+    check_type_size(mbstate_t MBSTATE_T_SIZE)
+    if(NOT MBSTATE_T_SIZE STREQUAL "")
+        set(HAVE_MBSTATE_T TRUE)
+    endif()
+    cmake_pop_check_state()
+endif()
+
+cmake_push_check_state()
+set(CMAKE_EXTRA_INCLUDE_FILES "stddef.h")
+check_type_size(wchar_t WCHAR_T_SIZE)
+if(NOT WCHAR_T_SIZE STREQUAL "")
+    set(HAVE_WCHAR_T TRUE)
+endif()
+cmake_pop_check_state()
+
+check_c_source_compiles([=[
+__thread int i;
+int main(void) {
+    return i;
+}
+]=] HAVE_GCCTLS)
+
+check_cxx_source_compiles([=[
+int main(void) {
+    try { throw  1; } catch (int i) { return i; }
+}
+]=] HAVE_EXCEPTIONS)
+
+check_cxx_source_compiles([=[
+static int volatile l;
+int main(void) {
+    __sync_lock_test_and_set(&l,1);
+    __sync_lock_release(&l);
+    __sync_add_and_fetch(&l,1);
+    __sync_bool_compare_and_swap(&l,&l,1);
+    __sync_synchronize();
+    return 0;
+}
+]=] HAVE_INTEL_ATOMIC_BUILTINS)
+
+check_c_source_compiles([=[
+long long int i;
+int main(void) {
+    return i;
+}
+]=] HAVE_LONG_LONG_INT)
+
+check_cxx_source_compiles([=[
+template<class T, int N> class A
+{ public:
+  template<int N2> A<T,N> operator=(const A<T,N2>& z) { return A<T,N>(); }
+};
+int main(void) {
+    A<double,4> x; A<double,7> y;
+    x = y;
+    return 0;
+}
+]=] HAVE_MEMBER_TEMPLATES)
+
+check_cxx_source_compiles([=[
+namespace Outer { namespace Inner { int i = 0; }}
+int main(void) {
+    using namespace Outer::Inner;
+    return i;
+}
+]=] HAVE_NAMESPACES)
+
+check_cxx_source_compiles([=[
+#include <new>
+struct X { int a; X(int a):a(a){} };
+X* foo(void *x) { return new(x) X(2); }
+int main(void) {
+    return 0;
+}
+]=] HAVE_STDINCLUDES)
+
+check_cxx_source_compiles([=[
+template<typename T>class X {public:X(){}};
+int main(void) {
+    X<float> z;
+    return 0;
+}
+]=] HAVE_TYPENAME)
+
+configure_file(config.h.in config.h)
+
+add_library(djvulibre
+    libdjvu/Arrays.cpp
+    libdjvu/atomic.cpp
+    libdjvu/BSByteStream.cpp
+    libdjvu/BSEncodeByteStream.cpp
+    libdjvu/ByteStream.cpp
+    libdjvu/DataPool.cpp
+    libdjvu/ddjvuapi.cpp
+    libdjvu/debug.cpp
+    libdjvu/DjVmDir.cpp
+    libdjvu/DjVmDir0.cpp
+    libdjvu/DjVmDoc.cpp
+    libdjvu/DjVmNav.cpp
+    libdjvu/DjVuAnno.cpp
+    libdjvu/DjVuDocEditor.cpp
+    libdjvu/DjVuDocument.cpp
+    libdjvu/DjVuDumpHelper.cpp
+    libdjvu/DjVuErrorList.cpp
+    libdjvu/DjVuFile.cpp
+    libdjvu/DjVuFileCache.cpp
+    libdjvu/DjVuGlobal.cpp
+    libdjvu/DjVuGlobalMemory.cpp
+    libdjvu/DjVuImage.cpp
+    libdjvu/DjVuInfo.cpp
+    libdjvu/DjVuMessage.cpp
+    libdjvu/DjVuMessageLite.cpp
+    libdjvu/DjVuNavDir.cpp
+    libdjvu/DjVuPalette.cpp
+    libdjvu/DjVuPort.cpp
+    libdjvu/DjVuText.cpp
+    libdjvu/DjVuToPS.cpp
+    libdjvu/GBitmap.cpp
+    libdjvu/GContainer.cpp
+    libdjvu/GException.cpp
+    libdjvu/GIFFManager.cpp
+    libdjvu/GMapAreas.cpp
+    libdjvu/GOS.cpp
+    libdjvu/GPixmap.cpp
+    libdjvu/GRect.cpp
+    libdjvu/GScaler.cpp
+    libdjvu/GSmartPointer.cpp
+    libdjvu/GString.cpp
+    libdjvu/GThreads.cpp
+    libdjvu/GUnicode.cpp
+    libdjvu/GURL.cpp
+    libdjvu/IFFByteStream.cpp
+    libdjvu/IW44EncodeCodec.cpp
+    libdjvu/IW44Image.cpp
+    libdjvu/JB2EncodeCodec.cpp
+    libdjvu/JB2Image.cpp
+    libdjvu/JPEGDecoder.cpp
+    libdjvu/miniexp.cpp
+    libdjvu/MMRDecoder.cpp
+    libdjvu/MMX.cpp
+    libdjvu/UnicodeByteStream.cpp
+    libdjvu/XMLParser.cpp
+    libdjvu/XMLTags.cpp
+    libdjvu/ZPCodec.cpp
+)
+set_target_properties(djvulibre PROPERTIES SOVERSION 21)
+# Fix symbols visibility.
+set_target_properties(djvulibre PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN TRUE
+)
+target_compile_definitions(djvulibre PRIVATE HAVE_CONFIG_H)
+target_compile_options(djvulibre PRIVATE -Wall)
+target_include_directories(djvulibre PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(djvulibre PRIVATE PkgConfig::JPeg Threads::Threads)
+
+install(TARGETS djvulibre)
+install(FILES
+    libdjvu/ddjvuapi.h
+    libdjvu/miniexp.h
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/libdjvu
+)

--- a/thirdparty/djvulibre/overlay/CMakeLists.txt
+++ b/thirdparty/djvulibre/overlay/CMakeLists.txt
@@ -213,6 +213,8 @@ set_target_properties(djvulibre PROPERTIES
 )
 target_compile_definitions(djvulibre PRIVATE HAVE_CONFIG_H)
 target_compile_options(djvulibre PRIVATE -Wall)
+# Unbreak build with GCC 16 at higher optimization levels (-O2 and above).
+target_compile_options(djvulibre PRIVATE -fno-strict-aliasing)
 target_include_directories(djvulibre PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(djvulibre PRIVATE PkgConfig::JPeg Threads::Threads)
 

--- a/thirdparty/djvulibre/overlay/config.h.in
+++ b/thirdparty/djvulibre/overlay/config.h.in
@@ -1,0 +1,152 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+/* version string */
+#cmakedefine DJVULIBRE_VERSION "${PACKAGE_VERSION}"
+
+/* Define to 1 if you have the <cpuid.h> header file. */
+#cmakedefine HAVE_CPUID_H
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines 'DIR'.
+   */
+#cmakedefine HAVE_DIRENT_H
+
+/* define if the compiler supports exceptions */
+#cmakedefine HAVE_EXCEPTIONS 1
+
+/* define if the compiler supports keyword __thread */
+#cmakedefine01 HAVE_GCCTLS
+
+/* Define to 1 if you have the 'getpwuid' function. */
+#cmakedefine01 HAVE_GETPWUID
+
+/* Define to 1 if you have the iconv function. */
+#cmakedefine HAVE_ICONV
+
+/* Define to 1 if you have the <iconv.h> header file. */
+#cmakedefine HAVE_ICONV_H
+
+/* define if the compiler supports intel atomic builtins */
+#cmakedefine HAVE_INTEL_ATOMIC_BUILTINS
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine01 HAVE_INTTYPES_H
+
+/* Define to 1 if the system has the type 'long long int'. */
+#cmakedefine HAVE_LONG_LONG_INT
+
+/* Define to 1 if the system has the type 'mbstate_t'. */
+#cmakedefine HAVE_MBSTATE_T
+
+/* define if the compiler supports member templates */
+#cmakedefine HAVE_MEMBER_TEMPLATES
+
+/* Define to 1 if you have the 'mkstemp' function. */
+#cmakedefine01 HAVE_MKSTEMP
+
+/* Define to 1 if you have a working 'mmap' system call. */
+#cmakedefine HAVE_MMAP
+
+/* define if the compiler implements namespaces */
+#cmakedefine HAVE_NAMESPACES
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines 'DIR'. */
+#cmakedefine HAVE_NDIR_H
+
+/* Define to 1 if you have the <new.h> header file. */
+#cmakedefine HAVE_NEW_H
+
+/* Define if pthreads are available */
+#cmakedefine01 HAVE_PTHREAD
+
+/* Define to 1 if you have the 'snprintf' function. */
+#cmakedefine01 HAVE_SNPRINTF
+
+/* define if the compiler comes with standard includes */
+#cmakedefine HAVE_STDINCLUDES
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine01 HAVE_STDINT_H
+
+/* Define to 1 if you have the 'strerror' function. */
+#cmakedefine HAVE_STRERROR
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines 'DIR'.
+   */
+#cmakedefine HAVE_SYS_DIR_H
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#cmakedefine HAVE_SYS_MMAN_H
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines 'DIR'.
+   */
+#cmakedefine HAVE_SYS_NDIR_H
+
+/* define if the compiler recognizes typename */
+#cmakedefine HAVE_TYPENAME
+
+/* Define to 1 if you have the 'vsnprintf' function. */
+#cmakedefine HAVE_VSNPRINTF
+
+/* Define to 1 if you have the <wchar.h> header file. */
+#cmakedefine01 HAVE_WCHAR_H
+
+/* Define to 1 if the system has the type 'wchar_t'. */
+#cmakedefine HAVE_WCHAR_T
+
+/* Define to 1 if you have the 'wcrtomb' function. */
+#cmakedefine HAVE_WCRTOMB
+
+/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. This
+   macro is obsolete. */
+#cmakedefine01 TIME_WITH_SYS_TIME
+
+/* - Miscellaneous */
+#define AUTOCONF 1
+#if defined(__CYGWIN32__) || !defined(_WIN32)
+# define UNIX 1
+#endif
+
+/* - WCHAR etc.*/
+#if ! defined(HAVE_WCHAR_T)
+#define HAS_WCHAR 0
+#define HAS_WCTYPE 0
+#define HAS_MBSTATE 0
+#else
+#define HAS_WCHAR 1
+#if defined(HAVE_WCTYPE_H) && defined(HAVE_ISWSPACE)
+#define HAS_WCTYPE 1
+#endif
+#if defined(HAVE_MBSTATE_T) && defined(HAVE_WCRTOMB)
+#define HAS_MBSTATE 1
+#endif
+#endif
+#if defined(HAVE_ICONV_H) && defined(HAVE_ICONV)
+#define HAS_ICONV 1
+#else
+#define HAS_ICONV 0
+#endif
+
+/* - I18N MESSAGES HELL */
+#define HAS_CTRL_C_IN_ERR_MSG 1
+
+/* - CONTAINERS */
+#ifndef HAVE_MEMBER_TEMPLATES
+#define GCONTAINER_NO_MEMBER_TEMPLATES 1
+#endif
+#ifndef HAVE_TYPENAME
+#define GCONTAINER_NO_TYPENAME 1
+#endif
+
+/* - JPEG */
+#define NEED_JPEG_DECODER 1
+
+/* - MMAP */
+#if defined(HAVE_MMAP) && defined(HAVE_SYS_MMAN_H)
+#define HAS_MEMMAP 1
+#else
+#define HAS_MEMMAP 0
+#endif
+
+/* config.h: end */
+#endif


### PR DESCRIPTION
The autotools build system ignore some of our compilation flags (e.g. -O…), and rather then having to wade through autohell I figured we might as well switch to a small custom overlay since we only need to build the library.

Additionally, the emulator build with GCC 16 would be broken: this is fixed by disabling strict aliasing (`-fstrict-aliasing` would get enabled by default by the autotools ignoring our optimization level and always compiling with `-O3`).

Code size change:
- `android-arm`: -19.6 KB
- `android-arm64`: -27.7 KB
- `kindlepw2`: -107.5 KB
- `linux`: -125.8 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2350)
<!-- Reviewable:end -->
