### PR TITLE
Android input: handle drawing

### DIFF
--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -64,11 +64,22 @@ local function setPointerDown(slot, down)
     end
 end
 
+local TOOL_TYPE_MAP = {
+    [android.lib.AMOTION_EVENT_TOOL_TYPE_STYLUS]  = 1, -- TOOL_TYPE_PEN
+    [android.lib.AMOTION_EVENT_TOOL_TYPE_ERASER] = 2, -- TOOL_TYPE_ERASER
+}
+
+local function getToolType(event, index)
+    local tool = android.lib.AMotionEvent_getToolType(event, index)
+    return TOOL_TYPE_MAP[tool] or 0 -- TOOL_TYPE_FINGER
+end
+
 local function genTouchDownEvent(event, slot, index)
     local x = android.lib.AMotionEvent_getX(event, index)
     local y = android.lib.AMotionEvent_getY(event, index)
     local timev = genInputTimeval(android.lib.AMotionEvent_getEventTime(event))
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, slot, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
@@ -80,6 +91,7 @@ local function genTouchUpEvent(event, slot, index)
     local y = android.lib.AMotionEvent_getY(event, index)
     local timev = genInputTimeval(android.lib.AMotionEvent_getEventTime(event))
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, -1, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
@@ -91,6 +103,7 @@ local function genTouchMoveEvent(event, timev, slot, index)
     local x = android.lib.AMotionEvent_getX(event, index)
     local y = android.lib.AMotionEvent_getY(event, index)
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
+    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
 end
@@ -149,15 +162,34 @@ local function motionEventHandler(motion_event)
 
         -- This effectively gives us the size of the current MotionEvent array...
         local pointer_count = tonumber(android.lib.AMotionEvent_getPointerCount(motion_event))
+        -- Collect the pointers that are still in contact, as (slot, pointer_index) pairs.
+        local active = {}
         for i = 0, pointer_count - 1 do
             -- So, loop through the array, and if that pointer is still down, move it
             local slot = android.lib.AMotionEvent_getPointerId(motion_event, i)
             if pointers[slot] then
-                genTouchMoveEvent(motion_event, timev, slot, i)
+                active[#active + 1] = { slot = slot, index = i }
             end
         end
 
-        -- Bundle everything in a single input frame
+        -- Useful for continious events like drawing
+        local history = tonumber(android.lib.AMotionEvent_getHistorySize(motion_event))
+        for h = 0, history - 1 do
+            local htimev = genInputTimeval(android.lib.AMotionEvent_getHistoricalEventTime(motion_event, h))
+            for __, ptr in ipairs(active) do
+                genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, ptr.slot, htimev)
+                genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(motion_event, ptr.index), htimev)
+                genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X,
+                    android.lib.AMotionEvent_getHistoricalX(motion_event, ptr.index, h), htimev)
+                genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y,
+                    android.lib.AMotionEvent_getHistoricalY(motion_event, ptr.index, h), htimev)
+            end
+            genEndTouchEvent(motion_event, htimev)
+        end
+
+        for __, ptr in ipairs(active) do
+            genTouchMoveEvent(motion_event, timev, ptr.slot, ptr.index)
+        end
         genEndTouchEvent(motion_event, timev)
     elseif flags == C.AMOTION_EVENT_ACTION_CANCEL then
         -- Invalidate the pointers, and push a custom event to notify front to do the same.

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -99,7 +99,6 @@ local function genTouchUpEvent(event, slot, index)
 end
 
 local function genTouchMoveEvent(event, timev, slot, index, x, y)
-    -- NOTE: May return a float for events w/ subpixel precision.
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
@@ -110,6 +109,7 @@ local function genTouchMoveFrame(event, timev, pointer_count, history_index)
     for i = 0, pointer_count - 1 do
         local slot = android.lib.AMotionEvent_getPointerId(event, i)
         if pointers[slot] then
