### PR TITLE
fix(wrap-mupdf): prevent integer overflow in allocator

### DIFF
--- a/wrap-mupdf.c
+++ b/wrap-mupdf.c
@@ -22,6 +22,7 @@
 #include <math.h>
 #include <stddef.h>
 #include <string.h>
+#include <stdint.h>
 #include "wrap-mupdf.h"
 
 static double LOG_TRESHOLD_PERC = 0.05; // 5%
@@ -75,6 +76,9 @@ static void log_size(char *funcName) {
 static void *
 my_malloc_default(void *opaque, size_t size)
 {
+    if (size > SIZE_MAX - sizeof(header)) {
+        return NULL;
+    }
     struct header * h = malloc(size + sizeof(header));
     if (h == NULL) {
         return NULL;


### PR DESCRIPTION
`my_malloc_default` computes `size + sizeof(header)` to allocate extra space
for its tracking header. If `size` is close to `SIZE_MAX`, the addition wraps
to a small value. `malloc` succeeds with a tiny allocation, but the caller
operates as if it received `size` bytes — heap buffer overflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2472)
<!-- Reviewable:end -->
