### PR TITLE
ffi/netinfo: new module to retrieve network information

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -747,6 +747,8 @@ ffi_target(linux einkfb_h.lua einkfb_decl.c ${EXCLUDE_FROM_ALL})
 ffi_target(linux inotify_h.lua inotify_decl.c ${EXCLUDE_FROM_ALL})
 ffi_target(linux linux_fb_h.lua linux_fb_decl.c ${EXCLUDE_FROM_ALL})
 ffi_target(linux linux_input_h.lua linux_input_decl.c ${EXCLUDE_FROM_ALL} ARGS -r ffi/posix_h)
+ffi_target(linux netlink_h.lua netlink_cdecl.c ${EXCLUDE_FROM_ALL} ARGS -r ffi/posix_h)
+ffi_target(linux nl80211_h.lua nl80211_cdecl.c ${EXCLUDE_FROM_ALL})
 ffi_target(linux rtc_h.lua rtc_cdecl.c ${EXCLUDE_FROM_ALL})
 
 # lodepng

--- a/ffi-cdecl/netlink_cdecl.c
+++ b/ffi-cdecl/netlink_cdecl.c
@@ -1,0 +1,44 @@
+#include <stdint.h>
+#include <sys/socket.h>
+#include <linux/genetlink.h>
+#include <linux/netlink.h>
+
+cdecl_type_replace(__u8, uint8_t);
+cdecl_type_replace(__u16, uint16_t);
+cdecl_type_replace(__u32, uint32_t);
+
+cdecl_type_replace(__kernel_sa_family_t, sa_family_t);
+
+cdecl_const(CTRL_ATTR_FAMILY_ID);
+cdecl_const(CTRL_ATTR_FAMILY_NAME);
+
+cdecl_const(CTRL_CMD_GETFAMILY);
+
+cdecl_const(GENL_ID_CTRL);
+
+#if !defined(NETLINK_CAP_ACK)
+# define NETLINK_CAP_ACK  10
+#endif
+cdecl_const(NETLINK_CAP_ACK);
+cdecl_const(NETLINK_GENERIC);
+
+cdecl_const(NLMSG_DONE);
+cdecl_const(NLMSG_ERROR);
+
+#if !defined(NLM_F_DUMP_INTR)
+# define NLM_F_DUMP_INTR  0x10
+#endif
+cdecl_const(NLM_F_ACK);
+cdecl_const(NLM_F_DUMP);
+cdecl_const(NLM_F_DUMP_INTR);
+cdecl_const(NLM_F_REQUEST);
+
+cdecl_struct(genlmsghdr);
+cdecl_sizeof(GENLMSGHDR, struct genlmsghdr);
+
+cdecl_struct(nlattr);
+cdecl_sizeof(NLATTR, struct nlattr);
+cdecl_struct(nlmsghdr);
+cdecl_sizeof(NLMSGHDR, struct nlmsghdr);
+
+cdecl_struct(sockaddr_nl);

--- a/ffi-cdecl/nl80211_cdecl.c
+++ b/ffi-cdecl/nl80211_cdecl.c
@@ -1,0 +1,10 @@
+#include <linux/nl80211.h>
+
+cdecl_const(NL80211_ATTR_BSS);
+cdecl_const(NL80211_ATTR_IFINDEX);
+
+cdecl_const(NL80211_BSS_INFORMATION_ELEMENTS);
+cdecl_const(NL80211_BSS_STATUS);
+cdecl_const(NL80211_BSS_STATUS_ASSOCIATED);
+
+cdecl_const(NL80211_CMD_GET_SCAN);