+            -- NOTE: May return a float for events w/ subpixel precision.
             local x = history_index and android.lib.AMotionEvent_getHistoricalX(event, i, history_index)
                           or android.lib.AMotionEvent_getX(event, i)
             local y = history_index and android.lib.AMotionEvent_getHistoricalY(event, i, history_index)

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -98,10 +98,8 @@ local function genTouchUpEvent(event, slot, index)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0, timev)
 end
 
-local function genTouchMoveEvent(event, timev, slot, index)
+local function genTouchMoveEvent(event, timev, slot, index, x, y)
     -- NOTE: May return a float for events w/ subpixel precision.
-    local x = android.lib.AMotionEvent_getX(event, index)
-    local y = android.lib.AMotionEvent_getY(event, index)
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
@@ -172,23 +170,22 @@ local function motionEventHandler(motion_event)
             end
         end
 
-        -- Useful for continious events like drawing
+        -- Useful for continuous events like drawing
         local history = tonumber(android.lib.AMotionEvent_getHistorySize(motion_event))
         for h = 0, history - 1 do
             local htimev = genInputTimeval(android.lib.AMotionEvent_getHistoricalEventTime(motion_event, h))
             for __, ptr in ipairs(active) do
-                genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, ptr.slot, htimev)
-                genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(motion_event, ptr.index), htimev)
-                genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X,
-                    android.lib.AMotionEvent_getHistoricalX(motion_event, ptr.index, h), htimev)
-                genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y,
-                    android.lib.AMotionEvent_getHistoricalY(motion_event, ptr.index, h), htimev)
+                genTouchMoveEvent(motion_event, htimev, ptr.slot, ptr.index,
+                    android.lib.AMotionEvent_getHistoricalX(motion_event, ptr.index, h),
+                    android.lib.AMotionEvent_getHistoricalY(motion_event, ptr.index, h))
             end
             genEndTouchEvent(motion_event, htimev)
         end
 
         for __, ptr in ipairs(active) do
-            genTouchMoveEvent(motion_event, timev, ptr.slot, ptr.index)
+            genTouchMoveEvent(motion_event, timev, ptr.slot, ptr.index,
+                android.lib.AMotionEvent_getX(motion_event, ptr.index),
+                android.lib.AMotionEvent_getY(motion_event, ptr.index))
         end
         genEndTouchEvent(motion_event, timev)
     elseif flags == C.AMOTION_EVENT_ACTION_CANCEL then

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -91,7 +91,6 @@ local function genTouchUpEvent(event, slot, index)
     local y = android.lib.AMotionEvent_getY(event, index)
     local timev = genInputTimeval(android.lib.AMotionEvent_getEventTime(event))
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
-    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_TRACKING_ID, -1, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
@@ -100,7 +99,6 @@ end
 
 local function genTouchMoveEvent(event, timev, slot, index, x, y)
     genEmuEvent(C.EV_ABS, C.ABS_MT_SLOT, slot, timev)
-    genEmuEvent(C.EV_ABS, C.ABS_MT_TOOL_TYPE, getToolType(event, index), timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_X, x, timev)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
 end

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -171,7 +171,7 @@ local function motionEventHandler(motion_event)
         -- This effectively gives us the size of the current MotionEvent array...
         local pointer_count = tonumber(android.lib.AMotionEvent_getPointerCount(motion_event))
 
-        -- Useful for continuous events like drawing
+        -- Useful for frequent events like drawing
         local history = tonumber(android.lib.AMotionEvent_getHistorySize(motion_event))
         for h = 0, history - 1 do
             local htimev = genInputTimeval(android.lib.AMotionEvent_getHistoricalEventTime(motion_event, h))

--- a/ffi/input_android.lua
+++ b/ffi/input_android.lua
@@ -106,6 +106,19 @@ local function genTouchMoveEvent(event, timev, slot, index, x, y)
     genEmuEvent(C.EV_ABS, C.ABS_MT_POSITION_Y, y, timev)
 end
 
