### PR TITLE
cmake: tweak ffi targets

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -628,8 +628,8 @@ function(ffi_target NAME OUTPUT INPUT)
         # don't correctly handle `--env-only --with-path=…` (ignoring that last
         # option).
         COMMAND env PKG_CONFIG_PATH=${STAGING_DIR}/lib/pkgconfig
-                ${FFI_CDECL} ${FFI_CDECL_FLAGS} -o ${OUTPUT}
-                ${_ARGS} ${INPUT}
+                ${FFI_CDECL} ${FFI_CDECL_FLAGS}
+                ${_ARGS} ${INPUT} -o ${OUTPUT}
         COMMENT "Generating 'ffi/${TGT}'"
         VERBATIM
         WORKING_DIRECTORY ${BASE_DIR}


### PR DESCRIPTION
Move `-o …` arguments at the end of the command line (for easier copy-pasting for stdout output).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2396)
<!-- Reviewable:end -->
