### PR TITLE
netinfo: don't ask socket() for SOCK_CLOEXEC

### DIFF
--- a/ffi/netinfo.lua
+++ b/ffi/netinfo.lua
@@ -123,10 +123,12 @@ if ffi.os == "Linux" then -- {{{
 function NetInfo:_iface_ssid_ioctl(iface)
     local sd = self.sd
     if not sd then
-        sd = C.socket(C.AF_INET, bit.bor(C.SOCK_DGRAM, C.SOCK_CLOEXEC), C.IPPROTO_IP)
+        -- SOCK_CLOEXEC in socket() needs Linux 2.6.27; older kernels fail with EINVAL.
+        sd = C.socket(C.AF_INET, C.SOCK_DGRAM, C.IPPROTO_IP)
         if sd < 0 then
             error(string.format("socket(AF_INET) failed: %s", posix.strerror()))
         end
+        C.fcntl(sd, C.F_SETFD, ffi.cast("int", C.FD_CLOEXEC))
         self.sd = sd
     end
     local essid = ffi.new("char[?]", C.IW_ESSID_MAX_SIZE + 1)

--- a/ffi/netinfo.lua
+++ b/ffi/netinfo.lua
@@ -124,11 +124,15 @@ function NetInfo:_iface_ssid_ioctl(iface)
     local sd = self.sd
     if not sd then
         -- SOCK_CLOEXEC in socket() needs Linux 2.6.27; older kernels fail with EINVAL.
+        -- It also sets the flag atomically, which the fcntl below cannot: another
+        -- thread forking and exec'ing in between leaks the descriptor (c.f. open(2)).
         sd = C.socket(C.AF_INET, C.SOCK_DGRAM, C.IPPROTO_IP)
         if sd < 0 then
             error(string.format("socket(AF_INET) failed: %s", posix.strerror()))
         end
-        C.fcntl(sd, C.F_SETFD, ffi.cast("int", C.FD_CLOEXEC))
+        if C.fcntl(sd, C.F_SETFD, ffi.cast("int", C.FD_CLOEXEC)) == -1 then
+            io.stderr:write("fcntl(F_SETFD, FD_CLOEXEC) failed: " .. posix.strerror())
+        end
         self.sd = sd
     end
     local essid = ffi.new("char[?]", C.IW_ESSID_MAX_SIZE + 1)


### PR DESCRIPTION
`SOCK_CLOEXEC` needs Linux 2.6.27, so on older kernels `socket()` fails with `EINVAL`
and the SSID is never read: Network info reports `SSID: off/any` while connected.
Set the flag with `fcntl()` afterwards instead, as `Device:ping4` already does.

Kindle 3, kernel 2.6.26: `SSID: off/any` → `SSID: "ad33"`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2480)
<!-- Reviewable:end -->
