### PR TITLE
fix(input): close pipe fds on fork failure

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -132,6 +132,8 @@ static int openInputDevice(lua_State* L)
 
         pid_t childpid;
         if ((childpid = fork()) == -1) {
+            close(pipefd[0]);
+            close(pipefd[1]);
             return luaL_error(L, "Cannot fork() fake event generator: %s", strerror(errno));
         }
         if (childpid == 0) {


### PR DESCRIPTION
Every time `openInputDevice("fake_events")` fails like this, two file descriptors (fd) are leaked. Repeated occurrences → /proc/self/fd fills up → new open() or pipe() calls all fail → KOReader die
This is particularly easy to trigger on the Kindle because power slider events use "fake_events," and if `lipc-wait-event` is not ready or is experiencing issues, `fork()` may fail

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2465)
<!-- Reviewable:end -->
