### PR TITLE
Support SDL3 pen events

### DIFF
--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -216,6 +216,124 @@ end
 -- Mouse buttons are keyed by slot, while touch contacts are keyed by fingerID.
 local pointers = {}
 local finger_pointers = {}
+local pen_pointers = {}
+local pen_button_state = {}
+
+local SDL_TOUCH_MOUSEID = 0xFFFFFFFF -- ((SDL_MouseID)-1), generated as signed -1 in our cdefs.
+local SDL_PEN_MOUSEID = 0xFFFFFFFE -- ((SDL_MouseID)-2), not generated in our cdefs.
+local SDL_PEN_SLOT = 4
+local TOOL_TYPE_PEN = 1
+local TOOL_TYPE_ERASER = 2
+local SDL_PEN_INPUT_DOWN = bit.lshift(1, 0)
+local SDL_PEN_INPUT_BUTTON_1 = bit.lshift(1, 1)
+local SDL_PEN_INPUT_BUTTON_2 = bit.lshift(1, 2)
+local SDL_PEN_INPUT_ERASER_TIP = bit.lshift(1, 30)
+
+local function isMousePointer(which)
+    local pointer_id = tonumber(which)
+    return pointer_id ~= SDL_TOUCH_MOUSEID and pointer_id ~= SDL_PEN_MOUSEID
+end
+
+local function hasPenFlag(pen_state, flag)
+    return bit.band(tonumber(pen_state) or 0, flag) ~= 0
+end
+
+local function getPenTool(eraser, pen_state)
+    if eraser or hasPenFlag(pen_state, SDL_PEN_INPUT_ERASER_TIP) then
+        return TOOL_TYPE_ERASER
+    end
+    return TOOL_TYPE_PEN
+end
+
+local function setPenButtonState(code, down)
+    if not code or pen_button_state[code] == down then
+        return
+    end
+    pen_button_state[code] = down
+    genEmuEvent(C.EV_KEY, code, down and 1 or 0)
+end
+
+local function syncPenButtons(pen_state)
+    setPenButtonState(C.BTN_STYLUS, hasPenFlag(pen_state, SDL_PEN_INPUT_BUTTON_1))
+    setPenButtonState(C.BTN_STYLUS2, hasPenFlag(pen_state, SDL_PEN_INPUT_BUTTON_2))
+end
+
+local function genPenToolEvent(tool, down)
+    genEmuEvent(C.EV_KEY, tool == TOOL_TYPE_ERASER and C.BTN_TOOL_RUBBER or C.BTN_TOOL_PEN, down and 1 or 0)
+end
+
+local function genPenDownEvent(slot, tracking_id, tool, x, y)
+    genPenToolEvent(tool, true)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, tool)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, tracking_id)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
+    genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
+end
+
+local function genPenUpEvent(slot, tool, x, y)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, tool)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, -1)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
+    genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
+    genPenToolEvent(tool, false)
+end
+
+local function genPenMoveEvent(slot, tool, x, y)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, tool)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
+    genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
+end
+
+local function getPenTrackingID(pen_id)
+    return pen_id ~= 0 and pen_id or SDL_PEN_SLOT
+end
+
+local function updatePenContact(pen_id, pen_state, tool, x, y)
+    local pointer = pen_pointers[pen_id]
+    local is_down = hasPenFlag(pen_state, SDL_PEN_INPUT_DOWN) or (pointer and pointer.down)
+    if not is_down then
+        return
+    end
+
+    if not pointer then
+        pointer = {
+            down = false,
+            tracking_id = getPenTrackingID(pen_id),
+        }
+        pen_pointers[pen_id] = pointer
+    end
+
+    if pointer.down then
+        genPenMoveEvent(SDL_PEN_SLOT, tool, x, y)
+    else
+        genPenDownEvent(SDL_PEN_SLOT, pointer.tracking_id, tool, x, y)
+    end
+
+    pointer.down = true
+    pointer.tool = tool
+    pointer.x = x
+    pointer.y = y
+end
+
+local function endPenContact(pen_id, tool, x, y)
+    local pointer = pen_pointers[pen_id]
+    if not pointer or not pointer.down then
+        return
+    end
+
+    genPenUpEvent(SDL_PEN_SLOT, tool or pointer.tool or TOOL_TYPE_PEN, x or pointer.x or 0, y or pointer.y or 0)
+    pointer.down = false
+    pointer.tool = tool or pointer.tool
+    pointer.x = x or pointer.x
+    pointer.y = y or pointer.y
+end
+
 local function setPointerDownState(slot, down)
     if not pointers[slot] then
         pointers[slot] = { down = down }
