### PR TITLE
sqlite: update to 3.53.2

### DIFF
--- a/thirdparty/sqlite/CMakeLists.txt
+++ b/thirdparty/sqlite/CMakeLists.txt
@@ -12,10 +12,10 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 9574a1dd0cafd6c38e11a8fbc52952ac
-    https://www.sqlite.org/2026/sqlite-amalgamation-3530100.zip
-    https://www2.sqlite.org/2026/sqlite-amalgamation-3530100.zip
-    https://www3.sqlite.org/2026/sqlite-amalgamation-3530100.zip
+    DOWNLOAD URL 935ef84696815cb41c2ed7be6cba599d
+    https://www.sqlite.org/2026/sqlite-amalgamation-3530200.zip
+    https://www2.sqlite.org/2026/sqlite-amalgamation-3530200.zip
+    https://www3.sqlite.org/2026/sqlite-amalgamation-3530200.zip
     PATCH_OVERLAY overlay
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
https://www.sqlite.org/releaselog/3_53_2.html#:~:text=version%203%2E53%2E2

Code size change:
- `android-arm`: +1.6 KB
- `android-arm64`: +1.8 KB
- `kindlepw2`: +1.3 KB
- `linux`: +2.3 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2390)
<!-- Reviewable:end -->
