### PR TITLE
mxcfb: fix kobo FFI cdecls

### DIFF
--- a/ffi-cdecl/mxcfb_kobo_decl.c
+++ b/ffi-cdecl/mxcfb_kobo_decl.c
@@ -42,7 +42,7 @@ cdecl_struct(mxcfb_update_data_v1_ntx)
 
 cdecl_struct(mxcfb_alt_buffer_data)
 cdecl_struct(mxcfb_update_data_v1)		// Aura
-cdecl_struct(mxcfb_update_data_v2)		// Mark 7
+cdecl_struct(mxcfb_update_data)			// Mark 7
 
 cdecl_struct(mxcfb_update_marker_data)		// Mark 7
 

--- a/ffi/framebuffer_mxcfb.lua
+++ b/ffi/framebuffer_mxcfb.lua
@@ -1077,7 +1077,7 @@ function framebuffer:init()
             -- TEMP_USE_AMBIENT, not that there was ever any other choice on Kobo...
             self.update_data.temp = C.TEMP_USE_AMBIENT
         elseif self.mech_refresh == refresh_kobo_mk7 then
-            self.update_data = ffi.new("struct mxcfb_update_data_v2")
+            self.update_data = ffi.new("struct mxcfb_update_data")
             -- TEMP_USE_AMBIENT, not that there was ever any other choice on Kobo...
             self.update_data.temp = C.TEMP_USE_AMBIENT
         elseif self.mech_refresh == refresh_kobo_mtk then


### PR DESCRIPTION
There's no `mxcfb_update_data_v2` struct: it's actually a define to the real `mxcfb_update_data` struct, which is a problem with our new tree-sitter based ffi-cdecl extractor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2375)
<!-- Reviewable:end -->
