### PR TITLE
fix(input): reap fake ev process without blocking

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -295,7 +295,7 @@ static int closeAllInputDevices(lua_State* L __attribute__((unused)))
     if (fake_ev_generator_pid != -1) {
         // Kill and wait to reap our child process.
         kill(fake_ev_generator_pid, SIGTERM);
-        waitpid(-1, NULL, 0);
+        waitpid(fake_ev_generator_pid, NULL, 0);
         fake_ev_generator_pid = -1;
     }
 


### PR DESCRIPTION
`closeAllInputDevices()` used `waitpid(-1, NULL, 0)` to reap the fake event
generator child process. This has two problems:

- `waitpid(-1, ...)` waits for *any* child
   process, not just the fake event generator. If other child processes are
   running (e.g., Wi-Fi scripts, USB mount helpers), they may be reaped
   instead — leaving the fake generator as a zombie, or causing the unrelated
   script's parent to lose track of it

= The fake generator may have already exited
   (via `PR_SET_PDEATHSIG` when the parent dies, or naturally). In that case,
   `waitpid(-1, NULL, 0)` blocks until a *different* child exits, causing
   KOReader to hang on shutdown

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2466)
<!-- Reviewable:end -->
