### PR TITLE
ffi/util: return available space from df, and fix its block maths

### DIFF
--- a/ffi/util.lua
+++ b/ffi/util.lua
@@ -105,11 +105,21 @@ function util.getDuration(from_timestamp)
     return util.getTimestamp() - from_timestamp
 end
 
-local statvfs = ffi.new("struct statvfs")
+-- bionic only got statvfs in API 19, and NDKABI is still 18 on 32-bit Android.
+local has_statvfs = pcall(function() return C.statvfs ~= nil end)
+
+--- Size, free space and available space of the filesystem holding path, in bytes.
+-- Available is what df reports in that column: free space less the blocks kept
+-- back for root. Returns nil plus a message if the filesystem cannot be queried.
 function util.df(path)
-    C.statvfs(path, statvfs)
-    return tonumber(statvfs.f_blocks * statvfs.f_bsize),
-        tonumber(statvfs.f_bfree * statvfs.f_bsize)
+    if not has_statvfs then return nil, "statvfs is not available" end
+    local statvfs = ffi.new("struct statvfs")
+    if C.statvfs(path, statvfs) ~= 0 then return nil, "statvfs: " .. posix.strerror() end
+    -- The block counts are in f_frsize units, which is not always f_bsize.
+    local frsize = tonumber(statvfs.f_frsize)
+    return tonumber(statvfs.f_blocks) * frsize,
+        tonumber(statvfs.f_bfree) * frsize,
+        tonumber(statvfs.f_bavail) * frsize
 end
 
 --- Wrapper for C.strcoll.

--- a/spec/unit/util_spec.lua
+++ b/spec/unit/util_spec.lua
@@ -163,6 +163,24 @@ describe("util module", function()
         end)
     end)
 
+    describe("util.df", function()
+        it("should report a filesystem's size, free and available space", function()
+            local total, free, available = util.df(".")
+            assert.is_number(total)
+            assert.is_true(total > 0)
+            -- Free space cannot exceed the filesystem, and what is available to
+            -- an unprivileged user cannot exceed what is free.
+            assert.is_true(free <= total)
+            assert.is_true(available <= free)
+        end)
+
+        it("should error out on a non-existent path", function()
+            local ok, err = util.df("/tmp/123/abc/567/foobar")
+            assert.is_nil(ok)
+            assert.is_not_nil(err)
+        end)
+    end)
+
     describe("util.purgeDir", function()
         it("should error out on non-exists directory", function()
             local ok, err = util.purgeDir('/tmp/123/abc/567/foobar')


### PR DESCRIPTION
`util.df` multiplied block counts by `f_bsize`, but statvfs counts them in
`f_frsize` units. The return value was ignored and the buffer was shared by
every caller, so a failed call handed back the previous numbers; it now returns
nil plus a message, as `purgeDir` does.

Available (`f_bavail`) comes back as a third value: that is the column `df`
prints, and `frontend/util.diskUsage` needs it (PR to follow).

Guarded for Android below API 19, where bionic has no statvfs and `NDKABI` is 18.

Verified on a Kindle 3 (kernel 2.6.26): matches `df` to the byte, with available
26 MB below free on ext3 and equal to it on VFAT.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2478)
<!-- Reviewable:end -->
