### PR TITLE
pocketbook: fix inkview version check

### DIFF
--- a/ffi/inkview.lua
+++ b/ffi/inkview.lua
@@ -5,10 +5,10 @@ ffi.cdef[[
 char *GetSoftwareVersion();
 ]]
 
--- format is $model.$major.$minor.$build, like "U743g.6.8.4143"
+-- format is $model.$major.$minor.$build, like "U743g.6.8.4143", or "U627.6.0.1118"
 local software_version = ffi.string(inkview.GetSoftwareVersion())
 print(string.format("PocketBook software version: %s", software_version))
-local version_major, version_minor = software_version:match("([1-9][0-9]*)[.]([1-9][0-9]*)[.][1-9][0-9]*$")
+local version_major, version_minor = software_version:match("[.](%d+)[.](%d+)[.]%d+$")
 if not version_major or not version_minor then
     error("could not parse PocketBook software version: "..software_version)
 end


### PR DESCRIPTION
Relax pattern so it can match "U627.6.0.1118" (cf. koreader/koreader#15824).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2499)
<!-- Reviewable:end -->
