### PR TITLE
Preserve screen buffer before adjusting its colors

### DIFF
--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -28,46 +28,57 @@ local function _updatePartial(fb, x, y, w, h, dither, hq)
 
     fb.debug("refresh: inkview partial", x, y, w, h, dither)
 
-    if fb.device.hasColorScreen() and hq then
+    if fb.device.hasColorScreen() and dither then
         -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
         -- We need to restore the original buffer to make sure it won't be adjusted twice.
         fb:saveCurrentBB()
         _adjustAreaColours(fb)
-        
+    end
+
+    if fb.device.hasColorScreen() and hq then        
         inkview.PartialUpdateHQ(x, y, w, h)
-        fb:restoreFromSavedBB()
     else
         inkview.PartialUpdate(x, y, w, h)
+    end
+
+    if dither then
+        fb:restoreFromSavedBB()
     end
 end
 
 local function _updateFull(fb, x, y, w, h, dither)
     fb.debug("refresh: inkview full", x, y, w, h, dither)
 
-    if fb.device.hasColorScreen() then
+    if fb.device.hasColorScreen() and dither then
         fb:saveCurrentBB()
+    end
+    
+    if fb.device.hasColorScreen() then
         _adjustAreaColours(fb)
         
         inkview.FullUpdateHQ()
-        fb:restoreFromSavedBB()
     else
         inkview.FullUpdate()
+    end
+
+    if fb.device.hasColorScreen() and dither then
+        fb:restoreFromSavedBB()
     end
 end
 
 local function _updateFast(fb, x, y, w, h, dither)
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
-    fb.debug("refresh: inkview fast", x, y, w, h, dither)
+    fb.debug("refresh: inkview fast", x, y, w, h, dither)        
 
-    if fb.device.hasColorScreen() then
+    if fb.device.hasColorScreen() and dither then
         fb:saveCurrentBB()
         _adjustAreaColours(fb)
     end
 
     inkview.DynamicUpdate(x, y, w, h)
 
-    if fb.device.hasColorScreen() then
+    if fb.device.hasColorScreen() and dither then
         fb:restoreFromSavedBB()
     end
 end

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -17,7 +17,6 @@ end
 local function _adjustAreaColours(fb)
     if fb.device.hasColorScreen() then
         fb.debug("adjusting image color saturation")
-
         inkview.adjustAreaDefault(fb.data, fb._finfo.line_length, fb._vinfo.width, fb._vinfo.height)
     end
 end
@@ -27,12 +26,14 @@ local function _updatePartial(fb, x, y, w, h, dither)
 
     fb.debug("refresh: inkview partial", x, y, w, h, dither)
 
-    if dither then
-        _adjustAreaColours(fb)
-    end
-
     if fb.device.hasColorScreen() then
+        -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
+        -- We need to restore the original buffer to make sure it won't be adjusted twice.
+        fb.saveCurrentBB()
+        _adjustAreaColours(fb)
+        
         inkview.PartialUpdateHQ(x, y, w, h)
+        fb.restoreFromSavedBB()
     else
         inkview.PartialUpdate(x, y, w, h)
     end
@@ -41,12 +42,12 @@ end
 local function _updateFull(fb, x, y, w, h, dither)
     fb.debug("refresh: inkview full", x, y, w, h, dither)
 
-    if dither then
-        _adjustAreaColours(fb)
-    end
-
     if fb.device.hasColorScreen() then
+        fb.saveCurrentBB()
+        _adjustAreaColours(fb)
+        
         inkview.FullUpdateHQ()
+        fb.restoreFromSavedBB()
     else
         inkview.FullUpdate()
     end
@@ -57,11 +58,16 @@ local function _updateFast(fb, x, y, w, h, dither)
 
     fb.debug("refresh: inkview fast", x, y, w, h, dither)
 
-    if dither then
+    if fb.device.hasColorScreen() then
+        fb.saveCurrentBB()
         _adjustAreaColours(fb)
     end
 
     inkview.DynamicUpdate(x, y, w, h)
+
+    if fb.device.hasColorScreen() then
+        fb.restoreFromSavedBB()
+    end
 end
 
 function framebuffer:init()

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -22,8 +22,7 @@ local function _adjustAreaColours(fb)
     end
 end
 