@@ -344,7 +462,52 @@ function S.waitForEvent(sec, usec)
         genEmuEvent(C.EV_KEY, event.key.key, 0)
     elseif event.type == SDL.SDL_EVENT_TEXT_INPUT then
         genEmuEvent(C.EV_SDL, SDL.SDL_EVENT_TEXT_INPUT, ffi.string(event.text.text))
-    elseif event.type == SDL.SDL_EVENT_MOUSE_MOTION and event.motion.which ~= SDL.SDL_TOUCH_MOUSEID
+    elseif event.type == SDL.SDL_EVENT_PEN_DOWN then
+        local pen_id = tonumber(event.ptouch.which)
+        local pen_state = bit.bor(tonumber(event.ptouch.pen_state) or 0, event.ptouch.down and SDL_PEN_INPUT_DOWN or 0)
+        local tool = getPenTool(event.ptouch.eraser, pen_state)
+        local x = event.ptouch.x * scale_x
+        local y = event.ptouch.y * scale_y
+        syncPenButtons(pen_state)
+        updatePenContact(pen_id, pen_state, tool, x, y)
+    elseif event.type == SDL.SDL_EVENT_PEN_UP then
+        local pen_id = tonumber(event.ptouch.which)
+        local pen_state = tonumber(event.ptouch.pen_state) or 0
+        local tool = getPenTool(event.ptouch.eraser, pen_state)
+        local x = event.ptouch.x * scale_x
+        local y = event.ptouch.y * scale_y
+        syncPenButtons(pen_state)
+        endPenContact(pen_id, tool, x, y)
+    elseif event.type == SDL.SDL_EVENT_PEN_MOTION then
+        local pen_id = tonumber(event.pmotion.which)
+        local pen_state = tonumber(event.pmotion.pen_state) or 0
+        local tool = getPenTool(false, pen_state)
+        syncPenButtons(pen_state)
+        updatePenContact(pen_id, pen_state, tool, event.pmotion.x * scale_x, event.pmotion.y * scale_y)
+    elseif event.type == SDL.SDL_EVENT_PEN_AXIS then
+        local pen_id = tonumber(event.paxis.which)
+        local pen_state = tonumber(event.paxis.pen_state) or 0
+        local tool = getPenTool(false, pen_state)
+        syncPenButtons(pen_state)
+        updatePenContact(pen_id, pen_state, tool, event.paxis.x * scale_x, event.paxis.y * scale_y)
+    elseif event.type == SDL.SDL_EVENT_PEN_BUTTON_DOWN
+        or event.type == SDL.SDL_EVENT_PEN_BUTTON_UP then
+        local button_code
+        if event.pbutton.button == 1 then
+            button_code = C.BTN_STYLUS
+        elseif event.pbutton.button == 2 then
+            button_code = C.BTN_STYLUS2
+        end
+        setPenButtonState(button_code, event.type == SDL.SDL_EVENT_PEN_BUTTON_DOWN)
+    elseif event.type == SDL.SDL_EVENT_PEN_PROXIMITY_OUT then
+        local pen_id = tonumber(event.pproximity.which)
+        local pointer = pen_pointers[pen_id]
+        if pointer and pointer.down then
+            endPenContact(pen_id, pointer.tool, pointer.x, pointer.y)
+        end
+        pen_pointers[pen_id] = nil
+        syncPenButtons(0)
+    elseif event.type == SDL.SDL_EVENT_MOUSE_MOTION and isMousePointer(event.motion.which)
         or event.type == SDL.SDL_EVENT_FINGER_MOTION then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_MOTION
         local slot
