### PR TITLE
android: fix getRotationMode() to return canonical DEVICE_ROTATED_* values

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -7,6 +7,7 @@ This will be extended by implementations of this API.
 --]]
 
 local Blitbuffer = require("ffi/blitbuffer")
+local logger = require("logger")
 
 local fb = {
     device = nil, -- points to a device object
@@ -454,7 +455,9 @@ end
 function fb:setRotationMode(mode)
     -- This, on the other hand, is responsible for the internal *buffer* rotation,
     -- as such, it's inverted compared to the DEVICE_ROTATED_ constants; i.e., it's in 90° CCW steps).
-    self.bb:rotateAbsolute(-90 * (mode - self.native_rotation_mode - self.blitbuffer_rotation_mode))
+    local bb_rot = -90 * (mode - self.native_rotation_mode - self.blitbuffer_rotation_mode)
+    logger.dbg("AROT_DIAG base_fb:setRotationMode mode=", mode, "native=", self.native_rotation_mode, "bb_rot=", self.blitbuffer_rotation_mode, "computed=", bb_rot)
+    self.bb:rotateAbsolute(bb_rot)
     if self.viewport then
         self.full_bb:setRotation(self.bb:getRotation())
     end

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -2,6 +2,7 @@ local ffi = require("ffi")
 local android = require("android")
 local BB = require("ffi/blitbuffer")
 local C = ffi.C
+local logger = require("logger")
 
 --[[ configuration for devices with an electric paper display controller ]]--
 
@@ -69,8 +70,11 @@ end
 
 function framebuffer:getRotationMode()
     if android.hasNativeRotation() then
-        return android.orientation.get()
+        local ao = android.orientation.get()
+        logger.dbg("AROT_DIAG framebuffer_android:getRotationMode ->", ao)
+        return ao
     else
+        logger.dbg("AROT_DIAG framebuffer_android:getRotationMode ->", self.cur_rotation_mode, "(cached)")
         return self.cur_rotation_mode
     end
 end
@@ -83,7 +87,9 @@ function framebuffer:setRotationMode(mode)
         elseif mode == 2 then key = "REVERSE_PORTRAIT"
         elseif mode == 3 then key = "REVERSE_LANDSCAPE" end
         if key then
-            android.orientation.set(C["ASCREEN_ORIENTATION_" .. key])
+            local ao = C["ASCREEN_ORIENTATION_" .. key]
+            logger.dbg("AROT_DIAG framebuffer_android:setRotationMode mode=", mode, "key=", key, "ao=", ao)
+            android.orientation.set(ao)
             self.cur_rotation_mode = mode
         end
     else

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -16,6 +16,18 @@ local full, partial, full_ui, partial_ui, fast, delay_page, delay_ui, delay_fast
 
 local framebuffer = {}
 
+-- Android ActivityInfo SCREEN_ORIENTATION_* to framebuffer DEVICE_ROTATED_* mapping
+-- c.f., https://developer.android.com/reference/android/content/pm/ActivityInfo
+local ANDROID_ORIENTATION_TO_ROTATION = {
+    [0]  = 1, -- ASCREEN_ORIENTATION_LANDSCAPE         → DEVICE_ROTATED_CLOCKWISE
+    [1]  = 0, -- ASCREEN_ORIENTATION_PORTRAIT          → DEVICE_ROTATED_UPRIGHT
+    [6]  = 1, -- ASCREEN_ORIENTATION_SENSOR_LANDSCAPE  → DEVICE_ROTATED_CLOCKWISE
+    [7]  = 0, -- ASCREEN_ORIENTATION_SENSOR_PORTRAIT   → DEVICE_ROTATED_UPRIGHT
+    [8]  = 3, -- ASCREEN_ORIENTATION_REVERSE_LANDSCAPE → DEVICE_ROTATED_COUNTER_CLOCKWISE
+    [9]  = 2, -- ASCREEN_ORIENTATION_REVERSE_PORTRAIT  → DEVICE_ROTATED_UPSIDE_DOWN
+    [10] = 0, -- ASCREEN_ORIENTATION_FULL_SENSOR       → default to UPRIGHT
+}
+
 -- update a region of the screen
 function framebuffer:_updatePartial(mode, delay, x, y, w, h)
     local bb = self.full_bb or self.bb
@@ -69,7 +81,15 @@ end
 
 function framebuffer:getRotationMode()
     if android.hasNativeRotation() then
-        return android.orientation.get()
+        local ao = android.orientation.get()
+        local mapped = ANDROID_ORIENTATION_TO_ROTATION[ao]
+        if mapped ~= nil then
+            return mapped
+        else
+            -- For UNSPECIFIED(-1), USER(2), BEHIND(3), SENSOR(4), NOSENSOR(5)
+            -- fall back to cached value
+            return self.cur_rotation_mode
+        end
     else
         return self.cur_rotation_mode
     end