+local function genTouchMoveFrame(event, timev, pointer_count, history_index)
+    for i = 0, pointer_count - 1 do
+        local slot = android.lib.AMotionEvent_getPointerId(event, i)
+        if pointers[slot] then
+            local x = history_index and android.lib.AMotionEvent_getHistoricalX(event, i, history_index)
+                          or android.lib.AMotionEvent_getX(event, i)
+            local y = history_index and android.lib.AMotionEvent_getHistoricalY(event, i, history_index)
+                          or android.lib.AMotionEvent_getY(event, i)
+            genTouchMoveEvent(event, timev, slot, i, x, y)
+        end
+    end
+end
+
 local function genEndTouchEvent(event, timev)
     genEmuEvent(C.EV_SYN, C.SYN_REPORT, 0, timev)
 end
@@ -155,38 +168,20 @@ local function motionEventHandler(motion_event)
         setPointerDown(slot, false)
         genTouchUpEvent(motion_event, slot, pointer_index)
     elseif flags == C.AMOTION_EVENT_ACTION_MOVE then
-        -- There may be multiple pointers involved, only request the ts once
-        local timev = genInputTimeval(android.lib.AMotionEvent_getEventTime(motion_event))
-
         -- This effectively gives us the size of the current MotionEvent array...
         local pointer_count = tonumber(android.lib.AMotionEvent_getPointerCount(motion_event))
-        -- Collect the pointers that are still in contact, as (slot, pointer_index) pairs.
-        local active = {}
-        for i = 0, pointer_count - 1 do
-            -- So, loop through the array, and if that pointer is still down, move it
-            local slot = android.lib.AMotionEvent_getPointerId(motion_event, i)
-            if pointers[slot] then
-                active[#active + 1] = { slot = slot, index = i }
-            end
-        end
 
         -- Useful for continuous events like drawing
         local history = tonumber(android.lib.AMotionEvent_getHistorySize(motion_event))
         for h = 0, history - 1 do
             local htimev = genInputTimeval(android.lib.AMotionEvent_getHistoricalEventTime(motion_event, h))
-            for __, ptr in ipairs(active) do
-                genTouchMoveEvent(motion_event, htimev, ptr.slot, ptr.index,
-                    android.lib.AMotionEvent_getHistoricalX(motion_event, ptr.index, h),
-                    android.lib.AMotionEvent_getHistoricalY(motion_event, ptr.index, h))
-            end
+            genTouchMoveFrame(motion_event, htimev, pointer_count, h)
             genEndTouchEvent(motion_event, htimev)
         end
 
-        for __, ptr in ipairs(active) do
-            genTouchMoveEvent(motion_event, timev, ptr.slot, ptr.index,
-                android.lib.AMotionEvent_getX(motion_event, ptr.index),
-                android.lib.AMotionEvent_getY(motion_event, ptr.index))
-        end
+        -- There may be multiple pointers involved, only request the ts once
+        local timev = genInputTimeval(android.lib.AMotionEvent_getEventTime(motion_event))
+        genTouchMoveFrame(motion_event, timev, pointer_count)
         genEndTouchEvent(motion_event, timev)
     elseif flags == C.AMOTION_EVENT_ACTION_CANCEL then
         -- Invalidate the pointers, and push a custom event to notify front to do the same.


### PR DESCRIPTION
In the release, drawing is very laggy: turns out many input touch points are lost because most of them end up in the 'historical' events while a few get into the 'current' event. This is crucial for any future Android stylus plugins, but also other frequent events as such may occur I guess.
I said 'drawing' but as of now it doesn't exist in KOReader per-se, so I've tested it with an external plugin.
I hope this PR is correct, since I checked and re-checked it 5 times but can't be sure since I'm no Android expert x) From what I found it seems like processing 'historical' events before the 'current' event is actually the conventional way of processing touch events

This PR has [`AMotionEvent_getToolType`](https://developer.android.com/reference/android/view/MotionEvent#getToolType(int)) that was introduced in koreader/android-luajit-launcher#606

See [the explanation on historical events](https://developer.android.com/reference/android/view/MotionEvent#batching)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/koreader-base/2501)
<!-- Reviewable:end -->
