### PR TITLE
fix(xtext): memory safety and input validation fixes

### DIFF
--- a/xtext.cpp
+++ b/xtext.cpp
@@ -620,10 +620,14 @@ public:
                     hb_feature_t f;
                     if ( hb_feature_from_string(feature, len, &f) ) {
                         hb_data->hb_features_nb++;
-                        hb_data->hb_features = (hb_feature_t*)realloc( hb_data->hb_features,
+                        hb_feature_t *tmp = (hb_feature_t*)realloc( hb_data->hb_features,
                                                     hb_data->hb_features_nb * sizeof(hb_feature_t) );
-                        if ( hb_data->hb_features )
+                        if ( tmp ) {
+                            hb_data->hb_features = tmp;
                             hb_data->hb_features[hb_data->hb_features_nb-1] = f;
+                        } else {
+                            hb_data->hb_features_nb--;
+                        }
                     }
                 }
                 lua_pop(m_L, 1); // remove fetched value, but keep key for next iteration

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -2295,13 +2295,12 @@ static int xtext_hb_font_data_destroy(lua_State *L) {
     FT_Library ft_lib = (FT_Library)ft_face->generic.data;
     int *refcount = (int *)hb_data->ft_size->generic.data;
     assert(*refcount > 0);
+    hb_font_destroy(hb_data->hb_font);  // Release HB's reference to face BEFORE FT_Done_Face
     if (!--*refcount) {
         free(refcount);
         FT_Done_Size(hb_data->ft_size);
         FT_Done_Face(ft_face);
-        FT_Done_Library(ft_lib);
     }
-    hb_font_destroy(hb_data->hb_font);
     FT_Done_Library(ft_lib);
     hb_buffer_destroy(hb_data->hb_buffer);
     if ( hb_data->hb_features )

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -2425,6 +2425,7 @@ static int XText_shapeLine(lua_State *L) {
     start--; // Lua to C index
     int end = luaL_checkint(L, 3);
     luaL_argcheck(L, end >= 1 && end <= xt->m_length, 3, "index out of range");
+    luaL_argcheck(L, end >= start, 3, "end must be >= start");
     // end--; // Lua to C index, but we don't as end is excluded in our C code,
               // but it is expected to be included in the Lua call
     int idx_to_substitute_with_ellipsis = -1;
@@ -2488,6 +2489,7 @@ static int XText_getText(lua_State *L) {
     start--; // Lua to C index
     int end = luaL_checkint(L, 3);
     luaL_argcheck(L, end >= 1 && end <= xt->m_length, 3, "index out of range");
+    luaL_argcheck(L, end >= start, 3, "end must be >= start");
     // end--; // Lua to C index, but we don't as end is excluded in our C code,
               // but it is expected to be included in the Lua call
     xt->getText(start, end);

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -538,7 +538,7 @@ public:
     // This must be a method of our XText object, as it uses the uservalue that has
     // been associated with the userdata that is wrapping this XText instance.
     xtext_hb_font_data * getHbFontData(int num) {
-        if ( num > MAX_FONT_NUM )
+        if ( num >= MAX_FONT_NUM )
             return NULL;
         // This uses the stack for C <-> Lua interaction, but we should put this
         // stack back in its original state, as it may carry additional arguments
@@ -828,7 +828,7 @@ public:
     // - we don't use cumulative widths: we store individual char widths (to store them in 16 bits
     //   in m_charinfo, instead of needing a full 32 bits int for each char)
     int measureSegment(int font_num, int start, int end, int hints) {
-        if ( font_num > MAX_FONT_NUM )
+        if ( font_num >= MAX_FONT_NUM )
             return NOT_MEASURED;
 
         #ifdef DEBUG_MEASURE_TEXT
@@ -1734,7 +1734,7 @@ public:
     // Based on crengine/src/lvfntman.cpp drawTextString() with _kerningMode == KERNING_MODE_HARFBUZZ
     // and crengine/src/lvtextfm.cpp addLine()
     void shapeSegment(int font_num, int start, int end, int hints, int & nb_glyphs) {
-        if ( font_num > MAX_FONT_NUM )
+        if ( font_num >= MAX_FONT_NUM )
             return;
             // No need to add a tofu char to s_shape_result: font_num
             // should have been checked before calling us, and if

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -366,10 +366,14 @@ public:
         // ZERO_WIDTH_JOINER before the ELLIPSIS (which might be needed with Arabic)
         size_t size = m_length + 1;
         m_charinfo = (xtext_charinfo_t *)calloc(size, sizeof(*m_charinfo)); // set all flags to 0
+        if ( !m_charinfo ) return;
         if ( m_has_rtl ) {
             m_bidi_ctypes = (FriBidiCharType *)malloc(size * sizeof(*m_bidi_ctypes));
+            if ( !m_bidi_ctypes ) { free(m_charinfo); m_charinfo = NULL; return; }
             m_bidi_btypes = (FriBidiBracketType *)malloc(size * sizeof(*m_bidi_btypes));
+            if ( !m_bidi_btypes ) { free(m_charinfo); m_charinfo = NULL; free(m_bidi_ctypes); m_bidi_ctypes = NULL; return; }
             m_bidi_levels = (FriBidiLevel *)malloc(size * sizeof(*m_bidi_levels));
+            if ( !m_bidi_levels ) { free(m_charinfo); m_charinfo = NULL; free(m_bidi_ctypes); m_bidi_ctypes = NULL; free(m_bidi_btypes); m_bidi_btypes = NULL; return; }
         }
     }
     void deallocate() {

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -2061,7 +2061,11 @@ public:
         // Let's be cheap and not count the nb of bytes really needed to store the
         // UTF-8 encoding of each Unicode codepoint: go allocate for the max (4).
         int len = end - start;
-        char * s_utf8 = (char *)malloc(len * 4*sizeof(char) + 1);
+        char * s_utf8 = (char *)malloc((size_t)len * 4 + 1);
+        if (!s_utf8) {
+            lua_pushstring(m_L, "");
+            return;
+        }
         fribidi_unicode_to_charset(FRIBIDI_CHAR_SET_UTF8, m_text+start, len, s_utf8);
         lua_pushstring(m_L, s_utf8);
         free(s_utf8);

--- a/xtext.cpp
+++ b/xtext.cpp
@@ -2170,6 +2170,7 @@ static int xtext_setDefaultParaDirection(lua_State *L) {
 // of the main one).
 static int xtext_setDefaultLang(lua_State *L) {
     const char * lang = luaL_checkstring(L, 1);
+    delete[] default_lang;
     default_lang = new char[strlen(lang)+1];
     strcpy(default_lang, lang);
     default_lang_hb_language = hb_language_from_string(default_lang, -1);


### PR DESCRIPTION


### Change 1: prevent memory leak on realloc failure in feature parsing

In `getHbFontData()`, HarfBuzz font features are parsed from Lua tables
and stored in a dynamically growing array via `realloc`:

```c
// OLD: if realloc fails, hb_features is set to NULL,
// losing the pointer to the old buffer
hb_data->hb_features_nb++;
hb_data->hb_features = (hb_feature_t*)realloc(hb_data->hb_features, ...);
if ( hb_data->hb_features )
    hb_data->hb_features[hb_data->hb_features_nb-1] = f;
```

If `realloc` returns NULL, the old pointer is overwritten and the
previously allocated buffer is leaked. The feature count is also left
one too high, causing subsequent operations to write beyond the actual
allocation.

### Change 2: prevent heap overflow in getText UTF-8 conversion

In `getText()`, the UTF-8 output buffer is sized as `len * 4` (max 4
bytes per Unicode codepoint). The multiplication was done in `int`:

```c
// OLD: int * int can overflow
int len = end - start;
char * s_utf8 = (char *)malloc(len * 4*sizeof(char) + 1);
```

For a text segment longer than ~536 million characters (INT_MAX / 4),
the product overflows to a small or negative value. `malloc` allocates
a tiny buffer, but `fribidi_unicode_to_charset` writes the full UTF-8
output — heap buffer overflow.

Fix: cast `len` to `size_t` before multiplication, and add a NULL check
for `malloc` failure (returns empty string to Lua).

### Change 3: fix font destruction order to prevent use-after-free

In `xtext_hb_font_data_destroy()`, the old code destroyed the FreeType
face and library **before** the HarfBuzz font:

```c
// OLD: wrong order
if (!--*refcount) {
    FT_Done_Size(hb_data->ft_size);
    FT_Done_Face(ft_face);
    FT_Done_Library(ft_lib);
}
hb_font_destroy(hb_data->hb_font);  // HB still references the face!
FT_Done_Library(ft_lib);            // double-free when refcount > 0
```

HarfBuzz's `hb_font_t` holds an internal reference to the `FT_Face`.
Destroying the face first leaves HB with a dangling pointer — any
subsequent HB operation on the font would use freed memory.

Additionally, `FT_Done_Library` was called unconditionally outside the
refcount check, causing a double-free of the library when `refcount > 0`.

Fix: call `hb_font_destroy` first, and only call `FT_Done_Library`
inside the refcount branches (once per code path).

### Change 4: fix off-by-one in font number validation

`MAX_FONT_NUM` is defined as 16. Font arrays (`hb_fonts`, etc.) are
indexed 0..15. The old bounds check used `>` instead of `>=`:

```c
// OLD: num == 16 passes this check
if ( num > MAX_FONT_NUM )
    return NULL;
```

If Lua code passes `font_num = 16`, it bypasses the guard and accesses
`hb_fonts[16]` — one element past the end of the array. Depending on
what occupies that memory, this causes undefined behavior (crash, silent
corruption, or seemingly correct operation).

Fix: changed to `num >= MAX_FONT_NUM` in all three functions:
`getHbFontData()`, `measureSegment()`, and `shapeSegment()`.

### Change 5: addd NULL checks for malloc in allocate()

The `allocate()` method calls `calloc` and three `malloc` calls for
BiDi data structures without checking for NULL:

```c
// OLD: no NULL checks
m_charinfo = (xtext_charinfo_t *)calloc(size, sizeof(*m_charinfo));
if ( m_has_rtl ) {
    m_bidi_ctypes = (FriBidiCharType *)malloc(size * sizeof(*m_bidi_ctypes));
    m_bidi_btypes = (FriBidiBracketType *)malloc(size * sizeof(*m_bidi_btypes));
    m_bidi_levels = (FriBidiLevel *)malloc(size * sizeof(*m_bidi_levels));
}
```

On OOM, any of these returns NULL. Subsequent code dereferences the NULL
pointer — crash. On memory-constrained KOReader devices (512MB-1GB RAM),
OOM is rare but possible with very large documents.

Fix: each allocation is checked. On failure, all previously allocated
buffers are freed (set to NULL for safety), and the method returns early.
Callers that depend on `m_charinfo` being non-NULL will need to handle
the incomplete state (this is consistent with how `deallocate()` already
handles NULL pointers).

Cjange 6: fix memory leak in setDefaultLang

`xtext_setDefaultLang()` allocates a new string for the language code
without freeing the previous one:

```c
// OLD: old default_lang is leaked
default_lang = new char[strlen(lang)+1];
```

If this function is called multiple times (e.g., user changes language
settings), each call leaks the previous allocation. Over time this
accumulates.

Fix: add `delete[] default_lang` before the `new` allocation.
`delete[]` on a null pointer is a safe no-op in C++, so the first call
(where `default_lang` is initialized to NULL) is handled correctly.

### Change 7: validate end >= start in shapeLine and getText

`XText_shapeLine()` and `XText_getText()` accept Lua arguments for
start and end indices, but only validate each independently against
the text length — not against each other:

```c
// OLD: end < start is not rejected
luaL_argcheck(L, start >= 1 && start <= xt->m_length, 2, "index out of range");
luaL_argcheck(L, end >= 1 && end <= xt->m_length, 3, "index out of range");
```

If `end < start`, the resulting `len = end - start` is negative.
In `getText()`, this causes `malloc` to be called with a wrapped
`size_t` value (negative int → huge size_t), or `fribidi_unicode_to_charset`
to read before the start of the buffer.

Fix: add `luaL_argcheck(L, end >= start, ...)` after the existing
range checks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2473)
<!-- Reviewable:end -->