@@ -84,6 +104,7 @@ function framebuffer:setRotationMode(mode)
         elseif mode == 3 then key = "REVERSE_LANDSCAPE" end
         if key then
             android.orientation.set(C["ASCREEN_ORIENTATION_" .. key])
+            self.cur_rotation_mode = mode
         end
     else
         framebuffer.parent.setRotationMode(self, mode)

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -83,13 +83,9 @@ function framebuffer:getRotationMode()
     if android.hasNativeRotation() then
         local ao = android.orientation.get()
         local mapped = ANDROID_ORIENTATION_TO_ROTATION[ao]
-        if mapped ~= nil then
-            return mapped
-        else
-            -- For UNSPECIFIED(-1), USER(2), BEHIND(3), SENSOR(4), NOSENSOR(5)
-            -- fall back to cached value
-            return self.cur_rotation_mode
-        end
+        -- For UNSPECIFIED(-1), USER(2), BEHIND(3), SENSOR(4), NOSENSOR(5)
+        -- fall back to cached value
+        return mapped or self.cur_rotation_mode
     else
         return self.cur_rotation_mode
     end

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -79,6 +79,19 @@ function framebuffer:getRotationMode()
     end
 end
 
+-- Android handles display rotation natively: the window buffer is already
+-- rotated by SurfaceFlinger, and touch events arrive in display coordinates.
+-- The BB is never rotated (setRotationMode only calls android.orientation.set),
+-- so touch coordinates must not be transformed. Return 0 (UR) to skip the
+-- translation in GestureDetector:adjustGesCoordinate / input:adjustTouchTranslate.
+function framebuffer:getTouchRotation()
+    if android.hasNativeRotation() then
+        return 0
+    else
+        return framebuffer.parent.getTouchRotation(self)
+    end
+end
+
 function framebuffer:setRotationMode(mode)
     if android.hasNativeRotation() then
         local key

--- a/ffi/framebuffer_android.lua
+++ b/ffi/framebuffer_android.lua
@@ -16,18 +16,6 @@ local full, partial, full_ui, partial_ui, fast, delay_page, delay_ui, delay_fast
 
 local framebuffer = {}
 
--- Android ActivityInfo SCREEN_ORIENTATION_* to framebuffer DEVICE_ROTATED_* mapping
--- c.f., https://developer.android.com/reference/android/content/pm/ActivityInfo
-local ANDROID_ORIENTATION_TO_ROTATION = {
-    [0]  = 1, -- ASCREEN_ORIENTATION_LANDSCAPE         → DEVICE_ROTATED_CLOCKWISE
-    [1]  = 0, -- ASCREEN_ORIENTATION_PORTRAIT          → DEVICE_ROTATED_UPRIGHT
-    [6]  = 1, -- ASCREEN_ORIENTATION_SENSOR_LANDSCAPE  → DEVICE_ROTATED_CLOCKWISE
-    [7]  = 0, -- ASCREEN_ORIENTATION_SENSOR_PORTRAIT   → DEVICE_ROTATED_UPRIGHT
-    [8]  = 3, -- ASCREEN_ORIENTATION_REVERSE_LANDSCAPE → DEVICE_ROTATED_COUNTER_CLOCKWISE
-    [9]  = 2, -- ASCREEN_ORIENTATION_REVERSE_PORTRAIT  → DEVICE_ROTATED_UPSIDE_DOWN
-    [10] = 0, -- ASCREEN_ORIENTATION_FULL_SENSOR       → default to UPRIGHT
-}
-
 -- update a region of the screen
 function framebuffer:_updatePartial(mode, delay, x, y, w, h)
     local bb = self.full_bb or self.bb
@@ -81,11 +69,7 @@ end
 
 function framebuffer:getRotationMode()
     if android.hasNativeRotation() then
-        local ao = android.orientation.get()
-        local mapped = ANDROID_ORIENTATION_TO_ROTATION[ao]
-        -- For UNSPECIFIED(-1), USER(2), BEHIND(3), SENSOR(4), NOSENSOR(5)
-        -- fall back to cached value
-        return mapped or self.cur_rotation_mode
+        return android.orientation.get()
     else
         return self.cur_rotation_mode
     end


### PR DESCRIPTION
Add a mapping from Android's SCREEN_ORIENTATION_* constants to KOReader's canonical DEVICE_ROTATED_* values. Required by [koreader/koreader#15507](https://github.com/koreader/koreader/pull/15507).

Changes:
- Add ANDROID_ORIENTATION_TO_ROTATION mapping table
- Fix getRotationMode() to return canonical DEVICE_ROTATED_* values
- Fix setRotationMode() to sync cur_rotation_mode

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2393)
<!-- Reviewable:end -->
