### PR TITLE
mupdf: fix missing `fz_drop_archive` function export

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,8 @@ skeleton: $(strip $(test_data_common))
 define test_data_base
 $(OUTPUT_DIR)/data/tessdata/eng.traineddata
 $(OUTPUT_DIR)/fonts/droid/DroidSansMono.ttf
+$(OUTPUT_DIR)/fonts/urw/NimbusRomNo9L-Med.cff
+$(OUTPUT_DIR)/fonts/urw/NimbusRomNo9L-Reg.cff
 $(OUTPUT_DIR)/spec/base
 endef
 
@@ -189,16 +191,18 @@ $(TESSDATA_FILE):
 	mkdir -p $(dir $(TESSDATA_FILE))
 	$(call wget_and_validate,$(TESSDATA_FILE),$(TESSDATA_FILE_URL),$(TESSDATA_FILE_SHA1))
 
-DROID_FONT = $(THIRDPARTY_DIR)/fonts/build/downloads/DroidSansMono.ttf
-DROID_FONT_URL = https://github.com/koreader/koreader-fonts/raw/master/droid/$(notdir $(DROID_FONT))
-DROID_FONT_SHA1 = 0b75601f8ef8e111babb6ed11de6573f7178ce44
+FONT_SHA1_droid/DroidSansMono.ttf   = 0b75601f8ef8e111babb6ed11de6573f7178ce44
+FONT_SHA1_urw/NimbusRomNo9L-Med.cff = 8c93500267bb1c6444012ba3b7ab807dc24255b4
+FONT_SHA1_urw/NimbusRomNo9L-Reg.cff = eac7ba4fa32b41eb0312ccd91f7723d98864eb55
 
-$(OUTPUT_DIR)/fonts/droid/DroidSansMono.ttf: $(DROID_FONT) | $(OUTPUT_DIR)/fonts/
-	$(SYMLINK) $(dir $(DROID_FONT)) $(OUTPUT_DIR)/fonts/droid
+FONT_BASE_URL = https://github.com/koreader/koreader-fonts/raw/046976988aa33639d60d6ffd25c7a0ff50b72ac0
 
-$(DROID_FONT):
-	mkdir -p $(dir $(DROID_FONT))
-	$(call wget_and_validate,$(DROID_FONT),$(DROID_FONT_URL),$(DROID_FONT_SHA1))
+$(OUTPUT_DIR)/fonts/%: $(THIRDPARTY_DIR)/fonts/build/downloads/% | $(OUTPUT_DIR)/fonts/
+	$(SYMLINK) $(patsubst %/,%,$(dir $<) $(dir $@))
+
+$(THIRDPARTY_DIR)/fonts/build/downloads/%:
+	mkdir -p $(dir $@)
+	$(call wget_and_validate,$@,$(FONT_BASE_URL)/$*,$(FONT_SHA1_$*))
 
 endif
 

--- a/spec/unit/mupdf_spec.lua
+++ b/spec/unit/mupdf_spec.lua
@@ -248,4 +248,19 @@ describe("mupdf module", function()
         assert.True(original ~= saturated)
         doc:close()
     end)
+
+    it("should open document from text", function()
+        local doc = M.openDocumentFromText([[
+        <html>
+          <head>
+            <title>Testing</title>
+          </head>
+          <body>
+            <h1>Header</h1>
+            <p>Lorem ipsum.</p>
+          <hr>
+          </body>
+        </html>]], "html", "spec/base/unit/data")
+        doc:close()
+    end)
 end)

--- a/thirdparty/mupdf/visibility.patch
+++ b/thirdparty/mupdf/visibility.patch
@@ -1,3 +1,15 @@
+diff --git a/include/mupdf/fitz/archive.h b/include/mupdf/fitz/archive.h
+index 29d3d16b8..090eec181 100644
+--- a/include/mupdf/fitz/archive.h
++++ b/include/mupdf/fitz/archive.h
+@@ -100,6 +100,7 @@ int fz_is_directory(fz_context *ctx, const char *path);
+ 	When the last reference is dropped, this closes and releases
+ 	any memory or filehandles associated with the archive.
+ */
++FZ_FUNCTION
+ void fz_drop_archive(fz_context *ctx, fz_archive *arch);
+ 
+ /**
 diff --git a/include/mupdf/fitz/buffer.h b/include/mupdf/fitz/buffer.h
 index 2a52aad3e..07cf95ac9 100644
 --- a/include/mupdf/fitz/buffer.h


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2450)
<!-- Reviewable:end -->
