### PR TITLE
cmake: use `CMAKE_COLOR_DIAGNOSTICS`

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -820,6 +820,8 @@ define cmake_toolchain
 
 cmake_minimum_required(VERSION 3.17.5)
 
+set(CMAKE_COLOR_DIAGNOSTICS TRUE)
+
 # CMake Cross ToolChain config file. Adapted from Debian's dpkg-cross ;).
 # c.f., https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-toolchain
 # NOTE: Remember that CMake is a special snowflake that completely *ignores* CPPFLAGS,


### PR DESCRIPTION
For colored compiler output in CMake (>= 3.24) thirdparty projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2461)
<!-- Reviewable:end -->