@@ -362,7 +525,7 @@ function S.waitForEvent(sec, usec)
                 genTouchMoveEvent(event, slot, event.motion.x * scale_x, event.motion.y * scale_y)
             end
         end
-    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_UP and event.button.which ~= SDL.SDL_TOUCH_MOUSEID
+    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_UP and isMousePointer(event.button.which)
         or event.type == SDL.SDL_EVENT_FINGER_UP then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_UP
         local slot
@@ -382,7 +545,7 @@ function S.waitForEvent(sec, usec)
         else
             pointers[slot] = nil
         end
-    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_DOWN and event.button.which ~= SDL.SDL_TOUCH_MOUSEID
+    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_DOWN and isMousePointer(event.button.which)
         or event.type == SDL.SDL_EVENT_FINGER_DOWN then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_DOWN
         if not is_finger and not (event.button.button == SDL.SDL_BUTTON_LEFT or event.button.button == SDL.SDL_BUTTON_RIGHT) then

--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -217,7 +217,12 @@ end
 local pointers = {}
 local finger_pointers = {}
 local pen_pointers = {}
-local pen_button_state = {}
+local suppress_mouse_until_sec = 0
+local suppress_mouse_until_usec = 0
+local pen_button_state = {
+    [C.BTN_STYLUS] = false,
+    [C.BTN_STYLUS2] = false,
+}
 
 local SDL_TOUCH_MOUSEID = 0xFFFFFFFF -- ((SDL_MouseID)-1), generated as signed -1 in our cdefs.
 local SDL_PEN_MOUSEID = 0xFFFFFFFE -- ((SDL_MouseID)-2), not generated in our cdefs.
@@ -234,6 +239,15 @@ local function isMousePointer(which)
     return pointer_id ~= SDL_TOUCH_MOUSEID and pointer_id ~= SDL_PEN_MOUSEID
 end
 
+local function shouldHandleMousePointer(which)
+    if not isMousePointer(which) then
+        return false
+    end
+    local now_sec, now_usec = util.gettime()
+    return now_sec > suppress_mouse_until_sec
+        or (now_sec == suppress_mouse_until_sec and now_usec >= suppress_mouse_until_usec)
+end
+
 local function hasPenFlag(pen_state, flag)
     return bit.band(tonumber(pen_state) or 0, flag) ~= 0
 end
@@ -246,6 +260,7 @@ local function getPenTool(eraser, pen_state)
 end
 
 local function setPenButtonState(code, down)
+    down = not not down
     if not code or pen_button_state[code] == down then
         return
     end
@@ -334,11 +349,13 @@ local function endPenContact(pen_id, tool, x, y)
     pointer.y = y or pointer.y
 end
 
-local function setPointerDownState(slot, down)
+local function setPointerDownState(slot, down, x, y)
     if not pointers[slot] then
-        pointers[slot] = { down = down }
+        pointers[slot] = { down = down, x = x, y = y }
     else
         pointers[slot].down = down
+        pointers[slot].x = x or pointers[slot].x
+        pointers[slot].y = y or pointers[slot].y
     end
 end
 
@@ -373,6 +390,27 @@ local function genTouchUpEvent(event, slot, x, y)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
+end
+
+local function releaseMousePointers()
+    for slot, pointer in pairs(pointers) do
+        if pointer.down then
+            genTouchUpEvent(nil, slot, pointer.x or 0, pointer.y or 0)
+        end
+    end
+    pointers = {}
+end
+
+local function suppressMousePointersAfterPenEvent()
+    local sec, usec = util.gettime()
+    usec = usec + 350000
+    if usec >= 1000000 then
+        sec = sec + 1
+        usec = usec - 1000000
+    end
+    suppress_mouse_until_sec = sec
+    suppress_mouse_until_usec = usec
+    releaseMousePointers()
 end
 
 local function genTouchMoveEvent(event, slot, x, y)
@@ -462,12 +500,15 @@ function S.waitForEvent(sec, usec)
         genEmuEvent(C.EV_KEY, event.key.key, 0)
     elseif event.type == SDL.SDL_EVENT_TEXT_INPUT then
         genEmuEvent(C.EV_SDL, SDL.SDL_EVENT_TEXT_INPUT, ffi.string(event.text.text))
