### PR TITLE
leptonica: switch to VCS archive

### DIFF
--- a/thirdparty/leptonica/CMakeLists.txt
+++ b/thirdparty/leptonica/CMakeLists.txt
@@ -57,8 +57,8 @@ endif()
 external_project(
     # NOTE: Needs to match the version used by whatever version of libk2pdfopt we're currently using...
     #       Probably applies to mupdf & tesseract, too...
-    DOWNLOAD URL d523d2c883b71850a46af2517d8915bf
-    https://github.com/DanBloomberg/leptonica/releases/download/1.87.0/leptonica-1.87.0.tar.gz
+    DOWNLOAD URL 1f66c425c270e9793982289e1ff9634a
+    https://github.com/DanBloomberg/leptonica/archive/refs/tags/1.87.0.tar.gz
     PATCH_FILES ${PATCH_FILES}
     CMAKE_ARGS ${CMAKE_ARGS}
     BUILD_COMMAND ${BUILD_CMD}


### PR DESCRIPTION
Get rid of the autotools cruft, since we don't use it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2438)
<!-- Reviewable:end -->
