### PR TITLE
[fix] blitfuffer.c: prevent SIGFPE in large anti-aliased rounded corners

### DIFF
--- a/blitbuffer.c
+++ b/blitbuffer.c
@@ -3363,12 +3363,12 @@ void BB_paint_rounded_corner_AA(BlitBuffer * restrict bb, unsigned int off_x, un
 
     int o_diam = 2*r; // outer diameter
     int odd_diam = o_diam&1; // odd diameter
-    int a2 = 2*r-2*bw;
-    int dx = 4*(o_diam-1)*o_diam*o_diam;
-    int dy = 4*(odd_diam-1)*o_diam*o_diam;                // error increment
+    double a2 = 2.0*r-2.0*bw;
+    double dx = 4.0*(o_diam-1)*o_diam*o_diam;
+    double dy = 4.0*(odd_diam-1)*o_diam*o_diam;            // error increment
     int i = o_diam+a2;
-    int err = odd_diam*o_diam*o_diam;
-    int dx2, dy2, e2, ed;
+    double err = odd_diam*o_diam*o_diam;
+    double dx2, dy2, e2, ed;
 
     if ((bw-1)*(2*o_diam-bw) > o_diam*o_diam) {
         a2 = 0;
@@ -3390,9 +3390,8 @@ void BB_paint_rounded_corner_AA(BlitBuffer * restrict bb, unsigned int off_x, un
     e2 = dx2*e2;
     y0 += (o_diam+1)>>1;
     y1 = y0-odd_diam;                              // starting pixel
-    int a1;
-    a1 = 8*o_diam*o_diam;
-    a2 = 8*a2*a2;
+    double a1 = 8.0*o_diam*o_diam;
+    a2 = 8.0*a2*a2;
 
     do {
         for (;;) {
@@ -3400,12 +3399,12 @@ void BB_paint_rounded_corner_AA(BlitBuffer * restrict bb, unsigned int off_x, un
                 i = x0;
                 break;
             }
-            i = MIN(dx,dy);
+            double i = MIN(dx,dy);
             ed = MAX(dx,dy);
 
-            ed += 2*ed*i*i/(4*ed*ed+i*i+1)+1;// approx ed=sqrt(dx*dx+dy*dy)
+            ed += 2.0*ed*i*i/(4.0*ed*ed+i*i+1.0)+1.0; // approx ed=sqrt(dx*dx+dy*dy)
 
-            i = 255*err/ed;                             // outside anti-aliasing
+            i = 255.0*err/ed;                            // outside anti-aliasing
             if (bb_type == TYPE_BB8) {
                 const Color8A color = { .a = c, .alpha = 255-i };
                 BB8_SET_ALL_QUADRANTS(x0, y0, x1, y1);
@@ -3451,12 +3450,12 @@ void BB_paint_rounded_corner_AA(BlitBuffer * restrict bb, unsigned int off_x, un
             }
         }
         while (e2 > 0 && x0+x1 >= 2*bw) {               // inside anti-aliasing
-            i = MIN(dx2,dy2);
+            double i = MIN(dx2,dy2);
             ed = MAX(dx2,dy2);
 
-            ed += 2*ed*i*i/(4*ed*ed+i*i);                 // approximation
+            ed += 2.0*ed*i*i/(4.0*ed*ed+i*i); // approximation
 
-            i = 255-255*e2/ed;             // get intensity value by pixel error
+            i = 255.0-255.0*e2/ed;          // get intensity value by pixel error
             if (bb_type == TYPE_BB8) {
                 const Color8A color = { .a = c, .alpha = 255-i };
                 BB8_SET_ALL_QUADRANTS(bw, y0, x0+x1-bw, y1);
@@ -3496,7 +3495,7 @@ void BB_paint_rounded_corner_AA(BlitBuffer * restrict bb, unsigned int off_x, un
             err -= dy;
         }
         for (; y0-y1 <= o_diam; err += dy += a1) { // too early stop of flat ellipses
-            i = 255*4*err/a1;  // -> finish tip of ellipse
+            i = 255.0*4.0*err/a1;  // -> finish tip of ellipse
             if (bb_type == TYPE_BB8) {
                 const Color8A color = { .a = c, .alpha = 255-i };
                 BB8_SET_ALL_QUADRANTS(x0, y0, x1, y1);

--- a/spec/unit/blitbuffer_spec.lua
+++ b/spec/unit/blitbuffer_spec.lua
@@ -377,6 +377,15 @@ describe("Blitbuffer unit tests", function()
             assert.are.equals(bb:getPixel(test_x, test_y)['a'], new_c['a'])
         end)
 
+        it("should paint a large anti-aliased rounded corner", function()
+            local bb = Blitbuffer.new(256, 256, Blitbuffer.TYPE_BB8)
+            bb:fill(Blitbuffer.Color8(0xFF))
+
+            bb:paintRoundedCorner(31, 31, 137, 137, 4, 68, Blitbuffer.Color8(0), true)
+
+            assert.are.equal(0, bb:getPixel(31, 99).a)
+        end)
+
         it("should do color comparison correctly", function()
             assert.True(Blitbuffer.Color4(122) == Blitbuffer.Color4(122))
             assert.True(Blitbuffer.Color4L(122) == Blitbuffer.Color4L(122))


### PR DESCRIPTION
Use floating-point error terms to avoid integer overflow and division by zero.

Cf. <https://github.com/koreader/koreader/issues/15708>.

---

It seemed more elegant to me than the alternative quick workaround I sketched in https://github.com/koreader/koreader/issues/15708#issuecomment-5023828253 (which could theoretically still cause issues regardless), and floating point should be hardware-supported, but alternative solutions are welcome of course.

Refer to <http://members.chello.at/easyfilter/bresenham.html> for the algorithm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2454)
<!-- Reviewable:end -->