+    elseif event.type == SDL.SDL_EVENT_PEN_PROXIMITY_IN then
+        suppressMousePointersAfterPenEvent()
     elseif event.type == SDL.SDL_EVENT_PEN_DOWN then
         local pen_id = tonumber(event.ptouch.which)
         local pen_state = bit.bor(tonumber(event.ptouch.pen_state) or 0, event.ptouch.down and SDL_PEN_INPUT_DOWN or 0)
         local tool = getPenTool(event.ptouch.eraser, pen_state)
         local x = event.ptouch.x * scale_x
         local y = event.ptouch.y * scale_y
+        suppressMousePointersAfterPenEvent()
         syncPenButtons(pen_state)
         updatePenContact(pen_id, pen_state, tool, x, y)
     elseif event.type == SDL.SDL_EVENT_PEN_UP then
@@ -476,23 +517,27 @@ function S.waitForEvent(sec, usec)
         local tool = getPenTool(event.ptouch.eraser, pen_state)
         local x = event.ptouch.x * scale_x
         local y = event.ptouch.y * scale_y
+        suppressMousePointersAfterPenEvent()
         syncPenButtons(pen_state)
         endPenContact(pen_id, tool, x, y)
     elseif event.type == SDL.SDL_EVENT_PEN_MOTION then
         local pen_id = tonumber(event.pmotion.which)
         local pen_state = tonumber(event.pmotion.pen_state) or 0
         local tool = getPenTool(false, pen_state)
+        suppressMousePointersAfterPenEvent()
         syncPenButtons(pen_state)
         updatePenContact(pen_id, pen_state, tool, event.pmotion.x * scale_x, event.pmotion.y * scale_y)
     elseif event.type == SDL.SDL_EVENT_PEN_AXIS then
         local pen_id = tonumber(event.paxis.which)
         local pen_state = tonumber(event.paxis.pen_state) or 0
         local tool = getPenTool(false, pen_state)
+        suppressMousePointersAfterPenEvent()
         syncPenButtons(pen_state)
         updatePenContact(pen_id, pen_state, tool, event.paxis.x * scale_x, event.paxis.y * scale_y)
     elseif event.type == SDL.SDL_EVENT_PEN_BUTTON_DOWN
         or event.type == SDL.SDL_EVENT_PEN_BUTTON_UP then
         local button_code
+        suppressMousePointersAfterPenEvent()
         if event.pbutton.button == 1 then
             button_code = C.BTN_STYLUS
         elseif event.pbutton.button == 2 then
@@ -506,8 +551,9 @@ function S.waitForEvent(sec, usec)
             endPenContact(pen_id, pointer.tool, pointer.x, pointer.y)
         end
         pen_pointers[pen_id] = nil
+        suppressMousePointersAfterPenEvent()
         syncPenButtons(0)
-    elseif event.type == SDL.SDL_EVENT_MOUSE_MOTION and isMousePointer(event.motion.which)
+    elseif event.type == SDL.SDL_EVENT_MOUSE_MOTION and shouldHandleMousePointer(event.motion.which)
         or event.type == SDL.SDL_EVENT_FINGER_MOTION then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_MOTION
         local slot
@@ -518,14 +564,20 @@ function S.waitForEvent(sec, usec)
         else
             if pointers[0] and pointers[0].down then
                 slot = 0 -- left mouse button down
-                genTouchMoveEvent(event, slot, event.motion.x * scale_x, event.motion.y * scale_y)
+                local x = event.motion.x * scale_x
+                local y = event.motion.y * scale_y
+                setPointerDownState(slot, true, x, y)
+                genTouchMoveEvent(event, slot, x, y)
             end
             if pointers[1] and pointers[1].down then
                 slot = 1 -- right mouse button down
-                genTouchMoveEvent(event, slot, event.motion.x * scale_x, event.motion.y * scale_y)
+                local x = event.motion.x * scale_x
+                local y = event.motion.y * scale_y
+                setPointerDownState(slot, true, x, y)
+                genTouchMoveEvent(event, slot, x, y)
             end
         end
