### PR TITLE
ffi/downloader: improve fetch implementation

### DIFF
--- a/ffi/downloader.lua
+++ b/ffi/downloader.lua
@@ -24,58 +24,48 @@ end
 
 function Downloader:fetch(url, callback, ranges, etag)
     assert(not (ranges and etag))
-    self.status_code = nil
-    self.etag = nil
-    local ok
     local sink = function(s)
         return s and callback(ffi.cast("uint8_t *", s), #s)
     end
-    local body, status_code, resp_headers, status_line
+    local abort
+    local response_headers = function(status_code, resp_headers, status_line)
+        if ranges then
+            abort = status_code ~= 206
+        else
+            abort = status_code ~= 200 and status_code ~= 304
+        end
+        return abort
+    end
+    local ok, status_code, resp_headers, status_line
     if ranges then
         ranges = merge_ranges(ranges)
-        local range_support_checked = false
         local ranges_index = 1
         repeat
-            body, status_code, resp_headers, status_line = http.request{
+            ok, status_code, resp_headers, status_line = http.request{
                 url = url,
                 headers = { ["Range"] = string.format("bytes=%u-%u", ranges[ranges_index][1], ranges[ranges_index][2]) },
+                response_headers = response_headers,
                 sink = sink,
             }
-            if not body then
-                self.err = status_code
-                return false
-            end
-            ok = status_code == 206
-            if not ok then
-                self.err = status_line
-                return false
-            end
-            if not range_support_checked then
-                if resp_headers["accept-ranges"] ~= "bytes" and not (resp_headers["content-range"] or ""):match("^bytes ") then
-                    self.err = "server does not support range requests!"
-                    return false
-                end
-                range_support_checked = true
-            end
+            ok = ok and not abort
             ranges_index = ranges_index + 1
-        until ranges_index > #ranges
+        until abort or not ok or ranges_index > #ranges
+        if not ok and status_code == 200 then
+            status_line = "server does not support range requests!"
+        end
     else
-        body, status_code, resp_headers, status_line = http.request{
+        ok, status_code, resp_headers, status_line = http.request{
             url = url,
             headers = etag and { ["If-None-Match"] = etag },
+            response_headers = response_headers,
             sink = sink,
         }
-        if not body then
-            self.err = status_code
-            return false
-        end
-        self.etag = resp_headers['etag']
-        ok = status_code == 200 or status_code == 304
-        if not ok then
-            self.err = status_line
-        end
+        ok = ok and not abort
     end
+    self.headers = resp_headers
+    self.etag = resp_headers['etag']
     self.status_code = status_code
+    self.err = not ok and (status_line or status_code) or nil
     return ok
 end
 

--- a/thirdparty/luasocket/CMakeLists.txt
+++ b/thirdparty/luasocket/CMakeLists.txt
@@ -7,6 +7,8 @@ list(APPEND PATCH_FILES
     luajit-compat.patch
     # To avoid duplicated code in luasec.
     export-api-for-luasec.patch
+    # Add support for headers callback to HTTP requests.
+    http_headers_callback.patch
 )
 if(NOT ANDROID)
     # Make sure socket fds are CLOEXEC on *nix.

--- a/thirdparty/luasocket/CMakeLists.txt
+++ b/thirdparty/luasocket/CMakeLists.txt
@@ -55,7 +55,7 @@ else()
 endif()
 
 external_project(
-    DOWNLOAD GIT e3ca4a767a68d127df548d82669aba3689bd84f4
+    DOWNLOAD GIT a3bcaed18cb6d69e6e2ae711c93dbe99c7a220bb
     https://github.com/lunarmodules/luasocket
     PATCH_OVERLAY overlay
     PATCH_FILES ${PATCH_FILES}

--- a/thirdparty/luasocket/enforce-cloexec.patch
+++ b/thirdparty/luasocket/enforce-cloexec.patch
@@ -1,8 +1,8 @@
 diff --git a/src/usocket.c b/src/usocket.c
-index 7965db6..fc1f607 100644
+index 23b3422..c0bceae 100644
 --- a/src/usocket.c
 +++ b/src/usocket.c
-@@ -122,8 +122,15 @@ int socket_select(t_socket n, fd_set *rfds, fd_set *wfds, fd_set *efds,
+@@ -114,8 +114,15 @@ int socket_select(t_socket n, fd_set *rfds, fd_set *wfds, fd_set *efds,
  \*-------------------------------------------------------------------------*/
  int socket_create(p_socket ps, int domain, int type, int protocol) {
      *ps = socket(domain, type, protocol);

--- a/thirdparty/luasocket/export-api-for-luasec.patch
+++ b/thirdparty/luasocket/export-api-for-luasec.patch
@@ -1,4 +1,5 @@
 diff --git a/src/usocket.c b/src/usocket.c
+index 7965db6..23b3422 100644
 --- a/src/usocket.c
 +++ b/src/usocket.c
 @@ -18,11 +18,7 @@
@@ -25,6 +26,7 @@ diff --git a/src/usocket.c b/src/usocket.c
      int ret;
      fd_set rfds, wfds, *rp, *wp;
 diff --git a/src/usocket.h b/src/usocket.h
+index 45f2f99..b1f8cbb 100644
 --- a/src/usocket.h
 +++ b/src/usocket.h
 @@ -56,4 +56,15 @@ typedef struct sockaddr_storage t_sockaddr_storage;
@@ -44,6 +46,7 @@ diff --git a/src/usocket.h b/src/usocket.h
 +
  #endif /* USOCKET_H */
 diff --git a/src/wsocket.c b/src/wsocket.c
+index d3af9d4..b56f751 100644
 --- a/src/wsocket.c
 +++ b/src/wsocket.c
 @@ -42,11 +42,6 @@ int socket_close(void) {
@@ -59,6 +62,7 @@ diff --git a/src/wsocket.c b/src/wsocket.c
      int ret;
      fd_set rfds, wfds, efds, *rp = NULL, *wp = NULL, *ep = NULL;
 diff --git a/src/wsocket.h b/src/wsocket.h
+index 3986640..c5a4b1c 100644
 --- a/src/wsocket.h
 +++ b/src/wsocket.h
 @@ -16,6 +16,11 @@ typedef SOCKADDR_STORAGE t_sockaddr_storage;

--- a/thirdparty/luasocket/http_headers_callback.patch
+++ b/thirdparty/luasocket/http_headers_callback.patch
@@ -1,0 +1,30 @@
+diff --git a/src/http.lua b/src/http.lua
+index 259eb2b..b27e630 100644
+--- a/src/http.lua
++++ b/src/http.lua
+@@ -344,6 +344,7 @@ local trequest, tredirect
+         headers = reqt.headers,
+         proxy = reqt.proxy,
+         maxredirects = reqt.maxredirects,
++        response_headers = reqt.response_headers,
+         nredirects = (reqt.nredirects or 0) + 1,
+         create = reqt.create
+     }
+@@ -387,6 +388,17 @@ end
+         return tredirect(reqt, headers.location)
+     end
+     -- here we are finally done
++    -- provide an opportunity to abort or replace the sink based on the response headers
++    if nreqt.response_headers then
++        local abort, sink = nreqt.response_headers(code, headers, status)
++        if abort then
++            h:close()
++            return 1, code, headers, status
++        end
++        if sink then
++            nreqt.sink = sink
++        end
++    end
+     if shouldreceivebody(nreqt, code) then
+         h:receivebody(headers, nreqt.sink, nreqt.step)
+     end

--- a/thirdparty/luasocket/luajit-compat.patch
+++ b/thirdparty/luasocket/luajit-compat.patch
@@ -1,4 +1,5 @@
 diff --git a/src/compat.h b/src/compat.h
+index fa2d7d7..0399a76 100644
 --- a/src/compat.h
 +++ b/src/compat.h
 @@ -1,3 +1,4 @@

--- a/thirdparty/luasocket/namespace.patch
+++ b/thirdparty/luasocket/namespace.patch
@@ -1,4 +1,5 @@
 diff --git a/src/luasocket.c b/src/luasocket.c
+index 0fd99f7..835c633 100644
 --- a/src/luasocket.c
 +++ b/src/luasocket.c
 @@ -96,7 +96,7 @@ static int base_open(lua_State *L) {
@@ -11,6 +12,7 @@ diff --git a/src/luasocket.c b/src/luasocket.c
      base_open(L);
      for (i = 0; mod[i].name; i++) mod[i].func(L);
 diff --git a/src/luasocket.h b/src/luasocket.h
+index 1e3d358..d38558d 100644
 --- a/src/luasocket.h
 +++ b/src/luasocket.h
 @@ -31,6 +31,6 @@
@@ -22,6 +24,7 @@ diff --git a/src/luasocket.h b/src/luasocket.h
  
  #endif /* LUASOCKET_H */
 diff --git a/src/mime.c b/src/mime.c
+index 05602f5..5d9a501 100644
 --- a/src/mime.c
 +++ b/src/mime.c
 @@ -167,7 +167,7 @@ static const UC b64unbase[] = {
@@ -34,6 +37,7 @@ diff --git a/src/mime.c b/src/mime.c
      lua_newtable(L);
      luaL_setfuncs(L, func, 0);
 diff --git a/src/mime.h b/src/mime.h
+index 4d938f4..1fc55c3 100644
 --- a/src/mime.h
 +++ b/src/mime.h
 @@ -17,6 +17,6 @@
@@ -45,6 +49,7 @@ diff --git a/src/mime.h b/src/mime.h
  
  #endif /* MIME_H */
 diff --git a/src/mime.lua b/src/mime.lua
+index 93539de..d23b2d1 100644
 --- a/src/mime.lua
 +++ b/src/mime.lua
 @@ -9,7 +9,7 @@
@@ -57,6 +62,7 @@ diff --git a/src/mime.lua b/src/mime.lua
  
  -- encode, decode and wrap algorithm tables
 diff --git a/src/socket.lua b/src/socket.lua
+index d1c0b16..ea7c8ef 100644
 --- a/src/socket.lua
 +++ b/src/socket.lua
 @@ -9,7 +9,7 @@


### PR DESCRIPTION
Use new HTTP response headers callback to abort early in case of error.

Additionally, simplify check for range request support: only check the
status code, instead of headers (since Cloudflare response doesn't
include the expected "Accept-range" header).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2485)
<!-- Reviewable:end -->
