### PR TITLE
ffi/SDL3: map gamepad paddle buttons (LEFT/RIGHT_PADDLE1/2)

### DIFF
--- a/ffi/SDL3.lua
+++ b/ffi/SDL3.lua
@@ -791,6 +791,14 @@ function S.waitForEvent(sec, usec)
         elseif button == SDL.SDL_GAMEPAD_BUTTON_DPAD_RIGHT then
             -- send right
             genEmuEvent(C.EV_KEY, 1073741903, 1)
+        elseif button == SDL.SDL_GAMEPAD_BUTTON_LEFT_PADDLE1 then
+            genEmuEvent(C.EV_KEY, 1073741895, 1) -- ScrollLock
+        elseif button == SDL.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1 then
+            genEmuEvent(C.EV_KEY, 1073741896, 1) -- Pause
+        elseif button == SDL.SDL_GAMEPAD_BUTTON_LEFT_PADDLE2 then
+            genEmuEvent(C.EV_KEY, 1073741897, 1) -- Insert
+        elseif button == SDL.SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2 then
+            genEmuEvent(C.EV_KEY, 1073741898, 1) -- Home
         end
     --- D-pad ---
     elseif event.type == SDL.SDL_EVENT_JOYSTICK_HAT_MOTION then


### PR DESCRIPTION
Controllers with back paddles — Steam Deck (L4/R4/L5/R5), Xbox Elite Series 2, and similar — send `SDL_GAMEPAD_BUTTON_LEFT_PADDLE1` through `SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2` events (SDL button values 16–19). The `SDL_EVENT_JOYSTICK_BUTTON_DOWN` handler in `ffi/SDL3.lua` currently covers buttons 0–14 only; paddle button events arrive but fall through the chain with no key emitted, making them unreachable by plugins or user keybindings.

This patch adds the four missing branches:

| SDL constant | Value | Key code | Key name |
|---|---|---|---|
| `SDL_GAMEPAD_BUTTON_LEFT_PADDLE1` | 17 | 1073741895 | ScrollLock |
| `SDL_GAMEPAD_BUTTON_RIGHT_PADDLE1` | 16 | 1073741896 | Pause |
| `SDL_GAMEPAD_BUTTON_LEFT_PADDLE2` | 19 | 1073741897 | Insert |
| `SDL_GAMEPAD_BUTTON_RIGHT_PADDLE2` | 18 | 1073741898 | Home |

ScrollLock, Pause, Insert, and Home are the nearest key codes not currently assigned to any gamepad button in this file. If there is a preferred convention for naming new gamepad inputs I am happy to adjust.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2374)
<!-- Reviewable:end -->
