### PR TITLE
fix(blitbuffer): fix inner rounded corner radius

### DIFF
--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -2039,7 +2039,7 @@ function BB_mt.__index:paintRoundedCorner(off_x, off_y, w, h, bw, r, c, anti_ali
         local r2 = r - bw
         local x2 = 0
         local y2 = r2
-        local delta2 = 5/4 - r
+        local delta2 = 5/4 - r2
 
         while x < y do
             -- decrease y if we are out of circle

--- a/ffi/blitbuffer.lua
+++ b/ffi/blitbuffer.lua
@@ -1960,7 +1960,7 @@ function BB_mt.__index:paintCircle(center_x, center_y, r, c, w)
     local r2 = r - w
     local x2 = 0
     local y2 = r2
-    local delta2 = 5/4 - r
+    local delta2 = 5/4 - r2
 
     -- draw two axles
     for tmp_y = r, r2+1, -1 do


### PR DESCRIPTION
This can be verified by comparing it to `paintRoundedCorner` on line 2042—which uses the same midpoint circle algorithm but is written correctly:
| Function | Line |  Initialize delta2 | Correct? |
| --- | -- | -- | --- |
| paintCircle (before fix)  |1963 | 5/4 - r | Wrong — uses the outer radius for the inner circle |
| paintCircle (after fix) | 1963 | 5/4 - r2 | Correct | 
| paintRoundedCorner | 2042 | 5/4 - r2 | Correct (reference) |

The midpoint circle algorithm requires that delta be initialized using its own radius (5/4 - radius). The outer circle uses r, and the inner circle uses `r2 = r - w`. The original error caused the inner circle to be drawn in the wrong position when `w < r`

To be honest, this file is quite sensitive. Personally, I think this is a bug, but we still need to be cautious so we don’t end up with a situation like the recent Node.js release incident

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2455)
<!-- Reviewable:end -->