-    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_UP and isMousePointer(event.button.which)
+    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_UP and shouldHandleMousePointer(event.button.which)
         or event.type == SDL.SDL_EVENT_FINGER_UP then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_UP
         local slot
@@ -536,6 +588,9 @@ function S.waitForEvent(sec, usec)
         else -- SDL_BUTTON_LEFT
             slot = 0
         end
+        if not is_finger and not (pointers[slot] and pointers[slot].down) then
+            return false, C.EINTR
+        end
 
         local x = is_finger and event.tfinger.x * S.w or event.button.x * scale_x
         local y = is_finger and event.tfinger.y * S.h or event.button.y * scale_y
@@ -545,7 +600,7 @@ function S.waitForEvent(sec, usec)
         else
             pointers[slot] = nil
         end
-    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_DOWN and isMousePointer(event.button.which)
+    elseif event.type == SDL.SDL_EVENT_MOUSE_BUTTON_DOWN and shouldHandleMousePointer(event.button.which)
         or event.type == SDL.SDL_EVENT_FINGER_DOWN then
         local is_finger = event.type == SDL.SDL_EVENT_FINGER_DOWN
         if not is_finger and not (event.button.button == SDL.SDL_BUTTON_LEFT or event.button.button == SDL.SDL_BUTTON_RIGHT) then
@@ -564,7 +619,9 @@ function S.waitForEvent(sec, usec)
         end
         local x = is_finger and event.tfinger.x * S.w or event.button.x * scale_x
         local y = is_finger and event.tfinger.y * S.h or event.button.y * scale_y
-        setPointerDownState(slot, true)
+        if not is_finger then
+            setPointerDownState(slot, true, x, y)
+        end
         genTouchDownEvent(event, slot, x, y)
     elseif event.type == SDL.SDL_EVENT_MOUSE_WHEEL then
         genEmuEvent(C.EV_SDL, SDL.SDL_EVENT_MOUSE_WHEEL, event.wheel)

--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -265,7 +265,6 @@ local function getPenTool(eraser, pen_state)
 end
 
 local function setPenButtonState(code, down)
-    down = not not down
     if not code or pen_button_state[code] == down then
         return
     end
@@ -283,7 +282,6 @@ local function getPenToolKey(tool)
 end
 
 local function setPenToolState(tool, down)
-    down = not not down
     local code = getPenToolKey(tool)
     if down then
         for active_code, active in pairs(pen_tool_state) do

--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -223,10 +223,15 @@ local pen_button_state = {
     [C.BTN_STYLUS] = false,
     [C.BTN_STYLUS2] = false,
 }
+local pen_tool_state = {
+    [C.BTN_TOOL_PEN] = false,
+    [C.BTN_TOOL_RUBBER] = false,
+}
 
 local SDL_TOUCH_MOUSEID = 0xFFFFFFFF -- ((SDL_MouseID)-1), generated as signed -1 in our cdefs.
 local SDL_PEN_MOUSEID = 0xFFFFFFFE -- ((SDL_MouseID)-2), not generated in our cdefs.
 local SDL_PEN_SLOT = 4
+local TOOL_TYPE_FINGER = 0
 local TOOL_TYPE_PEN = 1
 local TOOL_TYPE_ERASER = 2
 local SDL_PEN_INPUT_DOWN = bit.lshift(1, 0)
@@ -273,12 +278,39 @@ local function syncPenButtons(pen_state)
     setPenButtonState(C.BTN_STYLUS2, hasPenFlag(pen_state, SDL_PEN_INPUT_BUTTON_2))
 end
 
