### PR TITLE
feat(ffi): invert screenshots in night mode

### DIFF
--- a/ffi/framebuffer.lua
+++ b/ffi/framebuffer.lua
@@ -569,7 +569,11 @@ function fb:shot(filename)
     if self.device:hasBGRFrameBuffer() then
         bgr = true
     end
-    self.bb:writePNG(filename, bgr)
+    if self.night_mode then
+        self.bb:copy():invert():writePNG(filename, bgr)
+    else
+        self.bb:writePNG(filename, bgr)
+    end
 end
 
 -- Clear the screen to white


### PR DESCRIPTION
Inverts screenshots that are taken in night mode to match the expected behavior.

 _Originally discussed by @Commodore64user in [#13041](https://github.com/koreader/koreader/issues/13041#issuecomment-2585491453)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2401)
<!-- Reviewable:end -->