-local function _updatePartial(fb, x, y, w, h, dither, hq)
-    -- Use "hq" argument to trigger high quality refresh for color Pocketbook devices.
+local function _updatePartial(fb, x, y, w, h, dither)
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
     fb.debug("refresh: inkview partial", x, y, w, h, dither)
@@ -32,7 +31,7 @@ local function _updatePartial(fb, x, y, w, h, dither, hq)
         _adjustAreaColours(fb)
     end
 
-    if fb.device.hasColorScreen() and hq then
+    if fb.device.hasColorScreen() then
         inkview.PartialUpdateHQ(x, y, w, h)
     else
         inkview.PartialUpdate(x, y, w, h)
@@ -127,19 +126,19 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither, false)
+    _updatePartial(self, x, y, w, h, dither)
 end
 
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither, true)
+    _updatePartial(self, x, y, w, h, dither)
 end
 
 function framebuffer:refreshUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither, false)
+    _updatePartial(self, x, y, w, h, dither)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither, true)
+    _updatePartial(self, x, y, w, h, dither)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h, dither)

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -17,16 +17,18 @@ end
 local function _adjustAreaColours(fb)
     if fb.device.hasColorScreen() then
         fb.debug("adjusting image color saturation")
+
         inkview.adjustAreaDefault(fb.data, fb._finfo.line_length, fb._vinfo.width, fb._vinfo.height)
     end
 end
 
-local function _updatePartial(fb, x, y, w, h, dither)
+local function _updatePartial(fb, x, y, w, h, dither, hq)
+    -- Use "hq" argument to trigger high quality refresh for color Pocketbook devices.
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
     fb.debug("refresh: inkview partial", x, y, w, h, dither)
 
-    if fb.device.hasColorScreen() then
+    if fb.device.hasColorScreen() and hq then
         -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
         -- We need to restore the original buffer to make sure it won't be adjusted twice.
         fb:saveCurrentBB()
@@ -132,19 +134,19 @@ end
 --[[ framebuffer API ]]--
 
 function framebuffer:refreshPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, false)
 end
 
 function framebuffer:refreshFlashPartialImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, true)
 end
 
 function framebuffer:refreshUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, false)
 end
 
 function framebuffer:refreshFlashUIImp(x, y, w, h, dither)
-    _updatePartial(self, x, y, w, h, dither)
+    _updatePartial(self, x, y, w, h, dither, true)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h, dither)

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -72,7 +72,7 @@ end
 local function _updateFast(fb, x, y, w, h, dither)
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
-    fb.debug("refresh: inkview fast", x, y, w, h, dither)        
+    fb.debug("refresh: inkview fast", x, y, w, h, dither)
 
     if fb.device.hasColorScreen() and dither then
         fb:saveCurrentBB()

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -26,44 +26,47 @@ local function _updatePartial(fb, x, y, w, h, dither, hq)
     -- Use "hq" argument to trigger high quality refresh for color Pocketbook devices.
     x, y, w, h = _getPhysicalRect(fb, x, y, w, h)
 
-    fb.debug("refresh: inkview partial", x, y, w, h, dither)
+    fb.debug("refresh: inkview partial", x, y, w, h, dither, hq)
 
-    if fb.device.hasColorScreen() and dither then
-        -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
-        -- We need to restore the original buffer to make sure it won't be adjusted twice.
-        fb:saveCurrentBB()
-        _adjustAreaColours(fb)
+    if fb.device.hasColorScreen() then
+        if dither then
+            -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
+            -- We need to restore the original buffer to make sure it won't be adjusted twice.
+            fb:saveCurrentBB()
+            _adjustAreaColours(fb)
+        end
+        if hq then        
+            inkview.PartialUpdateHQ(x, y, w, h)
+        else
+            inkview.PartialUpdate(x, y, w, h)
+        end
+        if dither then
+            fb:restoreFromSavedBB()
+        end
+
+        return
     end
 
