### PR TITLE
fix(djvu): handle out-of-bounds render rectangle

### DIFF
--- a/djvu.c
+++ b/djvu.c
@@ -639,8 +639,13 @@ static int drawPage(lua_State *L) {
 	 */
 	renderrect.x = MAX(-dc->offset_x, 0);
 	renderrect.y = MAX(-dc->offset_y, 0);
-	renderrect.w = MIN(pagerect.w - renderrect.x, bb->w);
-	renderrect.h = MIN(pagerect.h - renderrect.y, bb->h);
+	if (renderrect.x >= pagerect.w || renderrect.y >= pagerect.h) {
+		renderrect.w = 0;
+		renderrect.h = 0;
+	} else {
+		renderrect.w = MIN(pagerect.w - renderrect.x, bb->w);
+		renderrect.h = MIN(pagerect.h - renderrect.y, bb->h);
+	}
 
 	/*printf("--renderrect--- (%d, %d), w:%d, h:%d\n", renderrect.x, renderrect.y, renderrect.w, renderrect.h);*/
 


### PR DESCRIPTION
- Prevent invalid render rect width and height
- Set dimensions to zero when offset exceeds page
- 
`ddjvu_rect_t` uses unsigned integer fields. When the user scrolls far enough
that `dc->offset_x` or `dc->offset_y` becomes negative with a magnitude
exceeding the page dimensions, `renderrect.x` (or `renderrect.y`) exceeds
`pagerect.w` (or `pagerect.h`).

The original code:
```c
renderrect.w = MIN(pagerect.w - renderrect.x, bb->w);
```
performs unsigned subtraction, wrapping pagerect.w - renderrect.x to a huge
value. MIN(huge, bb->w) returns bb->w, causing ddjvu_page_render to
read beyond the page buffer — potential crash or visual corruption.

Check whether the render origin falls outside the page bounds before
computing dimensions. If so, set renderrect.w and renderrect.h to zero,
which causes ddjvu_page_render to skip rendering (no-op).
```c
if (renderrect.x >= pagerect.w || renderrect.y >= pagerect.h) {
    renderrect.w = 0;
    renderrect.h = 0;
} else {
    renderrect.w = MIN(pagerect.w - renderrect.x, bb->w);
    renderrect.h = MIN(pagerect.h - renderrect.y, bb->h);
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2470)
<!-- Reviewable:end -->
