### PR TITLE
harfbuzz: update to 14.2.1

### DIFF
--- a/thirdparty/harfbuzz/CMakeLists.txt
+++ b/thirdparty/harfbuzz/CMakeLists.txt
@@ -64,8 +64,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 54a09da4efb0f172d00f90ac5bde6122
-    https://github.com/harfbuzz/harfbuzz/releases/download/14.2.0/harfbuzz-14.2.0.tar.xz
+    DOWNLOAD URL dda477eb1b44ac816ec1a8e4effee1af
+    https://github.com/harfbuzz/harfbuzz/releases/download/14.2.1/harfbuzz-14.2.1.tar.xz
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}
     CONFIGURE_COMMAND ${CFG_CMD}


### PR DESCRIPTION
https://github.com/harfbuzz/harfbuzz/releases/tag/14.2.1

Code size change:
- `android-arm`: -21.8 KB
- `android-arm64`: -29.9 KB
- `kindlepw2`: -17.5 KB
- `linux`: -18.6 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2391)
<!-- Reviewable:end -->
