### PR TITLE
einkfb: refresh the screen even when its content has not changed

### DIFF
--- a/ffi/framebuffer_einkfb.lua
+++ b/ffi/framebuffer_einkfb.lua
@@ -26,7 +26,9 @@ function framebuffer:refreshPartialImp(x, y, w, h)
 end
 
 function framebuffer:refreshFullImp(x, y, w, h)
-    einkfb_update(self, C.fx_update_full, x, y, w, h)
+    -- The driver skips an update whose pixels all match what is already on screen, dropping
+    -- explicit full refreshes on an unchanged screen; fx_update_slow is exempt from that check.
+    einkfb_update(self, C.fx_update_slow, x, y, w, h)
 end
 
 return require("ffi/framebuffer_linux"):extend(framebuffer)


### PR DESCRIPTION
The einkfb driver skips an update when every pixel matches what is already on screen, so
"Full screen refresh" on an unchanged screen did nothing. fx_update_slow is exempt from that
comparison and drives the panel at full fidelity.

Verified on a live Kindle 3: the refresh fires every time and clears ghosting; page turns and
UI flashes stay correct.

Fixes koreader/koreader#12774.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2481)
<!-- Reviewable:end -->
