### PR TITLE
posix: rework read / write API

### DIFF
--- a/ffi/posix.lua
+++ b/ffi/posix.lua
@@ -31,35 +31,43 @@ function posix.open(path, flags, mode)
 end
 
 function posix.read(fd, ptr, len)
-    local total = 0
-    while total < len do
-        local ret = C.read(fd, ptr + total, len - total)
-        if ret < 0 then
-            error("read: "..strerror())
-        end
+    ptr = ffi.cast("uint8_t *", ptr)
+    local count = 0
+    while count < len do
+        local ret = C.read(fd, ptr + count, len - count)
         if ret == 0 then
-            break
+            error("read: "..string.format("short read, %u/%u", count, len))
         end
-        total = total + ret
+        if ret < 0 then
+            if ffi.errno() ~= C.EINTR then
+                error("read: "..strerror())
+            end
+        else
+            count = count + ret
+        end
     end
-    return total
+    return len
 end
 
 posix.strerror = strerror
 
 function posix.write(fd, ptr, len)
-    local total = 0
-    while total < len do
-        local ret = C.write(fd, ptr + total, len - total)
-        if ret < 0 then
-            error("write: "..strerror())
-        end
+    ptr = ffi.cast("uint8_t *", ptr)
+    local count = 0
+    while count < len do
+        local ret = C.write(fd, ptr + count, len - count)
         if ret == 0 then
-            break
+            error("write: "..string.format("short write, %u/%u", count, len))
         end
-        total = total + ret
+        if ret < 0 then
+            if ffi.errno() ~= C.EINTR then
+                error("write: "..strerror())
+            end
+        else
+            count = count + ret
+        end
     end
-    return total
+    return len
 end
 
 return posix

--- a/ffi/posix.lua
+++ b/ffi/posix.lua
@@ -31,18 +31,14 @@ function posix.open(path, flags, mode)
 end
 
 function posix.read(fd, ptr, len, deny_short)
-    if not deny_short then
-        local ret = C.read(fd, ptr, len)
-        if ret ~= len then
-            error("read: "..(ret < 0 and strerror() or string.format("short read, %u/%u", ret, len)))
-        end
-        return ret
-    end
     ptr = ffi.cast("uint8_t *", ptr)
     local count = 0
     while count < len do
         local ret = C.read(fd, ptr + count, len - count)
         if ret == 0 then
+            if deny_short then
+                error("read: "..string.format("short read, %u/%u", count, len))
+            end
             break
         end
         if ret < 0 then
@@ -59,18 +55,14 @@ end
 posix.strerror = strerror
 
 function posix.write(fd, ptr, len, deny_short)
-    if not deny_short then
-        local ret = C.write(fd, ptr, len)
-        if ret ~= len then
-            error("write: "..(ret < 0 and strerror() or string.format("short write, %u/%u", ret, len)))
-        end
-        return ret
-    end
     ptr = ffi.cast("uint8_t *", ptr)
     local count = 0
     while count < len do
         local ret = C.write(fd, ptr + count, len - count)
         if ret == 0 then
+            if deny_short then
+                error("write: "..string.format("short write, %u/%u", count, len))
+            end
             break
         end
         if ret < 0 then

--- a/ffi/posix.lua
+++ b/ffi/posix.lua
@@ -30,13 +30,20 @@ function posix.open(path, flags, mode)
     return fd
 end
 
-function posix.read(fd, ptr, len)
+function posix.read(fd, ptr, len, deny_short)
+    if not deny_short then
+        local ret = C.read(fd, ptr, len)
+        if ret ~= len then
+            error("read: "..(ret < 0 and strerror() or string.format("short read, %u/%u", ret, len)))
+        end
+        return ret
+    end
     ptr = ffi.cast("uint8_t *", ptr)
     local count = 0
     while count < len do
         local ret = C.read(fd, ptr + count, len - count)
         if ret == 0 then
-            error("read: "..string.format("short read, %u/%u", count, len))
+            break
         end
         if ret < 0 then
             if ffi.errno() ~= C.EINTR then
@@ -46,18 +53,25 @@ function posix.read(fd, ptr, len)
             count = count + ret
         end
     end
-    return len
+    return count
 end
 
 posix.strerror = strerror
 
-function posix.write(fd, ptr, len)
+function posix.write(fd, ptr, len, deny_short)
+    if not deny_short then
+        local ret = C.write(fd, ptr, len)
+        if ret ~= len then
+            error("write: "..(ret < 0 and strerror() or string.format("short write, %u/%u", ret, len)))
+        end
+        return ret
+    end
     ptr = ffi.cast("uint8_t *", ptr)
     local count = 0
     while count < len do
         local ret = C.write(fd, ptr + count, len - count)
         if ret == 0 then
-            error("write: "..string.format("short write, %u/%u", count, len))
+            break
         end
         if ret < 0 then
             if ffi.errno() ~= C.EINTR then
@@ -67,7 +81,7 @@ function posix.write(fd, ptr, len)
             count = count + ret
         end
     end
-    return len
+    return count
 end
 
 return posix

--- a/ffi/posix.lua
+++ b/ffi/posix.lua
@@ -31,21 +31,35 @@ function posix.open(path, flags, mode)
 end
 
 function posix.read(fd, ptr, len)
-    local ret = C.read(fd, ptr, len)
-    if ret ~= len then
-        error("read: "..(ret < 0 and strerror() or string.format("short read, %u/%u", ret, len)))
+    local total = 0
+    while total < len do
+        local ret = C.read(fd, ptr + total, len - total)
+        if ret < 0 then
+            error("read: "..strerror())
+        end
+        if ret == 0 then
+            break
+        end
+        total = total + ret
     end
-    return ret
+    return total
 end
 
 posix.strerror = strerror
 
 function posix.write(fd, ptr, len)
-    local ret = C.write(fd, ptr, len)
-    if ret ~= len then
-        error("write: "..(ret < 0 and strerror() or string.format("short write, %u/%u", ret, len)))
+    local total = 0
+    while total < len do
+        local ret = C.write(fd, ptr + total, len - total)
+        if ret < 0 then
+            error("write: "..strerror())
+        end
+        if ret == 0 then
+            break
+        end
+        total = total + ret
     end
-    return ret
+    return total
 end
 
 return posix


### PR DESCRIPTION
- Loop to handle partial reads and writes
- Prevent errors on incomplete I/O operations
- Return total bytes successfully processed

My plugin occasionally encounters memory-reading errors (I'm not sure if this is caused by this module, so I've adjusted it to comply with `IEEE Std 1003.1`):
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html
- https://pubs.opengroup.org/onlinepubs/9699919799/functions/write.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2458)
<!-- Reviewable:end -->
