### PR TITLE
ffi/loadlib: fix loading SSL library in monolibtic mode

### DIFF
--- a/ffi/loadlib.lua
+++ b/ffi/loadlib.lua
@@ -40,6 +40,7 @@ local monolibtic = {
         ["png16"]      = true,
         ["sharpyuv"]   = true,
         ["sqlite3"]    = true,
+        ["ssl"]        = true,
         ["tffi_wrap"]  = true,
         ["turbojpeg"]  = true,
         ["unibreak"]   = true,


### PR DESCRIPTION
For turbo (`turbo/hash`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2403)
<!-- Reviewable:end -->
