### PR TITLE
harfbuzz: update to 14.2.0

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -64,8 +64,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL da27771546eb196b8bec6703d81b12b7
-    https://github.com/harfbuzz/harfbuzz/releases/download/14.1.0/harfbuzz-14.1.0.tar.xz
+    DOWNLOAD URL 54a09da4efb0f172d00f90ac5bde6122
+    https://github.com/harfbuzz/harfbuzz/releases/download/14.2.0/harfbuzz-14.2.0.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}


### PR DESCRIPTION
https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.0

There's another small code size increase on non-monolibtic platforms (~5.2-7.6 KB).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2378)
<!-- Reviewable:end -->
