### PR TITLE
fix(harfbuzz): prevent leaks and division by zero

### DIFF
--- a/ffi/harfbuzz.lua
+++ b/ffi/harfbuzz.lua
@@ -64,7 +64,7 @@ function hb_face_t:getCoverage()
     for script_id, tab in ipairs(coverage.scripts) do
         local hit, total = intersect(tab)
         -- for scripts, we do only rough majority hit
-        if 2*hit > total then
+        if total > 0 and 2*hit > total then
             scripts[script_id] = hit / total
         end
     end

--- a/ffi/harfbuzz.lua
+++ b/ffi/harfbuzz.lua
@@ -48,7 +48,8 @@ local coverage_thresholds = {
 
 -- Get script and language coverage
 function hb_face_t:getCoverage()
-    local set, tmp = hb.hb_set_create(), hb.hb_set_create()
+    local set = ffi.gc(hb.hb_set_create(), hb.hb_set_destroy)
+    local tmp = ffi.gc(hb.hb_set_create(), hb.hb_set_destroy)
     local scripts = {}
     local langs = {}
 
@@ -69,7 +70,7 @@ function hb_face_t:getCoverage()
     end
 
     for lang_id, tab in pairs(coverage.langs) do
-        local found
+        local found = 1
         local hit, total = intersect(tab)
         -- for languages, consider predefined threshold by glyph count
         for i=1, #coverage_thresholds, 2 do
@@ -77,13 +78,11 @@ function hb_face_t:getCoverage()
                 found = i+1
             end
         end
-        if hit*100/total >= coverage_thresholds[found] then
+        if total > 0 and hit*100/total >= coverage_thresholds[found] then
             langs[lang_id] = hit/total
         end
     end
 
-    hb.hb_set_destroy(set)
-    hb.hb_set_destroy(tmp)
     return scripts, langs
 end
 


### PR DESCRIPTION
- Use ffi.gc to ensure HarfBuzz sets are freed
- Initialize found index to prevent nil errors
- Add division-by-zero check for coverage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2456)
<!-- Reviewable:end -->
