### PR TITLE
djvulibre: update to 3.5.30.1-2-g69e23da

### DIFF
--- a/thirdparty/djvulibre/CMakeLists.txt
+++ b/thirdparty/djvulibre/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND BUILD_CMD COMMAND ninja)
 list(APPEND INSTALL_CMD COMMAND ${CMAKE_COMMAND} --install .)
 
 external_project(
-    DOWNLOAD GIT release.3.5.30.1
+    DOWNLOAD GIT release.3.5.30.1-2-g69e23da
     https://gitlab.com/koreader/djvulibre.git
     PATCH_OVERLAY overlay
     PATCH_FILES ${PATCH_FILES}

--- a/thirdparty/djvulibre/no-locale-mangling.patch
+++ b/thirdparty/djvulibre/no-locale-mangling.patch
@@ -31,7 +31,7 @@ index 488aedd..0785b93 100644
  {
  public:
 diff --git a/libdjvu/ddjvuapi.cpp b/libdjvu/ddjvuapi.cpp
-index f9ab454..a70ee57 100644
+index 535373e..a45de34 100644
 --- a/libdjvu/ddjvuapi.cpp
 +++ b/libdjvu/ddjvuapi.cpp
 @@ -358,12 +358,6 @@ ddjvu_context_create(const char *programname)


### PR DESCRIPTION
https://gitlab.com/koreader/djvulibre/-/compare/release.3.5.30.1...3.5.30.1-2-g69e23da

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2430)
<!-- Reviewable:end -->