-local function genPenToolEvent(tool, down)
-    genEmuEvent(C.EV_KEY, tool == TOOL_TYPE_ERASER and C.BTN_TOOL_RUBBER or C.BTN_TOOL_PEN, down and 1 or 0)
+local function getPenToolKey(tool)
+    return tool == TOOL_TYPE_ERASER and C.BTN_TOOL_RUBBER or C.BTN_TOOL_PEN
+end
+
+local function setPenToolState(tool, down)
+    down = not not down
+    local code = getPenToolKey(tool)
+    if down then
+        for active_code, active in pairs(pen_tool_state) do
+            if active_code ~= code and active then
+                pen_tool_state[active_code] = false
+                genEmuEvent(C.EV_KEY, active_code, 0)
+            end
+        end
+    end
+    if pen_tool_state[code] == down then
+        return
+    end
+    pen_tool_state[code] = down
+    genEmuEvent(C.EV_KEY, code, down and 1 or 0)
+end
+
+local function clearPenToolState()
+    for code, active in pairs(pen_tool_state) do
+        if active then
+            pen_tool_state[code] = false
+            genEmuEvent(C.EV_KEY, code, 0)
+        end
+    end
 end
 
 local function genPenDownEvent(slot, tracking_id, tool, x, y)
-    genPenToolEvent(tool, true)
+    setPenToolState(tool, true)
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, tool)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, tracking_id)
@@ -294,7 +326,6 @@ local function genPenUpEvent(slot, tool, x, y)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
-    genPenToolEvent(tool, false)
 end
 
 local function genPenMoveEvent(slot, tool, x, y)
@@ -305,24 +336,76 @@ local function genPenMoveEvent(slot, tool, x, y)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
 end
 
+local function genPenHoverEvent(slot, tool, x, y)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, tool)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, -1)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y)
+    genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0)
+end
+
 local function getPenTrackingID(pen_id)
     return pen_id ~= 0 and pen_id or SDL_PEN_SLOT
+end
+
+local function getPenPointer(pen_id)
+    if not pen_pointers[pen_id] then
+        pen_pointers[pen_id] = {
+            down = false,
+            tracking_id = getPenTrackingID(pen_id),
+            tool = TOOL_TYPE_PEN,
+        }
+    end
+    return pen_pointers[pen_id]
+end
+
+local function beginPenProximity(pen_id, tool, explicit)
+    local pointer = getPenPointer(pen_id)
+    pointer.in_proximity = true
+    pointer.explicit_proximity = pointer.explicit_proximity or explicit
+    pointer.tool = tool or pointer.tool or TOOL_TYPE_PEN
+    setPenToolState(pointer.tool, true)
+    return pointer
+end
+
+local function endImplicitPenProximity(pen_id)
+    local pointer = pen_pointers[pen_id]
+    if pointer and not pointer.down and not pointer.explicit_proximity then
+        pen_pointers[pen_id] = nil
+        clearPenToolState()
+    end
+end
+
+local function endPenProximity(pen_id)
+    local pointer = pen_pointers[pen_id]
+    if pointer and pointer.down then
+        genPenUpEvent(SDL_PEN_SLOT, pointer.tool or TOOL_TYPE_PEN, pointer.x or 0, pointer.y or 0)
+    end
+    if pointer and pointer.x and pointer.y then
+        genPenHoverEvent(SDL_PEN_SLOT, TOOL_TYPE_FINGER, pointer.x, pointer.y)
+    end
+    pen_pointers[pen_id] = nil
+    clearPenToolState()
+end
+
+local function updatePenHover(pen_id, tool, x, y)
+    local pointer = beginPenProximity(pen_id, tool, false)
+    pointer.tool = tool
+    pointer.x = x
+    pointer.y = y
+    genPenHoverEvent(SDL_PEN_SLOT, tool, x, y)
 end
 
 local function updatePenContact(pen_id, pen_state, tool, x, y)
     local pointer = pen_pointers[pen_id]
     local is_down = hasPenFlag(pen_state, SDL_PEN_INPUT_DOWN) or (pointer and pointer.down)
     if not is_down then
+        updatePenHover(pen_id, tool, x, y)
         return
     end
 
-    if not pointer then
-        pointer = {
-            down = false,
-            tracking_id = getPenTrackingID(pen_id),
-        }
-        pen_pointers[pen_id] = pointer
-    end
+    pointer = beginPenProximity(pen_id, tool, false)
 
     if pointer.down then
         genPenMoveEvent(SDL_PEN_SLOT, tool, x, y)
