### PR TITLE
bump crengine: support for initial-letter, and other fixes

### DIFF
--- a/thirdparty/kpvcrlib/CMakeLists.txt
+++ b/thirdparty/kpvcrlib/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(crengine STATIC
     ${CRE_DIR}/src/odxutil.cpp
     ${CRE_DIR}/src/pdbfmt.cpp
     ${CRE_DIR}/src/props.cpp
+    ${CRE_DIR}/src/renderutil.cpp
     ${CRE_DIR}/src/rtfimp.cpp
     ${CRE_DIR}/src/textlang.cpp
     ${CRE_DIR}/src/txtselector.cpp


### PR DESCRIPTION
Includes:
- fix GCC 16 warnings (-Wunused-but-set-variable) https://github.com/koreader/crengine/pull/663
- https://github.com/koreader/crengine/pull/666 :
  - ldomXRange::getRangeText(): newline on <br/>
  - createXPointer(pt)/getRect(): use formatter src->t.text
  - getRect(): unify one-char-long word width handling
  - CSS ::first-letter: use non-letter char if no letter in first text node
  - CSS ::first-line: properly handle inline-block
  - createXPointer(pt): return source text node on pseudoElem[FirstLetter]
  - getSegmentRects(): compare .bottom additionally to .top
  - lvfntman: add getCapHeight()
  - CSS initial-letter: add CSS parsing and style slot
  - CSS initial-letter: render ::first-letter via inline-box

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2367)
<!-- Reviewable:end -->
