### PR TITLE
Android: let the system handle power key events

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -179,17 +179,17 @@ local function keyEventHandler(key_event)
             return 0 -- event not consumed
         end
     elseif code == C.AKEYCODE_MEDIA_PLAY_PAUSE
-    or code == C.AKEYCODE_MEDIA_PLAY
-    or code == C.AKEYCODE_MEDIA_PAUSE
-    or code == C.AKEYCODE_MEDIA_STOP
-    or code == C.AKEYCODE_MEDIA_NEXT
-    or code == C.AKEYCODE_MEDIA_PREVIOUS
-    or code == C.AKEYCODE_MEDIA_REWIND
-    or code == C.AKEYCODE_MEDIA_FAST_FORWARD
-    or code == C.AKEYCODE_HEADSETHOOK then
+        or code == C.AKEYCODE_MEDIA_PLAY
+        or code == C.AKEYCODE_MEDIA_PAUSE
+        or code == C.AKEYCODE_MEDIA_STOP
+        or code == C.AKEYCODE_MEDIA_NEXT
+        or code == C.AKEYCODE_MEDIA_PREVIOUS
+        or code == C.AKEYCODE_MEDIA_REWIND
+        or code == C.AKEYCODE_MEDIA_FAST_FORWARD
+        or code == C.AKEYCODE_HEADSETHOOK
+        or code == C.AKEYCODE_POWER -- Normally third-party apps can't intercept the power button, but the Tolino Shine 3 (firmware 16.2.0) delivers it anyway.
+    then
         return 0 -- event not consumed
-    elseif code == C.AKEYCODE_POWER then
-        return 0 -- let Android handle the power button
     elseif code == C.AKEYCODE_MUTE
     or code == C.AKEYCODE_VOLUME_MUTE then
         if android.getVolumeKeysIgnored() then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -188,6 +188,8 @@ local function keyEventHandler(key_event)
     or code == C.AKEYCODE_MEDIA_FAST_FORWARD
     or code == C.AKEYCODE_HEADSETHOOK then
         return 0 -- event not consumed
+    elseif code == C.AKEYCODE_POWER then
+        return 0 -- let Android handle the power button
     elseif code == C.AKEYCODE_MUTE
     or code == C.AKEYCODE_VOLUME_MUTE then
         if android.getVolumeKeysIgnored() then


### PR DESCRIPTION
On a Tolino Shine 3 (firmware 16.2.0), short power-button presses were ignored by KOReader while working normally in the Tolino app.

`AKEYCODE_POWER` was consumed without being mapped to an action. Returning `0` lets Android handle it.

Tested with clean installations of KOReader v2026.07: the original build ignores the button, the patched build locks and wakes correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2482)
<!-- Reviewable:end -->