@@ -501,7 +584,9 @@ function S.waitForEvent(sec, usec)
     elseif event.type == SDL.SDL_EVENT_TEXT_INPUT then
         genEmuEvent(C.EV_SDL, SDL.SDL_EVENT_TEXT_INPUT, ffi.string(event.text.text))
     elseif event.type == SDL.SDL_EVENT_PEN_PROXIMITY_IN then
+        local pen_id = tonumber(event.pproximity.which)
         suppressMousePointersAfterPenEvent()
+        beginPenProximity(pen_id, TOOL_TYPE_PEN, true)
     elseif event.type == SDL.SDL_EVENT_PEN_DOWN then
         local pen_id = tonumber(event.ptouch.which)
         local pen_state = bit.bor(tonumber(event.ptouch.pen_state) or 0, event.ptouch.down and SDL_PEN_INPUT_DOWN or 0)
@@ -520,6 +605,7 @@ function S.waitForEvent(sec, usec)
         suppressMousePointersAfterPenEvent()
         syncPenButtons(pen_state)
         endPenContact(pen_id, tool, x, y)
+        endImplicitPenProximity(pen_id)
     elseif event.type == SDL.SDL_EVENT_PEN_MOTION then
         local pen_id = tonumber(event.pmotion.which)
         local pen_state = tonumber(event.pmotion.pen_state) or 0
@@ -536,6 +622,11 @@ function S.waitForEvent(sec, usec)
         updatePenContact(pen_id, pen_state, tool, event.paxis.x * scale_x, event.paxis.y * scale_y)
     elseif event.type == SDL.SDL_EVENT_PEN_BUTTON_DOWN
         or event.type == SDL.SDL_EVENT_PEN_BUTTON_UP then
+        local pen_id = tonumber(event.pbutton.which)
+        local pen_state = tonumber(event.pbutton.pen_state) or 0
+        local tool = getPenTool(false, pen_state)
+        local x = event.pbutton.x * scale_x
+        local y = event.pbutton.y * scale_y
         local button_code
         suppressMousePointersAfterPenEvent()
         if event.pbutton.button == 1 then
@@ -544,14 +635,11 @@ function S.waitForEvent(sec, usec)
             button_code = C.BTN_STYLUS2
         end
         setPenButtonState(button_code, event.type == SDL.SDL_EVENT_PEN_BUTTON_DOWN)
+        updatePenContact(pen_id, pen_state, tool, x, y)
     elseif event.type == SDL.SDL_EVENT_PEN_PROXIMITY_OUT then
         local pen_id = tonumber(event.pproximity.which)
-        local pointer = pen_pointers[pen_id]
-        if pointer and pointer.down then
-            endPenContact(pen_id, pointer.tool, pointer.x, pointer.y)
-        end
-        pen_pointers[pen_id] = nil
         suppressMousePointersAfterPenEvent()
+        endPenProximity(pen_id)
         syncPenButtons(0)
     elseif event.type == SDL.SDL_EVENT_MOUSE_MOTION and shouldHandleMousePointer(event.motion.which)
         or event.type == SDL.SDL_EVENT_FINGER_MOTION then


### PR DESCRIPTION
## Summary

Adds SDL3 pen event translation to the SDL input shim:

- turns SDL3 pen down/move/axis/up events into Linux-style multi-touch slot events
- forwards pen hover/proximity as the stylus slot with `ABS_MT_TRACKING_ID = -1`, coordinates, and current tool type
- emits `BTN_TOOL_PEN` / `BTN_TOOL_RUBBER` and `ABS_MT_TOOL_TYPE` so KOReader can distinguish pen tips and eraser tips
- emits stylus side-button key events as `BTN_STYLUS` / `BTN_STYLUS2`
- suppresses pen-generated synthetic mouse events so pen input does not double-report as mouse/touch input
- clears active pen button/tool state when the pen leaves proximity

## Validation

- `luajit -b ffi/SDL3.lua /tmp/koreader-base-sdl3.lua.bin`
- tested on a Linux Wayland session with a real pen
- verified hover/proximity, contact, lift, proximity-out, and eraser behavior in the Pencil input debug log

## What I use it for

Add pen support on Linux tablet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2351)
<!-- Reviewable:end -->
