### PR TITLE
ffi/netinfo: new module to retrieve network information

### DIFF
--- a/ffi-cdecl/posix_cdecl.c
+++ b/ffi-cdecl/posix_cdecl.c
@@ -43,11 +43,15 @@
 #include <net/if.h>
 #if defined(__APPLE__)
 # include <net/if_dl.h>
+# include <net/if_types.h>
 #endif
 #include <net/route.h>
 #include <netdb.h>
 #include <netinet/ip.h>
 #include <netinet/ip_icmp.h>
+#if defined(__linux__)
+# include <netpacket/packet.h>
+#endif
 #include <poll.h>
 #include <pthread.h>
 #if defined(__linux__)
@@ -285,10 +289,17 @@ cdecl_type(__fsfilcnt_t);
 
 cdecl_struct(statvfs);
 
+#if defined(__APPLE__)
+cdecl_const(IFT_ETHER);
+#endif
+
 cdecl_const(AF_INET);
 cdecl_const(AF_INET6);
 #if defined(__APPLE__)
 cdecl_const(AF_LINK);
+#endif
+#if defined(__linux__)
+cdecl_const(AF_PACKET);
 #endif
 cdecl_const(AF_UNIX);
 
@@ -339,6 +350,9 @@ cdecl_struct(sockaddr);
 #if defined(__APPLE__)
 cdecl_struct(sockaddr_dl);
 #endif
+#if defined(__linux__)
+cdecl_struct(sockaddr_ll);
+#endif
 cdecl_struct(sockaddr_in);
 cdecl_struct(sockaddr_in6);
 cdecl_struct(sockaddr_un);
@@ -357,9 +371,7 @@ cdecl_struct(ifreq);
 
 #if defined(__linux__) && !defined(__ANDROID__)
 
-cdecl_const(SIOCGIFHWADDR);
 cdecl_const(SIOCGIWESSID);
-cdecl_const(SIOCGIWNAME);
 
 cdecl_const(IW_ENCODE_INDEX);
 cdecl_const(IW_ESSID_MAX_SIZE);

