### PR TITLE
libarchive: update to 3.8.9

### DIFF
--- a/thirdparty/libarchive/CMakeLists.txt
+++ b/thirdparty/libarchive/CMakeLists.txt
@@ -50,8 +50,8 @@ if(NOT MONOLIBTIC)
 endif()
 
 external_project(
-    DOWNLOAD URL 81a6d70daf20671ea2c5cd4bb1d371ae
-    https://github.com/libarchive/libarchive/releases/download/v3.8.8/libarchive-3.8.8.tar.xz
+    DOWNLOAD URL 535e3afec5f61d493f0b1b9e8bcf7539
+    https://github.com/libarchive/libarchive/releases/download/v3.8.9/libarchive-3.8.9.tar.xz
     CMAKE_ARGS ${CMAKE_ARGS}
     PATCH_FILES ${PATCH_FILES}
     PATCH_COMMAND ${PATCH_CMD}

--- a/thirdparty/libarchive/android.patch
+++ b/thirdparty/libarchive/android.patch
@@ -1,8 +1,8 @@
 diff --git a/libarchive/archive_read_disk_posix.c b/libarchive/archive_read_disk_posix.c
-index 47c1d334..f6664745 100644
+index a3c9e583..85e405e7 100644
 --- a/libarchive/archive_read_disk_posix.c
 +++ b/libarchive/archive_read_disk_posix.c
-@@ -1792,7 +1792,7 @@ setup_current_filesystem(struct archive_read_disk *a)
+@@ -1796,7 +1796,7 @@ setup_current_filesystem(struct archive_read_disk *a)
  		/* pathconf(_PC_REX_*) operations are not supported. */
  #if defined(HAVE_STATVFS)
  		set_statvfs_transfer_size(t->current_filesystem, &svfs);

--- a/thirdparty/libarchive/avoid_mode_t.patch
+++ b/thirdparty/libarchive/avoid_mode_t.patch
@@ -1,5 +1,5 @@
 diff --git a/libarchive/archive_entry.h b/libarchive/archive_entry.h
-index aa4f4dfb..17cdd2e5 100644
+index 9c859a44..26a3dfb5 100644
 --- a/libarchive/archive_entry.h
 +++ b/libarchive/archive_entry.h
 @@ -93,7 +93,7 @@ typedef ssize_t la_ssize_t;

--- a/thirdparty/libarchive/ignore_locale_and_use_utf8.patch
+++ b/thirdparty/libarchive/ignore_locale_and_use_utf8.patch
@@ -1,5 +1,5 @@
 diff --git a/libarchive/archive_string.c b/libarchive/archive_string.c
-index bbcec444..cdd771f9 100644
+index 87e21c8d..0f71f3b8 100644
 --- a/libarchive/archive_string.c
 +++ b/libarchive/archive_string.c
 @@ -445,6 +445,7 @@ static const char *
@@ -10,7 +10,7 @@ index bbcec444..cdd771f9 100644
  #if HAVE_LOCALE_CHARSET && !defined(__APPLE__)
  	/* locale_charset() is broken on Mac OS */
  	return locale_charset();
-@@ -453,6 +454,9 @@ default_iconv_charset(const char *charset) {
+@@ -455,6 +456,9 @@ default_iconv_charset(const char *charset) {
  #else
  	return "";
  #endif


### PR DESCRIPTION
https://github.com/libarchive/libarchive/releases/tag/v3.8.9

Code size change:
- `android-arm`: +2.4 KB
- `android-arm64`: +1.7 KB
- `kindlepw2`: +1.4 KB
- `linux`: +4.3 KB

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2489)
<!-- Reviewable:end -->