--- a/ffi/netinfo.lua
+++ b/ffi/netinfo.lua
@@ -1,0 +1,218 @@
+local bit = require "bit"
+local ffi = require "ffi"
+local C = ffi.C
+local posix = require "ffi/posix"
+
+-- Misc {{{
+
+local function getifaddrs()
+    local ifaddr = ffi.new("struct ifaddrs *[1]")
+    if C.getifaddrs(ifaddr) == -1 then
+        io.stderr:write("getifaddrs() failed: " .. posix.strerror())
+        return function() end
+    end
+    ifaddr = ffi.gc(ifaddr[0], C.freeifaddrs)
+    local ifa_next = ifaddr
+    return function()
+        local ifa = ifa_next
+        if ifa == nil then
+            C.freeifaddrs(ffi.gc(ifaddr, nil))
+            return
+        end
+        ifa_next = ifa.ifa_next
+        return ifa
+    end
+end
+
+local function format_mac(mac)
+    return string.format("%02X:%02X:%02X:%02X:%02X:%02X",
+                         bit.band(mac[0], 0xFF),
+                         bit.band(mac[1], 0xFF),
+                         bit.band(mac[2], 0xFF),
+                         bit.band(mac[3], 0xFF),
+                         bit.band(mac[4], 0xFF),
+                         bit.band(mac[5], 0xFF))
+end
+
+-- }}}
+
+-- NetInfo {{{
+
+local NetInfo = {}
+
+function NetInfo:new()
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    self.nl = nil
+    return o
+end
+
+function NetInfo:free()
+    if self.nl then
+        self.nl:close()
+        self.nl = nil
+    end
+end
+
+function NetInfo:dump()
+    for __, iface in ipairs(self:retrieve()) do
+        print(string.format("%d:\t%s", iface.index, iface.name))
+        print(string.format("\tmac: %s", iface.mac))
+        if iface.ipv4 then
+            print(string.format("\tipv4: %s", iface.ipv4))
+        end
+        if iface.ipv6 then
+            print(string.format("\tipv6: %s", iface.ipv6))
+        end
+        if iface.wireless then
+            print(string.format("\tssid: %s", iface.ssid))
+        end
+    end
+end
+
+function NetInfo:retrieve()
+    local interfaces = {}
+    local ipv4 = {}
+    local ipv6 = {}
+    for ifa in getifaddrs() do
+        if ifa.ifa_addr == nil or
+            bit.band(ifa.ifa_flags, C.IFF_UP) == 0 or
+            bit.band(ifa.ifa_flags, C.IFF_LOOPBACK) ~= 0 then
+            goto continue
+        end
+        if ifa.ifa_addr.sa_family == C.AF_INET or ifa.ifa_addr.sa_family == C.AF_INET6 then
+            local host = ffi.new("char[?]", C.NI_MAXHOST)
+            local addrlen = ffi.sizeof("struct sockaddr_" .. (ifa.ifa_addr.sa_family == C.AF_INET and "in" or "in6"))
+            local ret = C.getnameinfo(ifa.ifa_addr, addrlen, host, C.NI_MAXHOST, nil, 0, C.NI_NUMERICHOST)
+            if ret ~= 0 then
+                io.stderr:write("getnameinfo() failed: " .. ffi.string(C.gai_strerror(ret)))
+            else
+                local ipvt = ifa.ifa_addr.sa_family == C.AF_INET and ipv4 or ipv6
+                local name = ffi.string(ifa.ifa_name)
+                local ip = ffi.string(host)
+                if not ipvt[name] then
+                    ipvt[name] = ip
+                else
+                    ipvt[name] = ipvt[name] .. " / " .. ip
+                end
+            end
+        else
+            local iface = self:_process_ifaddr(ifa)
+            if iface then
+                table.insert(interfaces, iface)
+            end
+        end
+        ::continue::
+    end
+    for __, iface in ipairs(interfaces) do
+        iface.ipv4 = ipv4[iface.name]
+        iface.ipv6 = ipv6[iface.name]
+    end
+    table.sort(interfaces, function(i1, i2) return i1.index < i2.index end)
+    return interfaces
+end
+
+if ffi.os == "Linux" then -- {{{
+
+local Netlink = require "ffi/netlink"
+
+function NetInfo:_iface_ssid(ifa_index)
+    local nl = self.nl
+    if not nl then
+        nl = Netlink:new():connect()
+        self.nl = nl
+    end
+    nl:new_message(nl:get_family_id("nl80211"), C.NL80211_CMD_GET_SCAN, true)
+    nl:put_u32(C.NL80211_ATTR_IFINDEX, ifa_index)
+    for msg_type, attrs_data, attrs_size in nl:send():receive() do
+        local associated, ssid
+        for nla_type, nla_data, nla_size in nl.iter_attrs(attrs_data, attrs_size) do
+            if nla_type ~= C.NL80211_ATTR_BSS then
+                goto continue
+            end
+            for bss_nla_type, bss_nla_data, bss_nla_size in Netlink.iter_attrs(nla_data, nla_size) do
+                if bss_nla_type == C.NL80211_BSS_INFORMATION_ELEMENTS then
+                    while bss_nla_size > 0 do
+                        local iehdr = ffi.cast("struct iehdr *", bss_nla_data)
+                        if iehdr.id == C.EID_SSID then
+                            ssid = ffi.string(bss_nla_data + C.SIZEOF_IEHDR, iehdr.len)
+                            break
+                        end
+                        bss_nla_data = bss_nla_data + iehdr.len + C.SIZEOF_IEHDR
+                        bss_nla_size = bss_nla_size - iehdr.len - C.SIZEOF_IEHDR
+                    end
+                elseif bss_nla_type == C.NL80211_BSS_STATUS then
+                    assert(bss_nla_size == 4)
+                    local status = ffi.cast("uint32_t *", bss_nla_data)[0]
+                    associated = status == C.NL80211_BSS_STATUS_ASSOCIATED
+                end
+            end
+            ::continue::
+        end
+        if associated and ssid then
+            return ssid
+        end
+    end
+end
+
+function NetInfo:_process_ifaddr(ifa)
+    if ifa.ifa_addr.sa_family ~= C.AF_PACKET then
+        return
+    end
+    local sll = ffi.cast("struct sockaddr_ll *", ifa.ifa_addr)
+    if sll.sll_ifindex == 0 then
+        return
+    end
+    assert(sll.sll_halen == 6)
+    assert(ifa.ifa_name ~= nil)
+    local iface = {
+        name = ffi.string(ifa.ifa_name),
+        index = sll.sll_ifindex,
+        mac = format_mac(sll.sll_addr),
+    }
+    iface.wireless = C.access("/sys/class/net/" .. iface.name .. "/wireless/", C.F_OK) == 0
+    if not iface.wireless then
+        return iface
+    end
+    local ok, err = pcall(self._iface_ssid, self, iface.index)
+    if not ok then
+        io.stderr:write("retrieving ssid with netlink failed: " .. err)
+        return iface
+    end
+    iface.ssid = err
+    return iface
+end
+
+end -- }}}
+
+if ffi.os == "macos" then -- {{{
+
+function NetInfo:_process_ifaddr(ifa)
+    if ifa.ifa_addr.sa_family ~= C.AF_LINK then
+        return
+    end
+    local sdl = ffi.cast("struct sockaddr_dl *", ifa.ifa_addr)
+    if sdl.sdl_index == 0 or sdl.sdl_type ~= C.IFT_ETHER then
+        return
+    end
+    assert(sdl.sdl_alen == 6)
+    assert(ifa.ifa_name ~= nil)
+    local iface = {
+        name = ffi.string(ifa.ifa_name),
+        index = sdl.sdl_index,
+        mac = format_mac(sdl.sdl_data + sdl.sdl_nlen),
+    }
+    --[[
+    TODO:
+    - how to check if the interface is wireless?
+    - unfortunately, retrieving SSID on modern version is not possible without location permission
+    ]]
+    return iface
+end
+
+end -- }}}
+
+return NetInfo
+
+-- vim: foldmethod=marker foldlevel=0

--- a/ffi/netlink.lua
+++ b/ffi/netlink.lua
@@ -1,0 +1,229 @@
+local bit = require "bit"
+local buffer = require "string.buffer"
+local ffi = require "ffi"
+local posix = require "ffi/posix"
+local C = ffi.C
+
+require "ffi/netlink_h"
+require "ffi/nl80211_h"
+
+-- C declarations. {{{
+
+ffi.cdef[[
+struct iehdr {
+  uint8_t id;
+  uint8_t len;
+};
+static const unsigned SIZEOF_IEHDR = sizeof(struct iehdr);
+static const unsigned EID_SSID = 0;
+typedef struct {
+    struct nlmsghdr;
+    union {
+        struct genlmsghdr;
+        int err;
+    };
+    uint8_t data[];
+} netlink_message;
+static const unsigned SIZEOF_NETLINK_MESSAGE = sizeof(netlink_message);
+]]
+
+-- }}}
+
+-- Netlink. {{{
+
+local Netlink = {}
+
+Netlink.family_id = {}
+
+function Netlink:new(manifest_url, state_dir, seed)
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    o.buf = buffer:new(8 * 1024)
+    o.seq = 0
+    return o
+end
+
+function Netlink:new_message(msg_type, msg_cmd, msg_dump)
+    local len = C.SIZEOF_NETLINK_MESSAGE
+    self.buf:reset():reserve(len)
+    self.buf:commit(len)
+    self.msg_type = msg_type
+    self.msg_flags = bit.bor(C.NLM_F_ACK, C.NLM_F_REQUEST, msg_dump and C.NLM_F_DUMP or 0)
+    self.msg_cmd = msg_cmd
+    return self
+end
+
+function Netlink:connect()
+    local fd = C.socket(C.AF_NETLINK, bit.bor(C.SOCK_DGRAM, C.SOCK_CLOEXEC), C.NETLINK_GENERIC)
+    if -1 == fd then
+        error(posix.strerror())
+    end
+    local value = ffi.new("uint32_t[1]")
+    value[0] = 32768
+    if C.setsockopt(fd, C.SOL_SOCKET, C.SO_SNDBUF, value, 4) ~= 0 then
+        io.stderr:write(string.format("setsockopt(SO_SNDBUF) failed: %s\n", posix.strerror()))
+    end
+    if C.setsockopt(fd, C.SOL_SOCKET, C.SO_RCVBUF, value, 4) ~= 0 then
+        io.stderr:write(string.format("setsockopt(SO_RCVBUF) failed: %s\n", posix.strerror()))
+    end
+    if C.setsockopt(fd, C.SOL_NETLINK, C.NETLINK_CAP_ACK, value, 4) ~= 0 then
+        local err = ffi.errno()
+        if err ~= C.ENOPROTOOPT then
+            io.stderr:write(string.format("setsockopt(NETLINK_CAP_ACK) failed: %s\n", posix.strerror(err)))
+        end
+    end
+    local sa = ffi.new("struct sockaddr_nl", C.AF_NETLINK)
+    local addr_len = ffi.new("socklen_t[1]", ffi.sizeof(sa))
+    if C.getsockname(fd, ffi.cast("struct sockaddr *", sa), addr_len) ~= 0 then
+        error(posix.strerror())
+    end
+    if addr_len[0] ~= ffi.sizeof(sa) or sa.nl_family ~= C.AF_NETLINK then
+        error("netlink not supported")
+    end
+    self.fd = fd
+    return self
+end
+
+function Netlink:close()
+    if self.fd then
+        C.close(self.fd)
+        self.fd = nil
+    end
+end
+
+function Netlink:_put(nla_type, nla_data, nla_size)
+    local len = C.SIZEOF_NLATTR + nla_size
+    local pad = len % 4
+    if pad ~= 0 then
+        -- Attribute headers must be aligned to
+        -- 4 bytes from the start of the message.
+        pad = 4 - pad
+    end
+    local ptr = self.buf:reserve(len + pad)
+    local attr = ffi.cast("struct nlattr *", ptr)
+    attr.nla_len = len
+    attr.nla_type = nla_type
+    ffi.copy(ptr + C.SIZEOF_NLATTR, nla_data, nla_size)
+    if pad ~= 0 then
+        ffi.fill(ptr + len, pad)
+    end
+    self.buf:commit(len + pad)
+    return self
+end
+
+function Netlink:put_string(nla_type, s)
+    return self:_put(nla_type, s, #s + 1)
+end
+
+function Netlink:put_u64(nla_type, u)
+    local u64 = ffi.new("uint64_t[1]", u)
+    return self:_put(nla_type, u64, 8)
+end
+
+function Netlink:put_u32(nla_type, u)
+    local u32 = ffi.new("uint32_t[1]", u)
+    return self:_put(nla_type, u32, 4)
+end
+
+function Netlink:send()
+    assert(self.msg_type and self.msg_flags and self.msg_cmd)
+    local ptr, len = self.buf:ref()
+    local msg = ffi.cast("netlink_message *", ptr)
+    self.seq = self.seq + 1
+    msg.nlmsg_len = #self.buf
+    msg.nlmsg_type = self.msg_type
+    msg.nlmsg_flags = self.msg_flags
+    msg.nlmsg_seq = self.seq
+    msg.nlmsg_pid = 0;
+    msg.cmd = self.msg_cmd
+    msg.version = 1
+    msg.reserved = 0
+    self.msg_type = nil
+    self.msg_flags = nil
+    self.msg_cmd = nil
+    posix.send(self.fd, ptr, len)
+    return self
+end
+
+function Netlink:receive()
+    self.buf:reset()
+    while true do
+        -- Peek at message length.
+        local len = posix.recv(self.fd, nil, 0, bit.bor(C.MSG_PEEK, C.MSG_TRUNC))
+        if len < C.SIZEOF_NLMSGHDR then
+            error("message too short")
+        end
+        local ptr = self.buf:reserve(len)
+        posix.recv(self.fd, ptr, len)
+        local msg = ffi.cast("netlink_message *", ptr)
+        assert(msg.nlmsg_seq == self.seq)
+        assert(msg.nlmsg_len >= C.SIZEOF_NETLINK_MESSAGE)
+        assert(bit.band(msg.nlmsg_flags, C.NLM_F_DUMP_INTR) == 0)
+        if msg.nlmsg_type == C.NLMSG_ERROR or msg.nlmsg_type == C.NLMSG_DONE then
+            local err = msg.err
+            if err == 0 then
+                break
+            end
+            error(err < 0 and posix.strerror(-err) or tostring(err))
+        end
+        self.buf:commit(len)
+    end
+    local ptr, len = self.buf:ref()
+    return function()
+        if len <= 0 then
+            return
+        end
+        local msg = ffi.cast("netlink_message *", ptr)
+        ptr = ptr + msg.nlmsg_len
+        len = len - msg.nlmsg_len
+        return msg.nlmsg_type, msg.data, msg.nlmsg_len - C.SIZEOF_NETLINK_MESSAGE
+    end
+end
+
+function Netlink.iter_attrs(ptr, len)
+    return function()
+        if len <= 0 then
+            return
+        end
+        local attr = ffi.cast("struct nlattr *", ptr)
+        local pad = attr.nla_len % 4
+        if pad ~= 0 then
+            pad = 4 - pad
+        end
+        assert(attr.nla_len >= C.SIZEOF_NLATTR)
+        assert(attr.nla_type ~= 0)
+        local nla_data = ptr + C.SIZEOF_NLATTR
+        local nla_size = attr.nla_len - C.SIZEOF_NLATTR
+        local skip = attr.nla_len + pad
+        assert(skip <= len)
+        ptr = ptr + skip
+        len = len - skip
+        return attr.nla_type, nla_data, nla_size
+    end
+end
+
+function Netlink:get_family_id(family_name)
+    local family_id = self.family_id[family_name]
+    if family_id then
+        return family_id
+    end
+    self:new_message(C.GENL_ID_CTRL, C.CTRL_CMD_GETFAMILY)
+    self:put_string(C.CTRL_ATTR_FAMILY_NAME, family_name)
+    for msg_type, attrs_data, attrs_size in self:send():receive() do
+        for nla_type, nla_data, nla_size in self.iter_attrs(attrs_data, attrs_size) do
+            if nla_type == C.CTRL_ATTR_FAMILY_ID then
+                assert(nla_size == 2, tostring(nla_size))
+                family_id = ffi.cast("uint16_t *", nla_data)[0]
+                self.family_id[family_name] = family_id
+            end
+        end
+    end
+    return family_id
+end
+
+-- }}}
+
+return Netlink
+
+-- vim: foldmethod=marker foldlevel=0

--- a/ffi/netlink_h.lua
+++ b/ffi/netlink_h.lua
@@ -1,0 +1,43 @@
+-- Automatically generated with ffi-cdecl.
+
+require "ffi/posix_h"
+
+require("ffi").cdef[[
+static const unsigned CTRL_ATTR_FAMILY_ID = 1;
+static const unsigned CTRL_ATTR_FAMILY_NAME = 2;
+static const unsigned CTRL_CMD_GETFAMILY = 3;
+static const unsigned GENL_ID_CTRL = 16;
+static const unsigned NETLINK_CAP_ACK = 10;
+static const unsigned NETLINK_GENERIC = 16;
+static const unsigned NLMSG_DONE = 3;
+static const unsigned NLMSG_ERROR = 2;
+static const unsigned NLM_F_ACK = 4;
+static const unsigned NLM_F_DUMP = 768;
+static const unsigned NLM_F_DUMP_INTR = 16;
+static const unsigned NLM_F_REQUEST = 1;
+struct genlmsghdr {
+  uint8_t cmd;
+  uint8_t version;
+  uint16_t reserved;
+};
+static const unsigned SIZEOF_GENLMSGHDR = 4;
+struct nlattr {
+  uint16_t nla_len;
+  uint16_t nla_type;
+};
+static const unsigned SIZEOF_NLATTR = 4;
+struct nlmsghdr {
+  uint32_t nlmsg_len;
+  uint16_t nlmsg_type;
+  uint16_t nlmsg_flags;
+  uint32_t nlmsg_seq;
+  uint32_t nlmsg_pid;
+};
+static const unsigned SIZEOF_NLMSGHDR = 16;
+struct sockaddr_nl {
+  sa_family_t nl_family;
+  unsigned short nl_pad;
+  uint32_t nl_pid;
+  uint32_t nl_groups;
+};
+]]

--- a/ffi/nl80211_h.lua
+++ b/ffi/nl80211_h.lua
@@ -1,0 +1,10 @@
+-- Automatically generated with ffi-cdecl.
+
+require("ffi").cdef[[
+static const unsigned NL80211_ATTR_BSS = 47;
+static const unsigned NL80211_ATTR_IFINDEX = 3;
+static const unsigned NL80211_BSS_INFORMATION_ELEMENTS = 6;
+static const unsigned NL80211_BSS_STATUS = 9;
+static const unsigned NL80211_BSS_STATUS_ASSOCIATED = 1;
+static const unsigned NL80211_CMD_GET_SCAN = 32;
+]]


### PR DESCRIPTION
To replace the methods currently used by `fontend/device/generic/device`, which have the following problems:
- use of Linux specific ioctls (that don't work on macOS):
  - `SIOCGIFHWADDR` for retrieving the MAC address
  - `SIOCGIWNAME` to check if the interface is wireless
  - `SIOCGIWESSID` for retrieving the SSID
- additionally, `SIOCGIWNAME` & `SIOCGIWESSID` don't always work (it depends on the driver, they don't work on my Kindle)

The new module directly uses `getifaddrs()` results to retrieve the MAC address (from AF_LINK on macOS, AF_PACKET on Linux).

For checking if the interface is wireless:
- on Linux: filesystem check for `/sys/class/net/$IFACE/wireless/`
- on macOS: not implemented

For retrieving the SSID:
- on Linux: use netlink (which is supported on my Kindle)
- on macOS: not implemented, and AFAIK, not possible on modern versions anyway (not without location permission)

NOTE: this needs some extra bits in `ffi/posix` & `ffi/posix_h`, not included until #2398 is in (which will need amending to drop some unused stuff if this PR approach is accepted).

Here is a ZIP with the necessary files for testing locally: [netinfo.zip](https://github.com/user-attachments/files/28932244/netinfo.zip).

Decompress and use `luajit -e 'require("ffi/netinfo"):new():dump()'` to test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2410)
<!-- Reviewable:end -->