--- a/ffi-cdecl/posix_h_android_arm.lua
+++ b/ffi-cdecl/posix_h_android_arm.lua
@@ -137,6 +137,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -177,6 +179,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  uint16_t sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {

--- a/ffi-cdecl/posix_h_android_arm64.lua
+++ b/ffi-cdecl/posix_h_android_arm64.lua
@@ -138,6 +138,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -178,6 +180,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  uint16_t sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {

--- a/ffi-cdecl/posix_h_android_x64.lua
+++ b/ffi-cdecl/posix_h_android_x64.lua
@@ -138,6 +138,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -178,6 +180,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  uint16_t sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {

--- a/ffi-cdecl/posix_h_android_x86.lua
+++ b/ffi-cdecl/posix_h_android_x86.lua
@@ -137,6 +137,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -177,6 +179,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  uint16_t sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {

--- a/ffi-cdecl/posix_h_linux_arm.lua
+++ b/ffi-cdecl/posix_h_linux_arm.lua
@@ -143,6 +143,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -185,6 +187,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  unsigned short sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {
@@ -254,12 +266,8 @@ struct ifreq {
     caddr_t ifru_data;
   } ifr_ifru;
 };
-// cdecl_const_SIOCGIFHWADDR
-static const unsigned SIOCGIFHWADDR = 35111;
 // cdecl_const_SIOCGIWESSID
 static const unsigned SIOCGIWESSID = 35611;
-// cdecl_const_SIOCGIWNAME
-static const unsigned SIOCGIWNAME = 35585;
 // cdecl_const_IW_ENCODE_INDEX
 static const unsigned IW_ENCODE_INDEX = 255;
 // cdecl_const_IW_ESSID_MAX_SIZE

--- a/ffi-cdecl/posix_h_linux_arm64.lua
+++ b/ffi-cdecl/posix_h_linux_arm64.lua
@@ -142,6 +142,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -184,6 +186,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  unsigned short sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {
@@ -253,12 +265,8 @@ struct ifreq {
     caddr_t ifru_data;
   } ifr_ifru;
 };
-// cdecl_const_SIOCGIFHWADDR
-static const unsigned SIOCGIFHWADDR = 35111;
 // cdecl_const_SIOCGIWESSID
 static const unsigned SIOCGIWESSID = 35611;
-// cdecl_const_SIOCGIWNAME
-static const unsigned SIOCGIWNAME = 35585;
 // cdecl_const_IW_ENCODE_INDEX
 static const unsigned IW_ENCODE_INDEX = 255;
 // cdecl_const_IW_ESSID_MAX_SIZE

--- a/ffi-cdecl/posix_h_linux_x64.lua
+++ b/ffi-cdecl/posix_h_linux_x64.lua
@@ -143,6 +143,8 @@ struct statvfs {
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6
 static const unsigned AF_INET6 = 10;
+// cdecl_const_AF_PACKET
+static const unsigned AF_PACKET = 17;
 // cdecl_const_AF_UNIX
 static const unsigned AF_UNIX = 1;
 // cdecl_const_NI_MAXHOST
@@ -185,6 +187,16 @@ struct in6_addr {
 struct sockaddr {
   sa_family_t sa_family;
   char sa_data[14];
+};
+// cdecl_struct_sockaddr_ll
+struct sockaddr_ll {
+  unsigned short sll_family;
+  unsigned short sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 // cdecl_struct_sockaddr_in
 struct sockaddr_in {
@@ -254,12 +266,8 @@ struct ifreq {
     caddr_t ifru_data;
   } ifr_ifru;
 };
-// cdecl_const_SIOCGIFHWADDR
-static const unsigned SIOCGIFHWADDR = 35111;
 // cdecl_const_SIOCGIWESSID
 static const unsigned SIOCGIWESSID = 35611;
-// cdecl_const_SIOCGIWNAME
-static const unsigned SIOCGIWNAME = 35585;
 // cdecl_const_IW_ENCODE_INDEX
 static const unsigned IW_ENCODE_INDEX = 255;
 // cdecl_const_IW_ESSID_MAX_SIZE

--- a/ffi-cdecl/posix_h_macos.lua
+++ b/ffi-cdecl/posix_h_macos.lua
@@ -139,6 +139,8 @@ struct statvfs {
   unsigned long f_flag;
   unsigned long f_namemax;
 };
+// cdecl_const_IFT_ETHER
+static const unsigned IFT_ETHER = 6;
 // cdecl_const_AF_INET
 static const unsigned AF_INET = 2;
 // cdecl_const_AF_INET6

--- a/ffi/netinfo.lua
+++ b/ffi/netinfo.lua
@@ -1,0 +1,207 @@
+local bit = require "bit"
+local ffi = require "ffi"
+local C = ffi.C
+local posix = require "ffi/posix"
+
+-- Misc {{{
+
+local function getifaddrs()
+    local ifaddr = ffi.new("struct ifaddrs *[1]")
+    if C.getifaddrs(ifaddr) == -1 then
+        io.stderr:write("getifaddrs() failed: " .. posix.strerror())
+        return function() end
+    end
+    ifaddr = ffi.gc(ifaddr[0], C.freeifaddrs)
+    local ifa_next = ifaddr
+    return function()
+        local ifa = ifa_next
+        if ifa == nil then
+            C.freeifaddrs(ffi.gc(ifaddr, nil))
+            return
+        end
+        ifa_next = ifa.ifa_next
+        return ifa
+    end
+end
+
+local function format_mac(mac)
+    return string.format("%02X:%02X:%02X:%02X:%02X:%02X",
+                         bit.band(mac[0], 0xFF),
+                         bit.band(mac[1], 0xFF),
+                         bit.band(mac[2], 0xFF),
+                         bit.band(mac[3], 0xFF),
+                         bit.band(mac[4], 0xFF),
+                         bit.band(mac[5], 0xFF))
+end
+
+-- }}}
+
+-- NetInfo {{{
+
+local NetInfo = {}
+
+function NetInfo:new()
+    local o = {}
+    setmetatable(o, self)
+    self.__index = self
+    self.nl = nil
+    self.sd = nil
+    return o
+end
+
+function NetInfo:free()
+    if self.nl then
+        self.nl:close()
+        self.nl = nil
+    end
+    if self.sd then
+        C.close(self.sd)
+        self.sd = nil
+    end
+end
+
+function NetInfo:dump()
+    for __, iface in ipairs(self:retrieve()) do
+        print(string.format("%d:\t%s", iface.index, iface.name))
+        print(string.format("\tmac: %s", iface.mac))
+        if iface.ipv4 then
+            print(string.format("\tipv4: %s", iface.ipv4))
+        end
+        if iface.ipv6 then
+            print(string.format("\tipv6: %s", iface.ipv6))
+        end
+        if iface.wireless then
+            print(string.format("\tssid: %s", iface.ssid or "off/any"))
+        end
+    end
+end
+
+function NetInfo:retrieve()
+    local interfaces = {}
+    local ipv4 = {}
+    local ipv6 = {}
+    for ifa in getifaddrs() do
+        if ifa.ifa_addr == nil or
+            bit.band(ifa.ifa_flags, C.IFF_UP) == 0 or
+            bit.band(ifa.ifa_flags, C.IFF_LOOPBACK) ~= 0 then
+            goto continue
+        end
+        if ifa.ifa_addr.sa_family == C.AF_INET or ifa.ifa_addr.sa_family == C.AF_INET6 then
+            local host = ffi.new("char[?]", C.NI_MAXHOST)
+            local addrlen = ffi.sizeof("struct sockaddr_" .. (ifa.ifa_addr.sa_family == C.AF_INET and "in" or "in6"))
+            local ret = C.getnameinfo(ifa.ifa_addr, addrlen, host, C.NI_MAXHOST, nil, 0, C.NI_NUMERICHOST)
+            if ret ~= 0 then
+                io.stderr:write("getnameinfo() failed: " .. ffi.string(C.gai_strerror(ret)))
+            else
+                local ipvt = ifa.ifa_addr.sa_family == C.AF_INET and ipv4 or ipv6
+                local name = ffi.string(ifa.ifa_name)
+                local ip = ffi.string(host)
+                if not ipvt[name] then
+                    ipvt[name] = ip
+                else
+                    ipvt[name] = ipvt[name] .. " / " .. ip
+                end
+            end
+        else
+            local iface = self:_process_ifaddr(ifa)
+            if iface then
+                table.insert(interfaces, iface)
+            end
+        end
+        ::continue::
+    end
+    for __, iface in ipairs(interfaces) do
+        iface.ipv4 = ipv4[iface.name]
+        iface.ipv6 = ipv6[iface.name]
+    end
+    table.sort(interfaces, function(i1, i2) return i1.index < i2.index end)
+    return interfaces
+end
+
+if ffi.os == "Linux" then -- {{{
+
+function NetInfo:_iface_ssid_ioctl(iface)
+    local sd = self.sd
+    if not sd then
+        sd = C.socket(C.AF_INET, bit.bor(C.SOCK_DGRAM, C.SOCK_CLOEXEC), C.IPPROTO_IP)
+        if sd < 0 then
+            error(string.format("socket(AF_INET) failed: %s", posix.strerror()))
+        end
+        self.sd = sd
+    end
+    local essid = ffi.new("char[?]", C.IW_ESSID_MAX_SIZE + 1)
+    local iwr = ffi.new("struct iwreq")
+    assert(#iface.name <= C.IFNAMSIZ)
+    ffi.copy(iwr.ifr_ifrn.ifrn_name, iface.name)
+    iwr.u.essid.pointer = ffi.cast("caddr_t", essid)
+    iwr.u.essid.length = C.IW_ESSID_MAX_SIZE + 1
+    iwr.u.essid.flags = 0
+    if C.ioctl(sd, C.SIOCGIWESSID, iwr) ~= 0 then
+        error(string.format("ioctl(SIOCGIWESSID) failed: %s", posix.strerror()))
+    end
+    return iwr.u.data.flags ~= 0 and ffi.string(essid) or nil
+end
+
+function NetInfo:_process_ifaddr(ifa)
+    if ifa.ifa_addr.sa_family ~= C.AF_PACKET then
+        return
+    end
+    local sll = ffi.cast("struct sockaddr_ll *", ifa.ifa_addr)
+    if sll.sll_ifindex == 0 then
+        return
+    end
+    assert(sll.sll_halen == 6)
+    assert(ifa.ifa_name ~= nil)
+    local iface = {
+        name = ffi.string(ifa.ifa_name),
+        index = sll.sll_ifindex,
+        mac = format_mac(sll.sll_addr),
+    }
+    iface.wireless = (
+        C.access("/sys/class/net/" .. iface.name .. "/phy82011/", C.F_OK) == 0 or
+        C.access("/sys/class/net/" .. iface.name .. "/wireless/", C.F_OK) == 0
+    )
+    if not iface.wireless then
+        return iface
+    end
+    local ok, err = pcall(self._iface_ssid_ioctl, self, iface)
+    if ok then
+        iface.ssid = err
+    else
+        io.stderr:write(string.format("retrieving ssid [%s, ioctl] failed: %s\n", iface.name, err))
+    end
+    return iface
+end
+
+end -- }}}
+
+if ffi.os == "macos" then -- {{{
+
+function NetInfo:_process_ifaddr(ifa)
+    if ifa.ifa_addr.sa_family ~= C.AF_LINK then
+        return
+    end
+    local sdl = ffi.cast("struct sockaddr_dl *", ifa.ifa_addr)
+    if sdl.sdl_index == 0 or sdl.sdl_type ~= C.IFT_ETHER then
+        return
+    end
+    assert(sdl.sdl_alen == 6)
+    assert(ifa.ifa_name ~= nil)
+    local iface = {
+        name = ffi.string(ifa.ifa_name),
+        index = sdl.sdl_index,
+        mac = format_mac(sdl.sdl_data + sdl.sdl_nlen),
+    }
+    --[[
+    TODO:
+    - how to check if the interface is wireless?
+    - unfortunately, retrieving SSID on modern version is not possible without location permission
+    ]]
+    return iface
+end
+
+end -- }}}
+
+return NetInfo
+
+-- vim: foldmethod=marker foldlevel=0

--- a/ffi/posix_h.lua
+++ b/ffi/posix_h.lua
@@ -295,6 +295,10 @@ struct statvfs {
 ]]
 end
 
+if --[[ macos ]] platform == 0x80 then
+ffi.cdef[[ static const unsigned IFT_ETHER = 6; ]]
+end
+
 ffi.cdef[[ static const unsigned AF_INET = 2; ]]
 
 if --[[ android_arm|android_arm64|android_x64|android_x86|linux_arm|linux_arm64|linux_x64 ]] bit.band(platform, 0x7f) ~= 0 then
@@ -305,6 +309,10 @@ end
 
 if --[[ macos ]] platform == 0x80 then
 ffi.cdef[[ static const unsigned AF_LINK = 18; ]]
+end
+
+if --[[ android_arm|android_arm64|android_x64|android_x86|linux_arm|linux_arm64|linux_x64 ]] bit.band(platform, 0x7f) ~= 0 then
+ffi.cdef[[ static const unsigned AF_PACKET = 17; ]]
 end
 
 ffi.cdef[[
@@ -426,6 +434,32 @@ struct sockaddr_dl {
   unsigned char sdl_alen;
   unsigned char sdl_slen;
   char sdl_data[12];
+};
+]]
+end
+
+if --[[ android_arm|android_arm64|android_x64|android_x86 ]] bit.band(platform, 0xf) ~= 0 then
+ffi.cdef[[
+struct sockaddr_ll {
+  unsigned short sll_family;
+  uint16_t sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
+};
+]]
+elseif --[[ linux_arm|linux_arm64|linux_x64 ]] bit.band(platform, 0x70) ~= 0 then
+ffi.cdef[[
+struct sockaddr_ll {
+  unsigned short sll_family;
+  unsigned short sll_protocol;
+  int sll_ifindex;
+  unsigned short sll_hatype;
+  unsigned char sll_pkttype;
+  unsigned char sll_halen;
+  unsigned char sll_addr[8];
 };
 ]]
 end
@@ -652,9 +686,7 @@ end
 
 if --[[ linux_arm|linux_arm64|linux_x64 ]] bit.band(platform, 0x70) ~= 0 then
 ffi.cdef[[
-static const unsigned SIOCGIFHWADDR = 35111;
 static const unsigned SIOCGIWESSID = 35611;
-static const unsigned SIOCGIWNAME = 35585;
 static const unsigned IW_ENCODE_INDEX = 255;
 static const unsigned IW_ESSID_MAX_SIZE = 32;
 struct iw_freq {


### PR DESCRIPTION
Avoid using unsupported ioctls on macOS, plus some additional tweak to support more configurations:

- uses `getifaddrs()` results to retrieve the MAC address (from `AF_LINK` on macOS, `AF_PACKET` on Linux), instead of the Linux specific `SIOCGIFHWADDR` ioctl
- for checking the interface is wireless on Linux: do a filesystem check for `/sys/class/net/$IFACE/wireless/`, instead of using the `SIOCGIWNAME` ioctl, which is not always supported (it depends on the driver: no dice on my Kindle PW2)
- on macOS: checking if the interface is wireless is still unsupported, as is retrieving the SSID (which is not possible anyway on more recent macOS versions without location permission)

Depend on #2398.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2414)
<!-- Reviewable:end -->
