### PR TITLE
LuaSocket: fix CLOEXEC flag setting in enforce-cloexec.patch

### DIFF
--- a/thirdparty/luasocket/enforce-cloexec.patch
+++ b/thirdparty/luasocket/enforce-cloexec.patch
@@ -11,7 +11,7 @@ index 7965db6..fc1f607 100644
 +    if (*ps != SOCKET_INVALID) {
 +        // Enforce CLOEXEC
 +        int flags = fcntl(*ps, F_GETFD, 0);
-+        flags |= O_CLOEXEC;
++        flags |= FD_CLOEXEC;
 +        fcntl(*ps, F_SETFD, flags);
 +        return IO_DONE;
 +    } else {


### PR DESCRIPTION
O_CLOEXEC can be set only during FD creation and completely ignored in fcntl. As a result, the fd is not closed on exec in child processes. 

It leads to issues with, for example, http inspector when it restarts (and other process inherited a copy of the FD already). 

Solved by using fd_cloexec flag instead which is doing the same thing but can be applied after creation

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2428)
<!-- Reviewable:end -->