-    if fb.device.hasColorScreen() and hq then        
-        inkview.PartialUpdateHQ(x, y, w, h)
-    else
-        inkview.PartialUpdate(x, y, w, h)
-    end
-
-    if dither then
-        fb:restoreFromSavedBB()
-    end
+    inkview.PartialUpdate(x, y, w, h)
 end
 
 local function _updateFull(fb, x, y, w, h, dither)
     fb.debug("refresh: inkview full", x, y, w, h, dither)
 
-    if fb.device.hasColorScreen() and dither then
-        fb:saveCurrentBB()
+    if fb.device.hasColorScreen() then
+        if dither then
+            fb:saveCurrentBB()
+            _adjustAreaColours(fb)
+        end
+        inkview.FullUpdateHQ()
+        if dither then
+            fb:restoreFromSavedBB()
+        end
+
+        return
     end
     
-    if fb.device.hasColorScreen() then
-        _adjustAreaColours(fb)
-        
-        inkview.FullUpdateHQ()
-    else
-        inkview.FullUpdate()
-    end
-
-    if fb.device.hasColorScreen() and dither then
-        fb:restoreFromSavedBB()
-    end
+    inkview.FullUpdate()
 end
 
 local function _updateFast(fb, x, y, w, h, dither)

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -35,7 +35,7 @@ local function _updatePartial(fb, x, y, w, h, dither, hq)
             fb:saveCurrentBB()
             _adjustAreaColours(fb)
         end
-        if hq then        
+        if hq then
             inkview.PartialUpdateHQ(x, y, w, h)
         else
             inkview.PartialUpdate(x, y, w, h)
@@ -65,7 +65,7 @@ local function _updateFull(fb, x, y, w, h, dither)
 
         return
     end
-    
+
     inkview.FullUpdate()
 end
 

--- a/ffi/framebuffer_pocketbook.lua
+++ b/ffi/framebuffer_pocketbook.lua
@@ -29,11 +29,11 @@ local function _updatePartial(fb, x, y, w, h, dither)
     if fb.device.hasColorScreen() then
         -- inkview.adjustAreaDefault updates buffer in-place, with additional refreshes mangling content.
         -- We need to restore the original buffer to make sure it won't be adjusted twice.
-        fb.saveCurrentBB()
+        fb:saveCurrentBB()
         _adjustAreaColours(fb)
         
         inkview.PartialUpdateHQ(x, y, w, h)
-        fb.restoreFromSavedBB()
+        fb:restoreFromSavedBB()
     else
         inkview.PartialUpdate(x, y, w, h)
     end
@@ -43,11 +43,11 @@ local function _updateFull(fb, x, y, w, h, dither)
     fb.debug("refresh: inkview full", x, y, w, h, dither)
 
     if fb.device.hasColorScreen() then
-        fb.saveCurrentBB()
+        fb:saveCurrentBB()
         _adjustAreaColours(fb)
         
         inkview.FullUpdateHQ()
-        fb.restoreFromSavedBB()
+        fb:restoreFromSavedBB()
     else
         inkview.FullUpdate()
     end
@@ -59,14 +59,14 @@ local function _updateFast(fb, x, y, w, h, dither)
     fb.debug("refresh: inkview fast", x, y, w, h, dither)
 
     if fb.device.hasColorScreen() then
-        fb.saveCurrentBB()
+        fb:saveCurrentBB()
         _adjustAreaColours(fb)
     end
 
     inkview.DynamicUpdate(x, y, w, h)
 
     if fb.device.hasColorScreen() then
-        fb.restoreFromSavedBB()
+        fb:restoreFromSavedBB()
     end
 end
 


### PR DESCRIPTION
`inkview.adjustAreaDefault` updates buffer in-place, with additional refreshes mangling content. We need to restore the original buffer to make sure it won't be adjusted twice.

Also, this change prevents extra posterization artifacts we had with the low quality images before.

Fixes https://github.com/koreader/koreader/issues/12527, https://github.com/koreader/koreader/issues/11865, https://github.com/koreader/koreader/issues/11233

Tested on Pocketbook Inkpad Color 3, as well as b&w Pocketbook Era Lite to check for possible regressions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2464)
<!-- Reviewable:end -->
