### PR TITLE
fix(input): recompute nfds correctly in clearTimer

### DIFF
--- a/input/input.c
+++ b/input/input.c
@@ -79,25 +79,22 @@ static void computeNfds(void) {
     // Compute select's nfds argument.
     // That's not the actual number of fds in the set, like poll(),
     // but the highest fd number in the set + 1 (c.f., select(2)).
-    // The fd_idx must be set to the actual number before calling this.
-    if (fd_idx == 0U) {
-        nfds = 0;
-    } else if (inputfds[fd_idx - 1U] >= nfds) {
-        nfds = inputfds[fd_idx - 1U] + 1;
-    }
-}
-
-// NOTE: Make sure the top member has the highest fd number, for clearTimer's sake when it recomputes nfds
-static void reorderArray(void) {
-    if (fd_idx > 0) {
-        int prev_fd   = inputfds[fd_idx - 1];
-        int opened_fd = inputfds[fd_idx];
-        if (opened_fd < prev_fd) {
-            inputfds[fd_idx - 1] = opened_fd;
-            inputfds[fd_idx]     = prev_fd;
+    // Scan all input fds and timer fds to find the true maximum.
+    nfds = 0;
+    for (size_t i = 0U; i < fd_idx; i++) {
+        if (inputfds[i] >= nfds) {
+            nfds = inputfds[i] + 1;
         }
     }
+#if defined(WITH_TIMERFD)
+    for (timerfd_node_t* restrict node = timerfds.head; node != NULL; node = node->next) {
+        if (node->fd >= nfds) {
+            nfds = node->fd + 1;
+        }
+    }
+#endif
 }
+
 
 static int openInputDevice(lua_State* L)
 {
@@ -172,9 +169,6 @@ static int openInputDevice(lua_State* L)
         }
     }
 
-    // Reorder the array to match clearTimer's expectations
-    reorderArray();
-
     // We're done w/ inputdevice, pop it
     lua_settop(L, 0);
     // Pass the fd to Lua, front makes use of it to track what was open'ed,
@@ -208,7 +202,6 @@ static int openInputFD(lua_State* L)
 
     // Update our state for the new input slot...
     inputfds[fd_idx] = fd;
-    reorderArray();
     fd_idx++;
     computeNfds();
 

--- a/input/timerfd-callbacks.h
+++ b/input/timerfd-callbacks.h
@@ -24,6 +24,9 @@
 // So that the main input code knows it's built w/ timerfd support
 #define WITH_TIMERFD 1
 
+// Forward declaration: defined in input.c, needed by setTimer/clearTimer
+static void computeNfds(void);
+
 // Unlike the main input module, the way in which we open/close timerfds is much more dynamic.
 // As such, we're using a doubly linked list to keep track of it.
 
@@ -154,9 +157,7 @@ static int setTimer(lua_State* L)
     node->fd = fd;
 
     // Need to update select's nfds, too...
-    if (fd >= nfds) {
-        nfds = fd + 1;
-    }
+    computeNfds();
 
     // Success!
     lua_pushlightuserdata(L, (void*) node);
@@ -171,15 +172,8 @@ static int clearTimer(lua_State* L)
 
     timerfd_list_delete_node(&timerfds, expired_node);
 
-    // Re-compute nfds...
-    // NOTE: Assumes that we've got at least one fd open, which should always hold true.
-    // NOTE: Also assumes that the top fd in the array is the one with the highest fd number, which openInputDevice makes sure of.
-    nfds = inputfds[fd_idx - 1U] + 1;
-    for (timerfd_node_t* restrict node = timerfds.head; node != NULL; node = node->next) {
-        if (node->fd >= nfds) {
-            nfds = node->fd + 1;
-        }
-    }
+    // Re-compute nfds after removing the timer
+    computeNfds();
 
     // Success!
     lua_pushboolean(L, true);


### PR DESCRIPTION
- Scan all input fds to find maximum fd
- Fix invalid assumption of sorted fd array

reorderArray does NOT keep the array completely sorted.
It only swaps the last two elements. Concrete trace:
```
Open fd=3:  [3]                  ✓ sorted
Open fd=5:  [3, 5]               ✓ sorted (5>3, no swap)
Open fd=4:  [3, 4, 5]            ✓ (swap 4↔5)
Open fd=2:  [3, 4, 2, 5]         ✗ UNSORTED! (swap 2↔5, byt 2 < 4)
```
inputfds[fd_idx-1] is ALWAYS the maximum AFTER EACH openInputDevice
Because reorderArray always places max(new_fd, old_last) at the end. The proof by induction is straightforward

`clearTimer` unconditionally recomputes `nfds` (the highest fd number + 1 used by `select(2)`) by reading `inputfds[fd_idx - 1]` — the last element of the input fd array. This relies on the assumption that the array is sorted and the last element is always the maximum. While `openInputDevice` maintains this invariant via `reorderArray`, `closeInputDevice` does not: after `repackFdArray` shifts elements left and removes the closed slot, the new last element may no longer be the maximum.

Additionally, when `fd_idx == 0` (all input devices closed but timers still pending), `inputfds[fd_idx - 1U]` wraps around via unsigned underflow (`SIZE_MAX`), causing an out-of-bounds read.
step
```
1. Open touch (fd=3), power (fd=4), headphone (fd=5)
   → inputfds = [3, 4, 5], fd_idx=3

2. Close touch (fd=3, index 0) → repack shifts left
   → inputfds = [4, 5, -1], fd_idx=2

3. Open accelerometer (fd=3 reused)
   → inputfds[2]=3, reorderArray swaps with 5
   → inputfds = [4, 3, 5], fd_idx=3

4. Close headphone (fd=5, index 2 — last element)
   → repackFdArray: no shift (closing last element)
   → inputfds = [4, 3, -1], fd_idx=2
   → inputfds[1] = 3, but max fd is actually 4

5. clearTimer fires:
   → nfds = inputfds[1] + 1 = 4
   → select(nfds=4) monitors fds 0..3 only
   → fd=4 (power button) is no longer monitored
```

Result: maybe power button stops responding with no error logged

Recompute `nfds` by scanning all remaining input fds and timer fds to find the true maximum, instead of reading only the last element. This handles both the unsorted array case and the `fd_idx == 0` underflow

### Why not convert `reorderArray` to a full insertion sort?

`reorderArray` ensures `inputfds[fd_idx-1]` is always the maximum, which lets `computeNfds` use a one-way guard (`nfds = ...` only if `>= nfds`). This means `computeNfds` never decreases `nfds` and never needs to scan — it only grows the value as new fds are opened

Converting `reorderArray` to a full insertion sort would make the array fully sorted, allowing `computeNfds` to use the simple `inputfds[fd_idx-1] + 1` approach. But `computeNfds` is called on every `openInputDevice` and `closeInputDevice`, while `clearTimer` only fires when a timer expires. The one-way guard in `computeNfds` is already optimal for the common path — it avoids a scan entirely at the cost of occasionally overestimating `nfds` (harmless, just checks a few extra fds in `select`). A full insertion sort would add unnecessary overhead on every device open/close for no practical benefit

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2467)
<!-- Reviewable:end -->
