### PR TITLE
bump crengine: CSS font-face and text layout enhancements

### DIFF
--- a/cre.cpp
+++ b/cre.cpp
@@ -2102,6 +2102,13 @@ static int getTextFromPositions(lua_State *L) {
     if (lua_isboolean(L, 8)) {
         includeImages = lua_toboolean(L, 8);
     }
+    // By default, we extend the selection to include the full words at start
+    // and end. Allow frontend to disable it (which might be welcome with
+    // languages like Thai that don't use spaces to separate words).
+    bool grabWords = true;
+    if (lua_isboolean(L, 9)) {
+        grabWords = lua_toboolean(L, 9);
+    }
 
     LVDocView *tv = doc->text_view;
 
@@ -2205,7 +2212,10 @@ static int getTextFromPositions(lua_State *L) {
     // printf("  after step1 end   %s\n", UnicodeToLocal(r.getEnd().toString()).c_str());
 
     // Step 2: grab complete words on each side
-    if ( not_panning ) {
+    if ( !grabWords ) {
+        // Explicitely disabled
+    }
+    else if ( not_panning ) {
         // Not panning: select the whole word (if any)
         if ( !r.getStart().isVisibleWordStart() ) {
             // Start (included in the selection) is not the start of a word: grab
@@ -2743,6 +2753,23 @@ static int getNearestWordFromPosition(lua_State *L) {
         return 1;
     }
 
+    return 0;
+}
+
+static int getLangTagForTextFromPosition(lua_State *L) {
+    CreDocument *doc = (CreDocument*) luaL_checkudata(L, 1, "credocument");
+    int x = luaL_checkint(L, 2);
+    int y = luaL_checkint(L, 3);
+
+    lvPoint pt(x, y);
+    ldomXPointer p = doc->text_view->getNodeByPoint(pt, true, true);
+    if ( p.isNull() )
+        return 0;
+    TextLangCfg * lang_cfg = TextLangMan::getTextLangCfg(p.getNode());
+    if ( lang_cfg ) {
+        lua_pushstring(L, UnicodeToLocal(lang_cfg->getLangTag()).c_str());
+        return 1;
+    }
     return 0;
 }
 
@@ -4459,6 +4486,7 @@ static const struct luaL_Reg credocument_meth[] = {
     {"getWordBoxesFromPositions", getWordBoxesFromPositions},
     {"getImageDataFromPosition", getImageDataFromPosition},
     {"getNearestWordFromPosition", getNearestWordFromPosition},
+    {"getLangTagForTextFromPosition", getLangTagForTextFromPosition},
     {"getDocumentFileContent", getDocumentFileContent},
     {"getTextFromXPointer", getTextFromXPointer},
     {"getHTMLFromXPointer", getHTMLFromXPointer},

--- a/cre.cpp
+++ b/cre.cpp
@@ -1953,7 +1953,10 @@ static int getLinkFromPosition(lua_State *L) {
 	int y = luaL_checkint(L, 3);
 
 	lvPoint pt(x, y);
-	ldomXPointer p = doc->text_view->getNodeByPoint(pt, true);
+	// Providing forTextSelection=true gives more chances of success to
+	// the link coherenrency checks done by frontend (eg. with negative
+	// text indent and the link rect being outside of its paragraph rect).
+	ldomXPointer p = doc->text_view->getNodeByPoint(pt, true, true);
 	ldomXPointer a_p;
 	lString32 href = p.getHRef(a_p);
 	lua_pushstring(L, UnicodeToLocal(href).c_str());


### PR DESCRIPTION
#### bump crengine: CSS font-face and text layout enhancements

Includes:
- cmake: add setting for custom memory manager use https://github.com/koreader/crengine/pull/715
- fix `USE_ANSI_FILES` setting https://github.com/koreader/crengine/pull/716
- lvtextfm: word expansion: avoid involving space condensing https://github.com/koreader/crengine/pull/717
- lvfntman: subpixel/fractional HarfBuzz glyph positioning https://github.com/koreader/crengine/pull/685
- CSS/lvfntman: consolidate `@font-face` parsing and handling https://github.com/koreader/crengine/pull/713
- bump CACHE_FILE_FORMAT_VERSION https://github.com/koreader/crengine/pull/720

#### cre.cpp: fix getLinkFromPosition()

Avoids some valid links from being considered non-coherent by frontend.
See https://github.com/koreader/koreader/pull/15613#issuecomment-4827147727

####     cre.cpp: add getLangTagForTextFromPosition()

Also add an option to getTextFromPositions() to disable grabbing full words at start and end of selection.
(May help finding a frontend solution for easier text selection on languages like Thai that don't use spaces to separate words,)
So we have some tools to think about https://github.com/koreader/koreader/issues/15785.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2497)
<!-- Reviewable:end -->
