### PR TITLE
fix(nnsvg): prevent usage of freed NSVGimage

### DIFF
--- a/nnsvg.c
+++ b/nnsvg.c
@@ -74,6 +74,9 @@ NSVGimage * check_NSVGimage(lua_State * L, int n) {
     // This checks that the thing at n on the stack is a correct nnSVGImage
     // wrapping userdata (tagged with the "luaL_nnSVGImage" metatable).
     NSVGimage * image = *(NSVGimage **)luaL_checkudata(L, n, NNSVG_METATABLE_NAME);
+    if (!image) {
+        luaL_error(L, "attempt to use a freed NSVGimage");
+    }
     return image;
 }
 


### PR DESCRIPTION
`nnSVGImage_free (lines 88–95)` is registered as both `:free()` and `__gc`:
```c
*udata = NULL; // line 93: set to NULL after freeing
```
lua code calls `:free()` and then accidentally calls `:getSize()` as well → `check_NSVGimage` will catch the error instead of crashing due to a dangling pointer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2471)
<!-- Reviewable:end -->
