### PR TITLE
bump crengine: Font Manager enhancements and fixes, invert colors in nightmode

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -3792,6 +3792,10 @@ static int drawCurrentPage(lua_State *L) {
 	if (lua_isboolean(L, 6)) {
 		dithering = lua_toboolean(L, 6);
 	}
+	bool invert_colors = invert_images;
+	if (lua_isboolean(L, 7)) {
+		invert_colors = lua_toboolean(L, 7);
+	}
 
 	int w = bb->w;
 	int h = bb->h;
@@ -3806,6 +3810,7 @@ static int drawCurrentPage(lua_State *L) {
 		 * Blitbuffer.TYPE_BBRGB32, see CreDocument:drawCurrentView */
 		LVColorDrawBuf drawBuf(w, h, bb->data, 32);
 		drawBuf.setInvertImages(invert_images);
+		drawBuf.setInvertColors(invert_colors);
 		drawBuf.setSmoothScalingImages(smooth_scaling);
 		doc->text_view->Draw(drawBuf, false);
 		drawn_images_count = drawBuf.getDrawnImagesCount();


### PR DESCRIPTION
Includes:
- lvfntman: `SetAlias` cleanup https://github.com/koreader/crengine/pull/678
- lvfntman: synthetic small caps https://github.com/koreader/crengine/pull/680
- lvfntman: fix duplicated `@font-face` handling https://github.com/koreader/crengine/pull/682
- lvfntman: resurrect `getFontFileNameAndFaceIndex()` https://github.com/koreader/crengine/pull/683
- CSS: allow arbitrary `font-weight`s https://github.com/koreader/crengine/pull/681
- DrawBuf: allow drawing colors inverted https://github.com/koreader/crengine/pull/677

Also:
cre.cpp: `drawCurrentPage()` set invert_colors when invert_images provided.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2415)
<!-- Reviewable:end -->
